### PR TITLE
CRITICAL FIX: Ensure provider_raw_response is always JSON stringified

### DIFF
--- a/server/repositories/ExplanationRepository.ts
+++ b/server/repositories/ExplanationRepository.ts
@@ -87,9 +87,7 @@ export class ExplanationRepository extends BaseRepository implements IExplanatio
         data.customPromptText || null,
         // CRITICAL: Raw API response fields for debugging expensive failures
         data.providerResponseId || null,
-        typeof data.providerRawResponse === 'string' 
-          ? data.providerRawResponse 
-          : this.safeJsonStringify(data.providerRawResponse),
+        this.safeJsonStringify(data.providerRawResponse),
         this.safeJsonStringify(this.sanitizeMultipleGrids(data.multiTestPredictionGrids))
       ], client);
 


### PR DESCRIPTION
PROBLEM:
The database was rejecting explanations with an 'invalid input syntax for type json' error, specifically for the 'provider_raw_response' field (parameter ).

ROOT CAUSE:
The previous logic in ExplanationRepository.ts would only JSON.stringify the provider_raw_response if it wasn't already a string. If the raw response was a plain string that was not valid JSON (e.g., simple text without quotes), it was passed directly to the database, causing a PostgreSQL parsing error for the jsonb column.

SOLUTION:
This commit simplifies and corrects the logic by unconditionally calling this.safeJsonStringify() on data.providerRawResponse. This ensures that any value (object, string, or other primitive) is correctly serialized into a valid JSON string before being inserted into the database, preventing the error.

Author: Gemini 2.5 Pro