### PR TITLE
Fix retry mode detection to require discussion referrer

### DIFF
--- a/client/src/pages/PuzzleExaminer.tsx
+++ b/client/src/pages/PuzzleExaminer.tsx
@@ -43,7 +43,26 @@ export default function PuzzleExaminer() {
   const { taskId } = useParams<{ taskId: string }>();
 
   // Check if we're in retry mode (coming from discussion page)
-  const isRetryMode = window.location.search.includes('retry=true') || document.referrer.includes('/discussion');
+  const isRetryMode = useMemo(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('retry') === 'true') {
+      return true;
+    }
+
+    if (!document.referrer) {
+      return false;
+    }
+
+    try {
+      const referrerUrl = new URL(document.referrer);
+      return (
+        referrerUrl.origin === window.location.origin &&
+        referrerUrl.pathname.startsWith('/discussion')
+      );
+    } catch {
+      return false;
+    }
+  }, []);
 
   // Local UI state
   const [showEmojis, setShowEmojis] = useState(false);


### PR DESCRIPTION
## Summary
- prevent puzzle examiner from enabling retry mode when the query param is absent
- only treat the page as retry mode when the referrer comes from the on-site discussion route

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f2ca7d795c8326838ccc0058e75090