### PR TITLE
CRITICAL FIX: Prevent null insertion into multi_test_prediction_grids

### DIFF
--- a/server/repositories/ExplanationRepository.ts
+++ b/server/repositories/ExplanationRepository.ts
@@ -90,7 +90,7 @@ export class ExplanationRepository extends BaseRepository implements IExplanatio
         typeof data.providerRawResponse === 'string' 
           ? data.providerRawResponse 
           : this.safeJsonStringify(data.providerRawResponse),
-        this.safeJsonStringify(this.sanitizeMultipleGrids(data.multiTestPredictionGrids))
+        this.safeJsonStringify(this.sanitizeMultipleGrids(data.multiTestPredictionGrids) || [])
       ], client);
 
       if (result.rows.length === 0) {


### PR DESCRIPTION
PROBLEM:
Database saves were failing with 'invalid input syntax for type json' for parameter .

ROOT CAUSE:
Parameter  corresponds to the multi_test_prediction_grids field, which is a jsonb column. The sanitizeMultipleGrids function could return ull for invalid input. This
ull value was being passed directly to the database, which is not valid JSON for a column expecting a JSON array (e.g., '[]').

SOLUTION:
This commit modifies the call in ExplanationRepository.ts to provide a default empty array ([]) if sanitizeMultipleGrids returns ull. This ensures that safeJsonStringify always receives a valid array, which is then serialized to valid JSON ('[]'), satisfying the database constraint.

Author: Gemini 2.5 Pro