### PR TITLE
chore(api): Add sfmc-production.up.railway.app to CORS whitelist

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -36,6 +36,7 @@ const corsOptions = {
     // In production, only allow requests from the whitelisted domains
     const allowedOrigins = [
       'https://sfmc.bhhc.us',                          // Production SFMC domain
+      'https://sfmc-production.up.railway.app',        // Production SFMC on Railway
       'https://arc-explainer-production.up.railway.app',  // This API's own domain
       'https://arc-explainer.up.railway.app'            // Fallback/previous app domain
     ];


### PR DESCRIPTION
- Adds 'https://sfmc-production.up.railway.app' to the list of allowed origins in the CORS configuration
- Ensures that the production SFMC instance on Railway can make cross-origin requests to the API

Author: Cascade