### PR TITLE
Improve OpenAI-prefixed streaming canonicalization

### DIFF
--- a/docs/2025-10-16-openai-prefix-streaming-plan.md
+++ b/docs/2025-10-16-openai-prefix-streaming-plan.md
@@ -1,0 +1,19 @@
+# 2025-10-16-openai-prefix-streaming-plan
+
+## Goal
+Normalize `openai/` prefixed model keys so streaming analysis and Saturn entry points
+choose the OpenAI provider while preserving original metadata for SSE clients.
+
+## Target Files
+- `server/services/aiServiceFactory.ts` – expose canonicalization helper and route using normalized keys.
+- `server/services/streaming/analysisStreamService.ts` – decode + canonicalize model key before provider lookup and SSE events.
+- `server/services/streaming/saturnStreamService.ts` – ensure Saturn harness also canonicalizes (already aligned, verify only).
+- `tests/analysisStreamService.test.ts` – extend coverage for OpenAI-prefixed streaming request.
+
+## Tasks
+1. Implement helper returning `{ original, normalized }` model keys and reuse before routing checks.
+2. Update streaming services to call `aiServiceFactory`/`supportsStreaming` with normalized key but emit original key in SSE metadata.
+3. Expand tests to simulate `/api/stream/analyze/{taskId}/openai%2Fgpt-5-2025-08-07` ensuring streaming events fire (no `STREAMING_UNAVAILABLE`).
+4. Harden decoding paths so malformed or already-decoded model keys gracefully fall back without breaking streaming.
+5. Backfill unit coverage for the canonicalization helper to guard against regressions when additional providers are added.
+

--- a/server/services/streaming/saturnStreamService.ts
+++ b/server/services/streaming/saturnStreamService.ts
@@ -44,7 +44,16 @@ class SaturnStreamService {
     previousResponseId,
     abortSignal,
   }: SaturnStreamParams): Promise<void> {
-    const decodedModelKey = decodeURIComponent(modelKey);
+    let decodedModelKey: string;
+    try {
+      decodedModelKey = decodeURIComponent(modelKey);
+    } catch (error) {
+      logger.warn(
+        `[SaturnStream] Failed to decode model key '${modelKey}', using raw value. ${(error as Error)?.message ?? error}`,
+        'SaturnStream'
+      );
+      decodedModelKey = modelKey;
+    }
     const {
       original: originalModelKey,
       normalized: canonicalModelKey,

--- a/tests/aiServiceFactory.test.ts
+++ b/tests/aiServiceFactory.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Author: gpt-5-codex
+ * Date: 2025-10-16T00:00:00Z
+ * PURPOSE: Ensures aiServiceFactory canonicalizes OpenAI-prefixed model keys and
+ *          routes them to the OpenAI provider while leaving other models intact.
+ *          Guards against regressions when new providers are added to the routing table.
+ * SRP/DRY check: Pass — isolates canonicalization behaviour without duplicating provider tests.
+ */
+
+import test from "node:test";
+import { strict as assert } from "node:assert";
+
+import { aiServiceFactory, canonicalizeModelKey } from "../server/services/aiServiceFactory.ts";
+
+test("canonicalizeModelKey strips openai prefix", () => {
+  const key = canonicalizeModelKey("openai/gpt-5-2025-08-07");
+  assert.deepEqual(key, {
+    original: "openai/gpt-5-2025-08-07",
+    normalized: "gpt-5-2025-08-07",
+  });
+});
+
+test("canonicalizeModelKey leaves non-prefixed models unchanged", () => {
+  const key = canonicalizeModelKey("meta-llama/llama-401b");
+  assert.deepEqual(key, {
+    original: "meta-llama/llama-401b",
+    normalized: "meta-llama/llama-401b",
+  });
+});
+
+test("aiServiceFactory routes openai-prefixed model to OpenAI service", (t) => {
+  const originalOpenai = (aiServiceFactory as any).openaiService;
+  const originalOpenrouter = (aiServiceFactory as any).openrouterService;
+
+  const fakeOpenai = { name: "openai" };
+  const fakeOpenrouter = { name: "openrouter" };
+
+  (aiServiceFactory as any).openaiService = fakeOpenai;
+  (aiServiceFactory as any).openrouterService = fakeOpenrouter;
+
+  t.after(() => {
+    (aiServiceFactory as any).openaiService = originalOpenai;
+    (aiServiceFactory as any).openrouterService = originalOpenrouter;
+  });
+
+  const routed = aiServiceFactory.getService("openai/gpt-5-mini");
+  assert.equal(routed, fakeOpenai);
+});


### PR DESCRIPTION
## Summary
- guard streaming analysis and Saturn streaming services against decodeURIComponent failures while preserving canonical routing and original SSE metadata
- expand the tracking plan to cover decoding resilience and dedicated canonicalization coverage
- add aiServiceFactory unit tests to lock down OpenAI-prefix normalization and routing behaviour

## Testing
- node --import tsx --test tests/analysisStreamService.test.ts tests/aiServiceFactory.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f14ca0e70483269cd36258e2378447