### PR TITLE
Ensure analysis streaming pending sessions clean up on all paths

### DIFF
--- a/docs/2025-10-16-pending-session-cleanup-plan.md
+++ b/docs/2025-10-16-pending-session-cleanup-plan.md
@@ -1,0 +1,14 @@
+# 2025-10-16 Pending session cleanup plan
+
+## Goal
+Polish the new analysis streaming handshake by ensuring pending payloads are always cleaned up and coverage/docs reflect the server-side cache lifecycle.
+
+## Tasks
+- [x] Update `server/services/streaming/analysisStreamService.ts` to clear pending payloads on unsupported/invalid session paths and tighten lifecycle logging (including TTL-based expirations for abandoned handshakes).
+- [x] Refresh `tests/analysisStreamService.test.ts` to cover the cleanup behaviour and repair module imports.
+- [x] Verify controller cancellation keeps cache in sync and document the flow touch-up in `docs/reference/api/EXTERNAL_API.md` if needed.
+- [x] Run targeted tests (`node --import tsx --test tests/analysisStreamService.test.ts`).
+
+## Notes
+- Reuse existing logging utilities; avoid new dependencies.
+- Ensure tests reset service state between cases to keep Map isolation.

--- a/docs/reference/api/EXTERNAL_API.md
+++ b/docs/reference/api/EXTERNAL_API.md
@@ -92,10 +92,11 @@ Some endpoints now require API key authentication via `Authorization: Bearer <ap
 - `POST /api/stream/analyze` - Prepare Server-Sent Events analysis stream
   - **Body**: Same analysis options accepted by the non-streaming POST endpoint (temperature, promptId, omitAnswer, reasoning options, etc.) plus `taskId` and `modelKey`
   - **Response**: `{ sessionId }` token referencing a cached payload stored on the server for the follow-up SSE request
-  - **Notes**: Payloads are discarded automatically when the stream completes, errors, or is cancelled
+  - **Notes**: Payloads are discarded automatically when the stream completes, errors, or is cancelled, and they auto-expire after 60 seconds if the SSE connection is never opened
 - `GET /api/stream/analyze/:taskId/:modelKey/:sessionId` - Start Server-Sent Events stream for token-by-token analysis
   - **Params**: `taskId` (string), `modelKey` (string), `sessionId` (string) returned from the POST handshake
   - **Query**: No longer accepts large option blobs; the server retrieves the cached payload prepared during the POST handshake
+  - **Safety**: If the `taskId`/`modelKey` tuple does not match the cached payload, the server rejects the connection and clears the pending session to avoid leaks.
   - **Response**: SSE channel emitting `stream.init`, `stream.chunk`, `stream.status`, `stream.complete`, `stream.error`
   - **Notes**: Enabled when `STREAMING_ENABLED=true`; defaults to `true` in development builds so SSE works out of the box. Currently implemented for GPT-5 mini/nano and Grok-4(-Fast) models.
   - **Client**: New `createAnalysisStream` utility in `client/src/lib/streaming/analysisStream.ts` provides a typed wrapper

--- a/server/services/streaming/analysisStreamService.ts
+++ b/server/services/streaming/analysisStreamService.ts
@@ -12,8 +12,6 @@
  * shadcn/ui: Pass — backend service only.
  */
 
-import { isFeatureFlagEnabled } from "@shared/utils/featureFlags";
-
 import { nanoid } from "nanoid";
 import type { Request } from "express";
 import { puzzleAnalysisService } from "../puzzleAnalysisService";
@@ -23,8 +21,6 @@ import { aiServiceFactory, canonicalizeModelKey } from "../aiServiceFactory";
 import type { PromptOptions } from "../promptBuilder";
 import type { ServiceOptions } from "../base/BaseAIService";
 import { resolveStreamingConfig } from "@shared/config/streaming";
-
-const STREAMING_ENABLED = isFeatureFlagEnabled(process.env.ENABLE_SSE_STREAMING);
 
 export interface StreamAnalysisPayload {
   taskId: string;
@@ -43,10 +39,13 @@ export interface StreamAnalysisPayload {
   createdAt?: number;
 }
 
+export const PENDING_SESSION_TTL_SECONDS = 60;
+
 export class AnalysisStreamService {
   private readonly pendingSessions: Map<string, StreamAnalysisPayload> = new Map();
+  private readonly pendingSessionTimers: Map<string, ReturnType<typeof setTimeout>> = new Map();
 
-  savePendingPayload(payload: StreamAnalysisPayload): string {
+  savePendingPayload(payload: StreamAnalysisPayload, ttlMs: number = PENDING_SESSION_TTL_SECONDS * 1000): string {
     const sessionId = payload.sessionId ?? nanoid();
     const enrichedPayload: StreamAnalysisPayload = {
       ...payload,
@@ -55,6 +54,7 @@ export class AnalysisStreamService {
     };
 
     this.pendingSessions.set(sessionId, enrichedPayload);
+    this.scheduleExpiration(sessionId, ttlMs);
     return sessionId;
   }
 
@@ -64,42 +64,73 @@ export class AnalysisStreamService {
 
   clearPendingPayload(sessionId: string): void {
     this.pendingSessions.delete(sessionId);
+    const timer = this.pendingSessionTimers.get(sessionId);
+    if (timer) {
+      clearTimeout(timer);
+      this.pendingSessionTimers.delete(sessionId);
+    }
+  }
+
+  private scheduleExpiration(sessionId: string, ttlMs: number): void {
+    const existingTimer = this.pendingSessionTimers.get(sessionId);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+    }
+
+    if (ttlMs <= 0) {
+      this.clearPendingPayload(sessionId);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      this.pendingSessions.delete(sessionId);
+      this.pendingSessionTimers.delete(sessionId);
+      logger.debug(
+        `[Streaming] Pending payload for session ${sessionId} expired after ${ttlMs}ms`,
+        "stream-service"
+      );
+    }, ttlMs);
+
+    if (typeof (timer as any).unref === "function") {
+      (timer as any).unref();
+    }
+
+    this.pendingSessionTimers.set(sessionId, timer);
   }
 
   async startStreaming(_req: Request, payload: StreamAnalysisPayload): Promise<string> {
     const sessionId = payload.sessionId ?? nanoid();
 
-    if (!sseStreamManager.has(sessionId)) {
-      throw new Error("SSE session must be registered before starting analysis.");
-    }
-
-    const streamingConfig = resolveStreamingConfig();
-    if (!streamingConfig.enabled) {
-      sseStreamManager.error(sessionId, "STREAMING_DISABLED", "Streaming is disabled on this server.");
-      this.clearPendingPayload(sessionId);
-      return sessionId;
-    }
-
-    const { taskId, modelKey } = payload;
-    const decodedModel = decodeURIComponent(modelKey);
-    const { original: originalModelKey, normalized: canonicalModelKey } = canonicalizeModelKey(decodedModel);
-
-    const aiService = aiServiceFactory.getService(canonicalModelKey);
-    if (!aiService?.supportsStreaming?.(canonicalModelKey)) {
-      logger.warn(
-        `Streaming requested for unsupported model ${originalModelKey} (normalized: ${canonicalModelKey})`,
-        "stream-service"
-      );
-      sseStreamManager.error(
-        sessionId,
-        "STREAMING_UNAVAILABLE",
-        "Streaming is not enabled for this model.",
-        { modelKey: originalModelKey }
-      );
-      return sessionId;
-    }
-
     try {
+      if (!sseStreamManager.has(sessionId)) {
+        throw new Error("SSE session must be registered before starting analysis.");
+      }
+
+      const streamingConfig = resolveStreamingConfig();
+      if (!streamingConfig.enabled) {
+        sseStreamManager.error(sessionId, "STREAMING_DISABLED", "Streaming is disabled on this server.");
+        return sessionId;
+      }
+
+      const { taskId, modelKey } = payload;
+      const decodedModel = decodeURIComponent(modelKey);
+      const { original: originalModelKey, normalized: canonicalModelKey } = canonicalizeModelKey(decodedModel);
+
+      const aiService = aiServiceFactory.getService(canonicalModelKey);
+      if (!aiService?.supportsStreaming?.(canonicalModelKey)) {
+        logger.warn(
+          `Streaming requested for unsupported model ${originalModelKey} (normalized: ${canonicalModelKey})`,
+          "stream-service"
+        );
+        sseStreamManager.error(
+          sessionId,
+          "STREAMING_UNAVAILABLE",
+          "Streaming is not enabled for this model.",
+          { modelKey: originalModelKey }
+        );
+        return sessionId;
+      }
+
       sseStreamManager.sendEvent(sessionId, "stream.status", {
         state: "starting",
         modelKey: originalModelKey,


### PR DESCRIPTION
## Summary
- restructure `analysisStreamService.startStreaming` so every early return clears the cached payload
- clear mismatched SSE requests in the controller and document the handshake safety behaviour
- expand the dedicated plan, docs, and tests around the pending-session lifecycle
- add controller-level handshake tests to verify the POST flow validates input and stores pending payloads per the streaming guide
- add TTL-based expiration so abandoned pending sessions drop automatically and update the external API docs accordingly

## Testing
- node --import tsx --test tests/analysisStreamService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f15205a37483268fec2157e8560b90