### PR TITLE
CRITICAL FIX: Custom prompts were always receiving correct answers

### DIFF
--- a/server/services/prompts/userTemplates.ts
+++ b/server/services/prompts/userTemplates.ts
@@ -98,11 +98,11 @@ function buildCustomUserPrompt(
   customText: string,
   options: UserPromptOptions = {}
 ): string {
-  const { isSolverMode = false } = options;
+  const { isSolverMode = false, omitAnswer = false } = options;
   
   // Always use raw numeric data for custom prompts
   const trainingExamples = formatTrainingExamples(task, false);
-  const testSection = formatTestSection(task, false, undefined, !isSolverMode, isSolverMode);
+  const testSection = formatTestSection(task, false, undefined, !omitAnswer, isSolverMode);
   
   const isMulti = task.test.length > 1;
   const testLabel = isSolverMode ? "TEST CASE:" : "TEST CASE:";
@@ -204,7 +204,7 @@ export function buildUserPromptForTemplate(
   const builderFn: (task: ARCTask, options?: UserPromptOptions) => string = getUserPromptBuilder(promptId);
   
   if (promptId === 'custom' && customText) {
-    return buildCustomUserPromptSimple(task, customText);
+    return buildCustomUserPrompt(task, customText, options);
   }
   
   return builderFn(task, options);


### PR DESCRIPTION
SECURITY/INTEGRITY BUG: Custom prompts completely ignored omitAnswer setting

Root Cause Analysis:
- buildCustomUserPrompt() used !isSolverMode instead of !omitAnswer for includeAnswers parameter
- Since custom prompts have isSolverMode=false, this became !false=true (always include answers)
- buildUserPromptForTemplate() called buildCustomUserPromptSimple() without passing options
- This meant omitAnswer setting was completely lost for custom prompts

Impact:
- Custom prompts ALWAYS received correct answers regardless of UI 'Hide solution' toggle
- Validation was meaningless since AI had access to the solution
- Users thought they were testing solver capability but AI was cheating
- Completely undermined accuracy scoring for custom prompts

Solution:
1. Fixed buildCustomUserPrompt() line 105: use !omitAnswer instead of !isSolverMode
2. Fixed buildUserPromptForTemplate() line 207: pass options to buildCustomUserPrompt()
3. Added omitAnswer to destructured options in buildCustomUserPrompt()

Files Modified:
- server/services/prompts/userTemplates.ts:
  * Line 101: Added omitAnswer to destructured options
  * Line 105: Changed !isSolverMode to !omitAnswer for includeAnswers parameter
  * Line 207: Changed to call buildCustomUserPrompt(task, customText, options)

Testing Required:
- Verify custom prompts with 'Hide solution' ON no longer receive answers
- Verify regular solver mode still works correctly
- Verify other prompt types still respect omitAnswer setting

Author: Gemini 2.5 Pro
Priority: CRITICAL - This was a fundamental integrity bug