### PR TITLE
v3.5.1: Fix server-side reasoning defaults (CRITICAL FIX)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,16 @@
 
 ### Changed
 - **GPT-5 Reasoning Effort Default** (Enhancement)
-  - Changed default `reasoningEffort` from `'low'` to `'high'` in useAnalysisResults hook
-  - Applies to all GPT-5 reasoning models across all pages (PuzzleExaminer, ModelDebate, etc.)
-  - Users can still manually override this setting on the ModelDebate page
+  - Changed default `reasoningEffort` from `'low'` to `'high'` across frontend and backend
+  - **Client-side**: useAnalysisResults hook now defaults to 'high' (line 62)
+  - **Server-side**: OpenAI service now defaults to 'high' for both prompt preview (line 158) and API calls (line 230)
+  - Also updated default `reasoningVerbosity` from 'medium' to 'high' for consistency (line 163)
+  - Applies to all GPT-5 reasoning models (gpt-5-2025-08-07, gpt-5-mini-2025-08-07, gpt-5-nano-2025-08-07)
+  - Users can still manually override these settings in the UI
   - Ensures maximum reasoning quality by default for GPT-5 models
-  - Files: client/src/hooks/useAnalysisResults.ts (line 62)
+  - Files: 
+    - client/src/hooks/useAnalysisResults.ts (line 62)
+    - server/services/openai.ts (lines 158, 163, 230)
   - Author: Cascade using Sonnet 4
 
 ## [2025-10-03]

--- a/server/services/openai.ts
+++ b/server/services/openai.ts
@@ -155,12 +155,12 @@ export class OpenAIService extends BaseAIService {
       ...(isReasoningModel && {
         reasoning: isGPT5Model 
           ? { 
-              effort: serviceOpts.reasoningEffort || "medium",
+              effort: serviceOpts.reasoningEffort || "high",
               summary: serviceOpts.reasoningSummaryType || "detailed" 
             }
           : { summary: "detailed" },
         ...(isGPT5Model && {
-          text: { verbosity: serviceOpts.reasoningVerbosity || "medium" }
+          text: { verbosity: serviceOpts.reasoningVerbosity || "high" }
         })
       })
     };
@@ -227,7 +227,7 @@ export class OpenAIService extends BaseAIService {
     if (isReasoningModel) {
       if (isGPT5Model) {
         reasoningConfig = {
-          effort: serviceOpts.reasoningEffort || 'low',
+          effort: serviceOpts.reasoningEffort || 'high',
           summary: serviceOpts.reasoningSummaryType || serviceOpts.reasoningSummary || 'detailed'
         };
         textConfig = {


### PR DESCRIPTION
The previous commit only changed the UI default - this commit fixes the actual server-side defaults that get sent to the OpenAI API.

Root Cause:
The OpenAI service had THREE hardcoded defaults that were overriding frontend settings:
1. Line 158: Prompt preview defaulted to medium (now high)
2. Line 230: Actual API calls defaulted to low (now high) - CRITICAL
3. Line 163: Verbosity defaulted to medium (now high)

Without these server-side changes, the frontend UI changes had NO effect on actual API calls. The backend was always sending low effort regardless of UI settings when no explicit value was provided.

Impact:
- All GPT-5 model API calls now use high reasoning effort by default
- ModelDebate page now correctly uses high reasoning when generating challenges
- PuzzleExaminer and all other pages also benefit from this fix
- Users can still override via UI controls on ModelDebate page

Files modified:
- server/services/openai.ts: Fixed three default values (lines 158, 163, 230)
- CHANGELOG.md: Updated to reflect comprehensive frontend + backend fix

Author: Cascade using Sonnet 4
Date: 2025-10-04T21:03:28-04:00