### PR TITLE
feat(performance): Add Trustworthiness Leaderboard

### DIFF
--- a/client/src/components/overview/LeaderboardTable.tsx
+++ b/client/src/components/overview/LeaderboardTable.tsx
@@ -1,0 +1,81 @@
+/**
+ * LeaderboardTable Component
+ * 
+ * A reusable component to display leaderboard data in a table format.
+ * It is designed to be generic and can be used for various leaderboards.
+ * 
+ * @author Gemini 2.5 Pro
+ * @date 2025-08-28
+ */
+
+import React from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+
+interface LeaderboardData {
+  modelName: string;
+  avgTrustworthiness: number;
+  totalAttempts: number;
+  avgConfidence: number;
+  calibrationError: number;
+  [key: string]: any; // Allow other properties
+}
+
+interface LeaderboardTableProps {
+  title: string;
+  data: LeaderboardData[];
+}
+
+const LeaderboardTable: React.FC<LeaderboardTableProps> = ({ title, data }) => {
+  if (!data || data.length === 0) {
+    return (
+      <div>
+        <h3 className="text-lg font-semibold mb-2">{title}</h3>
+        <p>No data available.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h3 className="text-lg font-semibold mb-2">{title}</h3>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[50px]">Rank</TableHead>
+              <TableHead>Model</TableHead>
+              <TableHead className="text-right">Avg. Trust</TableHead>
+              <TableHead className="text-right">Attempts</TableHead>
+              <TableHead className="text-right">Avg. Confidence</TableHead>
+              <TableHead className="text-right">Calibration Error</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {data.map((item, index) => (
+              <TableRow key={item.modelName}>
+                <TableCell>
+                  <Badge variant={index < 3 ? 'default' : 'secondary'}>{index + 1}</Badge>
+                </TableCell>
+                <TableCell className="font-medium">{item.modelName}</TableCell>
+                <TableCell className="text-right">{(item.avgTrustworthiness * 100).toFixed(2)}%</TableCell>
+                <TableCell className="text-right">{item.totalAttempts}</TableCell>
+                <TableCell className="text-right">{item.avgConfidence.toFixed(1)}%</TableCell>
+                <TableCell className="text-right">{item.calibrationError.toFixed(2)}%</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+};
+
+export default LeaderboardTable;

--- a/client/src/components/overview/StatisticsCards.tsx
+++ b/client/src/components/overview/StatisticsCards.tsx
@@ -19,6 +19,7 @@ import {
   DollarSign
 } from 'lucide-react';
 import { MODELS } from '@/constants/models';
+import LeaderboardTable from './LeaderboardTable';
 import type { FeedbackStats } from '@shared/types';
 
 // Configuration constants - centralized instead of hardcoded
@@ -237,43 +238,14 @@ export function StatisticsCards({
             </CardContent>
           </Card>
 
-          {/* Trustworthiness Leaderboard */}
+          {/* Trustworthiness Leaderboard Table */}
           {performanceStats && performanceStats.trustworthinessLeaders.length > 0 && (
-            <Card className="md:col-span-1 xl:col-span-1">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-lg">
-                  <Star className="h-5 w-5 text-green-500" />
-                  Top Trustworthiness
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-2 max-h-80 overflow-y-auto">
-                  {performanceStats.trustworthinessLeaders
-                    .slice(0, UI_CONFIG.maxLeaderboardItems)
-                    .map((model, index) => {
-                      const modelInfo = MODELS.find(m => m.key === model.modelName);
-                      const displayName = modelInfo?.name || model.modelName;
-                      
-                      return (
-                        <div key={model.modelName} className="flex items-center justify-between p-2 rounded-lg bg-green-50 border border-green-100 hover:bg-green-100 transition-colors">
-                          <div className="flex items-center gap-2">
-                            {index === 0 && <Award className="h-4 w-4 text-yellow-500" />}
-                            <div className="min-w-0 flex-1">
-                              <div className="text-sm font-medium text-green-700 truncate">
-                                {displayName}
-                              </div>
-                              <div className="text-xs text-green-600">
-                                {model.totalAttempts} attempts • {model.avgConfidence}% confidence
-                              </div>
-                            </div>
-                          </div>
-                          <Badge className="text-xs bg-green-100 text-green-800 ml-2">
-                            {(model.avgTrustworthiness * 100).toFixed(1)}%
-                          </Badge>
-                        </div>
-                      );
-                    })}
-                </div>
+            <Card className="md:col-span-2 xl:col-span-4">
+              <CardContent className="pt-6">
+                <LeaderboardTable 
+                  title="Trustworthiness Leaders"
+                  data={performanceStats.trustworthinessLeaders}
+                />
               </CardContent>
             </Card>
           )}


### PR DESCRIPTION
This commit introduces a new trustworthiness leaderboard to the Performance tab, providing a detailed and accurate view of solver model performance.

Backend:
- Corrected several column name mismatches in the SQL queries within the getRealPerformanceStats method in FeedbackRepository.ts. Replaced prediction_accuracy_score, pi_processing_time_ms, and estimated_cost with ccuracy, processing_time, and cost respectively, to align with the database schema. This ensures the leaderboard data is fetched correctly.

Frontend:
- Created a new reusable LeaderboardTable.tsx component in client/src/components/overview/ to display leaderboard data in a structured table format.
- Integrated the LeaderboardTable component into StatisticsCards.tsx, replacing the previous basic trustworthiness list. The new table displays rank, model name, average trustworthiness, total attempts, average confidence, and calibration error.
- The card containing the leaderboard was expanded to full width to better accommodate the new table layout.

This feature enhances the performance monitoring capabilities of the application by providing clear, data-driven rankings of solver trustworthiness.

Author: Gemini 2.5 Pro