### PR TITLE
Normalize SSE streaming flag handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ npm run test  # Allow ~10s to warm up, then open localhost:5173
 
 **For detailed setup, deployment, and technical documentation, see [CLAUDE.md](./CLAUDE.md)**
 
+### Streaming feature flag values
+
+- **Server:** `ENABLE_SSE_STREAMING`
+- **Client:** `VITE_ENABLE_SSE_STREAMING`
+
+Set either variable to any of the following case-insensitive truthy values to enable SSE streaming for analysis flows: `true`, `1`, `yes`, `y`, `on`, `enable`, `enabled`. All other values (including empty strings) disable streaming.
+
 ---
 
 ## Architecture Overview

--- a/client/src/hooks/useAnalysisResults.ts
+++ b/client/src/hooks/useAnalysisResults.ts
@@ -16,6 +16,7 @@ import type { ExplanationData } from '@/types/puzzle';
 import { useAnalysisStreaming } from '@/hooks/useAnalysisStreaming';
 import type { AnalysisStreamParams } from '@/lib/streaming/analysisStream';
 import type { ModelConfig } from '@shared/types';
+import { isFeatureFlagEnabled } from '@shared/utils/featureFlags';
 
 interface UseAnalysisResultsProps {
   taskId: string;
@@ -60,7 +61,7 @@ export function useAnalysisResults({
   const [reasoningSummaryType, setReasoningSummaryType] = useState<'auto' | 'detailed'>('detailed');
 
   // Streaming integration
-  const streamingEnabled = import.meta.env.VITE_ENABLE_SSE_STREAMING === 'true';
+  const streamingEnabled = isFeatureFlagEnabled(import.meta.env.VITE_ENABLE_SSE_STREAMING as string | undefined);
   const {
     startStream,
     closeStream,

--- a/docs/2025-02-17-streaming-flag-normalization-plan.md
+++ b/docs/2025-02-17-streaming-flag-normalization-plan.md
@@ -1,0 +1,14 @@
+# 2025-02-17-streaming-flag-normalization-plan
+
+## Objective
+Align server and client feature flag handling for SSE analysis streaming and document accepted environment variable values.
+
+## Planned Changes
+- [x] Create shared helper in `shared/utils` for normalizing truthy flag values.
+- [x] Update `server/services/streaming/analysisStreamService.ts` to use the helper.
+- [x] Update `client/src/hooks/useAnalysisResults.ts` to consume the same helper.
+- [x] Document accepted `ENABLE_SSE_STREAMING` / `VITE_ENABLE_SSE_STREAMING` values in README.
+- [x] Add unit test covering uppercase and numeric truthy values for the helper.
+
+## Testing Strategy
+- Run Node's built-in test runner (`node --test tests`).

--- a/server/services/streaming/analysisStreamService.ts
+++ b/server/services/streaming/analysisStreamService.ts
@@ -1,13 +1,13 @@
-const STREAMING_ENABLED = process.env.ENABLE_SSE_STREAMING === 'true';
-
 /**
- * 
+ *
  * Author: Codex using GPT-5-high
  * Date: 2025-10-09T00:00:00Z
  * PURPOSE: Coordinates streaming analysis sessions, bridging SSE connections with provider services, handling capability checks, option parsing, and graceful lifecycle management.
  * SRP/DRY check: Pass — no existing orchestration layer for SSE token streaming.
  * shadcn/ui: Pass — backend service only.
  */
+
+import { isFeatureFlagEnabled } from "@shared/utils/featureFlags";
 
 import { nanoid } from "nanoid";
 import type { Request } from "express";
@@ -17,6 +17,8 @@ import { logger } from "../../utils/logger";
 import { aiServiceFactory } from "../aiServiceFactory";
 import type { PromptOptions } from "../promptBuilder";
 import type { ServiceOptions } from "../base/BaseAIService";
+
+const STREAMING_ENABLED = isFeatureFlagEnabled(process.env.ENABLE_SSE_STREAMING);
 
 export interface StreamAnalysisPayload {
   taskId: string;

--- a/shared/utils/featureFlags.ts
+++ b/shared/utils/featureFlags.ts
@@ -1,0 +1,39 @@
+/**
+ * Feature Flag Utilities
+ *
+ * Author: gpt-5-codex
+ * Date: 2025-02-17T00:00:00Z
+ * PURPOSE: Provide consistent helpers for interpreting environment-driven feature flags across server and client runtimes.
+ * SRP/DRY check: Pass — single-purpose module for flag normalization reused by server and client streaming checks.
+ */
+
+const TRUTHY_FLAG_VALUES = new Set([
+  'true',
+  '1',
+  'yes',
+  'y',
+  'on',
+  'enable',
+  'enabled'
+]);
+
+/**
+ * Normalizes a string-based feature flag to a boolean.
+ * Treats common truthy forms (case-insensitive) as enabled and everything else as disabled.
+ */
+export function isFeatureFlagEnabled(rawValue: string | undefined | null): boolean {
+  if (typeof rawValue !== 'string') {
+    return false;
+  }
+
+  const normalized = rawValue.trim().toLowerCase();
+  if (!normalized) {
+    return false;
+  }
+
+  return TRUTHY_FLAG_VALUES.has(normalized);
+}
+
+export const featureFlagConstants = {
+  TRUTHY_FLAG_VALUES
+};

--- a/tests/featureFlags.test.ts
+++ b/tests/featureFlags.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Feature Flag Helper Tests
+ *
+ * Author: gpt-5-codex
+ * Date: 2025-02-17T00:00:00Z
+ * PURPOSE: Ensure environment flag normalization recognises common truthy values across server and client usage.
+ * SRP/DRY check: Pass — focused regression coverage for shared helper only.
+ */
+
+import { strict as assert } from 'node:assert';
+import test from 'node:test';
+import { isFeatureFlagEnabled } from '../shared/utils/featureFlags.ts';
+
+test('isFeatureFlagEnabled accepts uppercase TRUE', () => {
+  assert.equal(isFeatureFlagEnabled('TRUE'), true);
+});
+
+test('isFeatureFlagEnabled accepts numeric 1', () => {
+  assert.equal(isFeatureFlagEnabled('1'), true);
+});
+
+test('isFeatureFlagEnabled treats other values as disabled', () => {
+  assert.equal(isFeatureFlagEnabled('nope'), false);
+  assert.equal(isFeatureFlagEnabled(''), false);
+  assert.equal(isFeatureFlagEnabled(undefined), false);
+});


### PR DESCRIPTION
## Summary
- add a shared helper to normalize SSE streaming feature flags and reuse it in the analysis stream service and hook
- document accepted ENABLE_SSE_STREAMING values and capture the work plan for the change
- add regression coverage ensuring TRUE and 1 evaluate as enabled

## Testing
- node --test tests/featureFlags.test.ts --test-only

------
https://chatgpt.com/codex/tasks/task_e_68f1334ee2f883268cef67b057316616