### PR TITLE
refactor(debate): Separate original explanation and rebuttal cards

### DIFF
--- a/client/src/components/puzzle/debate/IndividualDebate.tsx
+++ b/client/src/components/puzzle/debate/IndividualDebate.tsx
@@ -37,6 +37,8 @@ import { Textarea } from '@/components/ui/textarea';
 // Reuse existing components
 import { AnalysisResultCard } from '@/components/puzzle/AnalysisResultCard';
 import { PromptPreviewModal } from '@/components/PromptPreviewModal';
+import { OriginalExplanationCard } from './OriginalExplanationCard';
+import { RebuttalCard } from './RebuttalCard';
 
 // Types
 import type { ExplanationData } from '@/types/puzzle';
@@ -188,6 +190,7 @@ export const IndividualDebate: React.FC<IndividualDebateProps> = ({
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-2">
         {/* Debate Messages */}
         <div className="lg:col-span-2 space-y-2">
+          {/* Header Card */}
           <Card>
             <CardHeader className="p-2">
               <CardTitle className="flex items-center gap-2 text-sm">
@@ -196,36 +199,31 @@ export const IndividualDebate: React.FC<IndividualDebateProps> = ({
                 <Badge variant="outline" className="text-xs">{debateMessages.length} participants</Badge>
               </CardTitle>
             </CardHeader>
-            <CardContent className="p-2">
-              <div className="space-y-2 max-h-96 overflow-y-auto">
-                {debateMessages.map((message) => (
-                  <div key={message.id}>
-                    <div className="flex items-center gap-1 mb-1">
-                      <Badge variant={message.messageType === 'original' ? 'default' : 'destructive'} className="text-xs px-1 py-0">
-                        {message.modelName}
-                      </Badge>
-                      <Badge variant="outline" className="text-xs px-1 py-0">
-                        {message.messageType === 'original' ? 'Original' : 'Challenge'}
-                      </Badge>
-                      <span className="text-[10px] text-gray-500">
-                        {new Date(message.timestamp).toLocaleTimeString()}
-                      </span>
-                    </div>
-
-                    {/* AnalysisResultCard with proper PuzzleGrid/GridCell components */}
-                    {/* eloMode=false to show Expected Output and diff comparison */}
-                    <AnalysisResultCard
-                      result={message.content}
-                      modelKey={message.modelName}
-                      model={models?.find(m => m.key === message.modelName)}
-                      testCases={testCases}
-                      eloMode={false}
-                    />
-                  </div>
-                ))}
-              </div>
-            </CardContent>
           </Card>
+
+          {/* Scrollable debate content */}
+          <div className="space-y-2 max-h-[800px] overflow-y-auto">
+            {debateMessages.map((message, index) => (
+              message.messageType === 'original' ? (
+                <OriginalExplanationCard
+                  key={message.id}
+                  explanation={message.content}
+                  models={models}
+                  testCases={testCases}
+                  timestamp={message.timestamp}
+                />
+              ) : (
+                <RebuttalCard
+                  key={message.id}
+                  explanation={message.content}
+                  models={models}
+                  testCases={testCases}
+                  timestamp={message.timestamp}
+                  rebuttalNumber={debateMessages.slice(0, index).filter(m => m.messageType === 'challenge').length + 1}
+                />
+              )
+            ))}
+          </div>
         </div>
 
         {/* Challenge Controls */}

--- a/client/src/components/puzzle/debate/OriginalExplanationCard.tsx
+++ b/client/src/components/puzzle/debate/OriginalExplanationCard.tsx
@@ -1,0 +1,82 @@
+/**
+ * OriginalExplanationCard.tsx
+ *
+ * Author: Claude Code using Sonnet 4.5
+ * Date: 2025-09-30
+ * PURPOSE: Dedicated component for displaying the original explanation in a debate.
+ * This component wraps the AnalysisResultCard and adds context-specific styling and badges
+ * to clearly identify this as the original explanation being debated.
+ * SRP/DRY check: Pass - Single responsibility (display original explanation), reuses AnalysisResultCard
+ * shadcn/ui: Pass - Uses shadcn/ui Card and Badge components
+ */
+
+import React from 'react';
+import { Card, CardHeader, CardContent, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { MessageSquare, ArrowRight } from 'lucide-react';
+import { AnalysisResultCard } from '@/components/puzzle/AnalysisResultCard';
+import type { ExplanationData } from '@/types/puzzle';
+import type { ARCExample, ModelConfig } from '@shared/types';
+
+interface OriginalExplanationCardProps {
+  explanation: ExplanationData;
+  models?: ModelConfig[];
+  testCases: ARCExample[];
+  timestamp: string;
+}
+
+export const OriginalExplanationCard: React.FC<OriginalExplanationCardProps> = ({
+  explanation,
+  models,
+  testCases,
+  timestamp
+}) => {
+  // Determine correctness status
+  const hasMultiTest = explanation.hasMultiplePredictions &&
+    (explanation.multiTestAllCorrect !== undefined || explanation.multiTestAverageAccuracy !== undefined);
+
+  const isExplicitlyCorrect = hasMultiTest
+    ? explanation.multiTestAllCorrect === true
+    : explanation.isPredictionCorrect === true;
+
+  const wasIncorrect = !isExplicitlyCorrect;
+
+  return (
+    <Card className="border-2 border-blue-200 bg-blue-50/30">
+      <CardHeader className="p-2 bg-blue-100/50">
+        <CardTitle className="flex items-center gap-2 text-sm">
+          <MessageSquare className="h-4 w-4 text-blue-600" />
+          Original Explanation
+          <Badge variant="default" className="text-xs">
+            {explanation.modelName}
+          </Badge>
+          {wasIncorrect && (
+            <Badge variant="destructive" className="text-xs">
+              {(hasMultiTest ? explanation.multiTestAllCorrect : explanation.isPredictionCorrect) === false
+                ? 'Incorrect'
+                : 'Under Review'}
+            </Badge>
+          )}
+          {explanation.rebuttingExplanationId && (
+            <Badge variant="secondary" className="text-xs flex items-center gap-1">
+              <ArrowRight className="h-3 w-3" />
+              Rebuttal
+            </Badge>
+          )}
+          <span className="ml-auto text-[10px] text-gray-500 font-normal">
+            {new Date(timestamp).toLocaleTimeString()}
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-2">
+        <AnalysisResultCard
+          result={explanation}
+          modelKey={explanation.modelName}
+          model={models?.find(m => m.key === explanation.modelName)}
+          testCases={testCases}
+          eloMode={false}
+        />
+      </CardContent>
+    </Card>
+  );
+};

--- a/client/src/components/puzzle/debate/RebuttalCard.tsx
+++ b/client/src/components/puzzle/debate/RebuttalCard.tsx
@@ -1,0 +1,81 @@
+/**
+ * RebuttalCard.tsx
+ *
+ * Author: Claude Code using Sonnet 4.5
+ * Date: 2025-09-30
+ * PURPOSE: Dedicated component for displaying a rebuttal/challenge in a debate.
+ * This component wraps the AnalysisResultCard and adds context-specific styling and badges
+ * to clearly identify this as a challenge response from another AI model.
+ * SRP/DRY check: Pass - Single responsibility (display rebuttal), reuses AnalysisResultCard
+ * shadcn/ui: Pass - Uses shadcn/ui Card and Badge components
+ */
+
+import React from 'react';
+import { Card, CardHeader, CardContent, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { MessageSquare } from 'lucide-react';
+import { AnalysisResultCard } from '@/components/puzzle/AnalysisResultCard';
+import type { ExplanationData } from '@/types/puzzle';
+import type { ARCExample, ModelConfig } from '@shared/types';
+
+interface RebuttalCardProps {
+  explanation: ExplanationData;
+  models?: ModelConfig[];
+  testCases: ARCExample[];
+  timestamp: string;
+  rebuttalNumber?: number; // Optional number to show rebuttal order
+}
+
+export const RebuttalCard: React.FC<RebuttalCardProps> = ({
+  explanation,
+  models,
+  testCases,
+  timestamp,
+  rebuttalNumber
+}) => {
+  // Determine correctness status
+  const hasMultiTest = explanation.hasMultiplePredictions &&
+    (explanation.multiTestAllCorrect !== undefined || explanation.multiTestAverageAccuracy !== undefined);
+
+  const isExplicitlyCorrect = hasMultiTest
+    ? explanation.multiTestAllCorrect === true
+    : explanation.isPredictionCorrect === true;
+
+  return (
+    <Card className="border-2 border-red-200 bg-red-50/30">
+      <CardHeader className="p-2 bg-red-100/50">
+        <CardTitle className="flex items-center gap-2 text-sm">
+          <MessageSquare className="h-4 w-4 text-red-600" />
+          Challenge {rebuttalNumber ? `#${rebuttalNumber}` : ''}
+          <Badge variant="destructive" className="text-xs">
+            {explanation.modelName}
+          </Badge>
+          {isExplicitlyCorrect && (
+            <Badge variant="default" className="text-xs bg-green-600">
+              Correct
+            </Badge>
+          )}
+          {!isExplicitlyCorrect && (
+            <Badge variant="outline" className="text-xs">
+              {(hasMultiTest ? explanation.multiTestAllCorrect : explanation.isPredictionCorrect) === false
+                ? 'Incorrect'
+                : 'Unverified'}
+            </Badge>
+          )}
+          <span className="ml-auto text-[10px] text-gray-500 font-normal">
+            {new Date(timestamp).toLocaleTimeString()}
+          </span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-2">
+        <AnalysisResultCard
+          result={explanation}
+          modelKey={explanation.modelName}
+          model={models?.find(m => m.key === explanation.modelName)}
+          testCases={testCases}
+          eloMode={false}
+        />
+      </CardContent>
+    </Card>
+  );
+};


### PR DESCRIPTION
Created dedicated components for better visual distinction in debates:
- OriginalExplanationCard: Blue-themed card for original explanations
- RebuttalCard: Red-themed card for challenges/rebuttals
- Updated IndividualDebate to render each in separate cards

Benefits:
- Clear visual separation between original and challenges
- Each card independently styled with appropriate badges
- Better UX for understanding debate flow
- Adheres to SRP (single responsibility per component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)