### PR TITLE
v3.5.1: Change default reasoningEffort to 'high' for GPT-5 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [2025-10-04]
+
+## v3.5.1 - Default Reasoning Effort Update
+
+### Changed
+- **GPT-5 Reasoning Effort Default** (Enhancement)
+  - Changed default `reasoningEffort` from `'low'` to `'high'` in useAnalysisResults hook
+  - Applies to all GPT-5 reasoning models across all pages (PuzzleExaminer, ModelDebate, etc.)
+  - Users can still manually override this setting on the ModelDebate page
+  - Ensures maximum reasoning quality by default for GPT-5 models
+  - Files: client/src/hooks/useAnalysisResults.ts (line 62)
+  - Author: Cascade using Sonnet 4
+
 ## [2025-10-03]
 
 ## v3.5.0 - Bug Fixes and Deep Linking

--- a/client/src/hooks/useAnalysisResults.ts
+++ b/client/src/hooks/useAnalysisResults.ts
@@ -59,7 +59,7 @@ export function useAnalysisResults({
   const [analysisTimes, setAnalysisTimes] = useState<Record<string, number>>({});
   
   // GPT-5 reasoning parameters
-  const [reasoningEffort, setReasoningEffort] = useState<'minimal' | 'low' | 'medium' | 'high'>('low');
+  const [reasoningEffort, setReasoningEffort] = useState<'minimal' | 'low' | 'medium' | 'high'>('high');
   const [reasoningVerbosity, setReasoningVerbosity] = useState<'low' | 'medium' | 'high'>('high');
   const [reasoningSummaryType, setReasoningSummaryType] = useState<'auto' | 'detailed'>('detailed');
 


### PR DESCRIPTION
Changed the default reasoning effort level from 'low' to 'high' in the useAnalysisResults hook (line 62). This ensures that all GPT-5 reasoning models (gpt-5-2025-08-07, gpt-5-mini-2025-08-07, gpt-5-nano-2025-08-07) use maximum reasoning quality by default across all pages including PuzzleExaminer and ModelDebate. Users can still manually override this setting in the UI if needed. This change improves the quality of AI analysis by leveraging GPT-5's full reasoning capabilities by default.

Files modified:

- client/src/hooks/useAnalysisResults.ts: Changed reasoningEffort default from 'low' to 'high'

- CHANGELOG.md: Added v3.5.1 entry documenting the change

Author: Cascade using Sonnet 4

Date: 2025-10-04T16:33:34-04:00