### PR TITLE
Fix OpenRouter model API routing by URL encoding model names with sla…

### DIFF
--- a/client/src/hooks/useAnalysisResults.ts
+++ b/client/src/hooks/useAnalysisResults.ts
@@ -87,7 +87,9 @@ export function useAnalysisResults({
         requestBody.customPrompt = customPrompt.trim();
       }
       
-      const analysisResponse = await apiRequest('POST', `/api/puzzle/analyze/${taskId}/${modelKey}`, requestBody);
+      // URL-encode model key to handle OpenRouter provider/model format (e.g., qwen/qwen-2.5-coder-32b-instruct)
+      const encodedModelKey = encodeURIComponent(modelKey);
+      const analysisResponse = await apiRequest('POST', `/api/puzzle/analyze/${taskId}/${encodedModelKey}`, requestBody);
       if (!analysisResponse.ok) {
         throw new Error(`Analysis request failed: ${analysisResponse.statusText}`);
       }

--- a/server/controllers/puzzleController.ts
+++ b/server/controllers/puzzleController.ts
@@ -67,7 +67,9 @@ export const puzzleController = {
    * @param res - Express response object
    */
   async analyze(req: Request, res: Response) {
-    const { taskId, model } = req.params;
+    const { taskId, model: encodedModel } = req.params;
+    // Decode model parameter to handle OpenRouter provider/model format (e.g., qwen%2Fqwen-2.5-coder-32b-instruct)
+    const model = decodeURIComponent(encodedModel);
     const { 
       temperature = 0.2, 
       captureReasoning = true, 


### PR DESCRIPTION
…shes

ISSUE: OpenRouter models like 'qwen/qwen-2.5-coder-32b-instruct' contain slashes
PROBLEM: Express route '/api/puzzle/analyze/:taskId/:model' treated 'qwen' as model parameter
RESULT: 404 errors for all OpenRouter models with provider/model-name format

FIX:
• Client: URL-encode model key using encodeURIComponent() • Server: URL-decode model parameter using decodeURIComponent() • Route now handles: qwen%2Fqwen-2.5-coder-32b-instruct → qwen/qwen-2.5-coder-32b-instruct

This allows OpenRouter models to work with the existing route structure. Alternative would be changing route pattern to capture full model name.

🤖 Generated with Claude Code