### PR TITLE
Route Saturn streaming via saturnService

### DIFF
--- a/server/services/saturnService.ts
+++ b/server/services/saturnService.ts
@@ -23,7 +23,7 @@ import { readFile } from 'fs/promises';
 
 export class SaturnService extends BaseAIService {
   protected provider = "Saturn";
-  
+
   // Map Saturn model keys to underlying provider models (RESPONSES API compatible only)
   // Now supports BOTH old format (saturn-*) and new format (direct model keys)
   protected models: Record<string, string> = {
@@ -38,6 +38,37 @@ export class SaturnService extends BaseAIService {
     "gpt-5-2025-08-07": "gpt-5-2025-08-07",
     "grok-4": "grok-4"
   };
+
+  /**
+   * Determine whether a requested model key should be processed by the Saturn pipeline.
+   */
+  isSaturnModelKey(modelKey: string): boolean {
+    return Object.prototype.hasOwnProperty.call(this.models, modelKey);
+  }
+
+  supportsStreaming(modelKey: string): boolean {
+    if (!this.isSaturnModelKey(modelKey)) {
+      return false;
+    }
+
+    const underlyingModel = this.models[modelKey];
+    const underlyingService = aiServiceFactory.getService(underlyingModel);
+
+    if (underlyingService?.supportsStreaming) {
+      try {
+        return underlyingService.supportsStreaming(underlyingModel);
+      } catch (error) {
+        logger.logError(
+          `Saturn failed to inspect streaming support for ${underlyingModel}`,
+          { error, context: this.provider }
+        );
+        return true;
+      }
+    }
+
+    // Default to true when the underlying provider does not expose capability metadata.
+    return true;
+  }
 
   /**
    * Override streaming method to route to analyzePuzzleWithModel which already handles streaming harness


### PR DESCRIPTION
## Summary
- detect Saturn model keys, including the new direct identifiers, and delegate SSE runs to the Saturn streaming pipeline with the existing harness
- expose Saturn streaming capability metadata so Saturn models are accepted during availability checks

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68f06d9172648326a95ef65ec57d5f16