### PR TITLE
CRITICAL FIX: Resolve overview endpoint 'this' context error

### DIFF
--- a/server/controllers/puzzleController.ts
+++ b/server/controllers/puzzleController.ts
@@ -425,12 +425,12 @@ export const puzzleController = {
       logger.debug('Puzzle overview request with filters: ' + JSON.stringify(req.query), 'puzzle-controller');
 
       // Build puzzle filters using helper method
-      const puzzleFilters = this.buildOverviewFilters(req.query);
+      const puzzleFilters = puzzleController.buildOverviewFilters(req.query);
       const allPuzzles = await puzzleService.getPuzzleList(puzzleFilters);
       
       // If no database connection, return basic overview
       if (!repositoryService.isConnected()) {
-        const basicOverview = this.createBasicOverview(allPuzzles, offset as string, limit as string);
+        const basicOverview = puzzleController.createBasicOverview(allPuzzles, offset as string, limit as string);
         return res.json(formatResponse.success(basicOverview));
       }
 
@@ -479,7 +479,7 @@ export const puzzleController = {
             if (explanations && explanations.length > 0) {
               const puzzle = puzzleMap.get(puzzleId);
               if (puzzle) {
-                const filteredExplanations = this.applyExplanationFilters(explanations, explanationFilters);
+                const filteredExplanations = puzzleController.applyExplanationFilters(explanations, explanationFilters);
                 
                 if (filteredExplanations.length > 0) {
                   puzzle.explanations = filteredExplanations;
@@ -516,8 +516,8 @@ export const puzzleController = {
       }
 
       // Sort and paginate results
-      const sortedResults = this.sortOverviewResults(results, sortBy as string, sortOrder as string);
-      const finalResults = this.applyPagination(sortedResults, offset as string, limit as string);
+      const sortedResults = puzzleController.sortOverviewResults(results, sortBy as string, sortOrder as string);
+      const finalResults = puzzleController.applyPagination(sortedResults, offset as string, limit as string);
 
       res.json(formatResponse.success(finalResults));
 


### PR DESCRIPTION
PROBLEM:
- Overview endpoint returning 500 error with 'Cannot read properties of undefined (reading buildOverviewFilters)'
- puzzleController object literal methods using 'this.' references incorrectly
- Methods like buildOverviewFilters, createBasicOverview, applyExplanationFilters not accessible

ROOT CAUSE:
- puzzleController exported as object literal, not class
- 'this' context undefined in object literal methods
- Calls like 'this.buildOverviewFilters()' failing at runtime

SOLUTION:
- Changed all 'this.' references to 'puzzleController.' references
- Fixed calls: buildOverviewFilters, createBasicOverview, applyExplanationFilters, sortOverviewResults, applyPagination
- Maintains object literal pattern while enabling proper method access

TECHNICAL DETAILS:
- puzzleController.ts:428 - Fixed puzzleController.buildOverviewFilters() call
- puzzleController.ts:433 - Fixed puzzleController.createBasicOverview() call
- puzzleController.ts:482 - Fixed puzzleController.applyExplanationFilters() call
- puzzleController.ts:519-520 - Fixed sorting and pagination method calls

IMPACT:
- Overview endpoint now returns proper puzzle data with explanations
- Database pagination and filtering working correctly
- Frontend /overview page functional again

VERIFICATION:
- curl http://localhost:5000/api/puzzle/overview?limit=2 returns success:true
- Puzzle data includes proper explanations array with reasoning logs
- No more 500 errors on overview page access

🤖 Generated with [Claude Code](https://claude.ai/code)