### PR TITLE
feat: refresh discussion launchpad with provider-aware grid

### DIFF
--- a/client/src/components/puzzle/refinement/EligibleAnalysisLaunchpadCard.tsx
+++ b/client/src/components/puzzle/refinement/EligibleAnalysisLaunchpadCard.tsx
@@ -1,0 +1,156 @@
+/**
+ * EligibleAnalysisLaunchpadCard.tsx
+ *
+ * Author: gpt-5-codex
+ * Date: 2025-10-17T00:00:00Z
+ * PURPOSE: Thin wrapper around AnalysisResultListCard for the discussion landing page.
+ * Displays recent eligible analyses in a responsive launchpad grid with hero styling.
+ * SRP/DRY check: Pass — delegates rich rendering to AnalysisResultListCard and only adds layout metadata.
+ */
+
+import React, { useMemo } from 'react';
+import { Link } from 'wouter';
+import { Sparkles, Clock3 } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { AnalysisResultListCard } from '@/components/puzzle/AnalysisResultListCard';
+import { determineCorrectness } from '@shared/utils/correctness';
+import { useExplanationById } from '@/hooks/useExplanation';
+import type { EligibleExplanation } from '@/hooks/useEligibleExplanations';
+
+interface EligibleAnalysisLaunchpadCardProps {
+  explanation: EligibleExplanation;
+  onRefine: (puzzleId: string, explanationId: number) => void;
+}
+
+const providerLabelMap: Record<string, string> = {
+  openai: 'OpenAI',
+  xai: 'xAI',
+};
+
+const relativeTimeFormatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+const getRelativeLabel = (hoursOld: number) => {
+  if (hoursOld >= 24) {
+    const days = Math.round(hoursOld / 24);
+    return relativeTimeFormatter.format(-days, 'day');
+  }
+
+  if (hoursOld >= 1) {
+    const wholeHours = Math.floor(hoursOld);
+    return relativeTimeFormatter.format(-wholeHours, 'hour');
+  }
+
+  const minutes = Math.max(1, Math.round(hoursOld * 60));
+  return relativeTimeFormatter.format(-minutes, 'minute');
+};
+
+export const EligibleAnalysisLaunchpadCard: React.FC<EligibleAnalysisLaunchpadCardProps> = ({
+  explanation,
+  onRefine,
+}) => {
+  const { data: fullExplanation, isLoading } = useExplanationById(explanation.id);
+
+  const correctness = useMemo(() => {
+    if (fullExplanation) {
+      return determineCorrectness({
+        modelName: fullExplanation.modelName,
+        isPredictionCorrect: fullExplanation.isPredictionCorrect ?? null,
+        multiTestAllCorrect: fullExplanation.multiTestAllCorrect ?? null,
+        hasMultiplePredictions: fullExplanation.hasMultiplePredictions ?? null,
+      });
+    }
+
+    return {
+      isCorrect: explanation.isCorrect,
+      isIncorrect: !explanation.isCorrect,
+      status: explanation.isCorrect ? 'correct' : 'incorrect',
+      label: explanation.isCorrect ? 'Correct' : 'Incorrect',
+    };
+  }, [explanation.isCorrect, fullExplanation]);
+
+  const providerLabel = providerLabelMap[explanation.provider] ?? explanation.provider.toUpperCase();
+  const relativeUpdated = getRelativeLabel(explanation.hoursOld);
+
+  return (
+    <div className="group rounded-2xl border border-white/10 bg-white/5 [background:linear-gradient(135deg,rgba(255,255,255,0.08),rgba(148,163,255,0.12))] p-4 shadow-lg shadow-indigo-950/20 backdrop-blur transition hover:-translate-y-0.5 hover:shadow-xl">
+      <div className="grid gap-4 lg:grid-cols-[1.25fr,1fr,1fr,1fr,1.1fr] lg:items-center">
+        <div className="space-y-1">
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-indigo-200/70 lg:hidden">Puzzle</span>
+          <Link
+            href={`/discussion/${explanation.puzzleId}`}
+            className="inline-flex items-center gap-2 font-mono text-sm text-indigo-100 transition hover:text-white"
+          >
+            <span className="rounded-md border border-indigo-400/40 bg-indigo-500/10 px-2 py-1">{explanation.puzzleId}</span>
+          </Link>
+        </div>
+
+        <div className="space-y-1">
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-indigo-200/70 lg:hidden">Model</span>
+          <Badge variant="outline" className="border-indigo-400/40 bg-indigo-500/10 text-indigo-50">
+            {explanation.modelName}
+          </Badge>
+        </div>
+
+        <div className="space-y-1">
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-indigo-200/70 lg:hidden">Status</span>
+          <Badge
+            className={
+              correctness.isCorrect
+                ? 'border-emerald-400/50 bg-emerald-500/15 text-emerald-100'
+                : 'border-rose-400/50 bg-rose-500/15 text-rose-100'
+            }
+          >
+            {correctness.label}
+          </Badge>
+        </div>
+
+        <div className="space-y-1">
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-indigo-200/70 lg:hidden">Provider</span>
+          <span className="inline-flex items-center rounded-md border border-indigo-400/40 bg-indigo-500/10 px-3 py-1 text-xs font-semibold tracking-wide text-indigo-100">
+            {providerLabel}
+          </span>
+        </div>
+
+        <div className="flex flex-col gap-2 lg:flex-row lg:items-center lg:justify-end">
+          <div className="flex items-center gap-2 text-xs font-medium text-indigo-100/80">
+            <Clock3 className="h-4 w-4 text-indigo-200" />
+            <span>{relativeUpdated}</span>
+          </div>
+          <button
+            type="button"
+            onClick={() => onRefine(explanation.puzzleId, explanation.id)}
+            className="btn btn-primary btn-sm gap-2 bg-gradient-to-r from-indigo-500 to-purple-500 border-0 text-white shadow-md transition hover:from-indigo-400 hover:to-purple-400"
+          >
+            <Sparkles className="h-4 w-4" />
+            Refine
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        {isLoading && (
+          <div className="h-24 animate-pulse rounded-xl border border-indigo-400/20 bg-indigo-500/10" />
+        )}
+
+        {!isLoading && fullExplanation && (
+          <AnalysisResultListCard
+            result={fullExplanation}
+            modelKey={fullExplanation.modelName}
+            testCases={[]}
+            showDebateButton={false}
+            compact
+            enableExpansion={false}
+          />
+        )}
+
+        {!isLoading && !fullExplanation && (
+          <div className="rounded-xl border border-indigo-400/20 bg-indigo-500/10 p-4 text-sm text-indigo-100/80">
+            Detailed explanation preview is unavailable. Open the puzzle to view the full analysis history.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+

--- a/client/src/hooks/useExplanation.ts
+++ b/client/src/hooks/useExplanation.ts
@@ -98,6 +98,37 @@ export function useExplanations(puzzleId: string | null) {
 }
 
 /**
+ * Fetch a single explanation by its ID.
+ */
+export function useExplanationById(explanationId: number | null) {
+  return useQuery<ExplanationData | null, Error>({
+    queryKey: ['explanation-by-id', explanationId],
+    enabled: explanationId !== null,
+    queryFn: async () => {
+      if (explanationId === null) {
+        return null;
+      }
+
+      const response = await apiRequest('GET', `/api/explanations/${explanationId}`);
+      if (response.status === 404) {
+        return null;
+      }
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch explanation ${explanationId}`);
+      }
+
+      const payload = await response.json();
+      if (payload?.success && payload.data) {
+        return payload.data as ExplanationData;
+      }
+
+      return null;
+    },
+  });
+}
+
+/**
  * Combined hook that provides explanation data for a puzzle.
  */
 export function usePuzzleWithExplanation(puzzleId: string | null) {

--- a/client/src/pages/PuzzleDiscussion.tsx
+++ b/client/src/pages/PuzzleDiscussion.tsx
@@ -19,7 +19,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { CollapsibleCard } from '@/components/ui/collapsible-card';
-import { Brain, Loader2, AlertTriangle, Search, Sparkles, Info } from 'lucide-react';
+import { Brain, Loader2, AlertTriangle, Search, Info } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 
 // Refinement-specific components
@@ -28,6 +28,7 @@ import { PuzzleGrid } from '@/components/puzzle/PuzzleGrid';
 import { ProfessionalRefinementUI } from '@/components/puzzle/refinement/ProfessionalRefinementUI';
 import { StreamingAnalysisPanel } from '@/components/puzzle/StreamingAnalysisPanel';
 import { AnalysisSelector } from '@/components/puzzle/refinement/AnalysisSelector';
+import { EligibleAnalysisLaunchpadCard } from '@/components/puzzle/refinement/EligibleAnalysisLaunchpadCard';
 
 import { usePuzzle } from '@/hooks/usePuzzle';
 import { usePuzzleWithExplanation } from '@/hooks/useExplanation';
@@ -44,6 +45,7 @@ export default function PuzzleDiscussion() {
   const { toast } = useToast();
   const [location, navigate] = useLocation();
   const [searchPuzzleId, setSearchPuzzleId] = useState('');
+  const [recentProviderFilter, setRecentProviderFilter] = useState<'all' | string>('all');
 
   // Parse ?select=123 query parameter for auto-selection
   const selectId = useMemo(() => {
@@ -65,6 +67,26 @@ export default function PuzzleDiscussion() {
   // Fetch eligible explanations for landing page (filtered client-side to match refinement requirements)
   const { data: eligibleData, isLoading: isLoadingEligible } = useEligibleExplanations(20, 0);
   const eligibleExplanations = eligibleData?.explanations || [];
+
+  const availableRecentProviders = useMemo(() => {
+    const providers = new Set<string>();
+    eligibleExplanations.forEach((exp) => providers.add(exp.provider));
+    return Array.from(providers);
+  }, [eligibleExplanations]);
+
+  useEffect(() => {
+    if (recentProviderFilter !== 'all' && !availableRecentProviders.includes(recentProviderFilter)) {
+      setRecentProviderFilter('all');
+    }
+  }, [availableRecentProviders, recentProviderFilter]);
+
+  const filteredEligibleExplanations = useMemo(() => {
+    if (recentProviderFilter === 'all') {
+      return eligibleExplanations;
+    }
+
+    return eligibleExplanations.filter((exp) => exp.provider === recentProviderFilter);
+  }, [eligibleExplanations, recentProviderFilter]);
   // Refinement state management (NOT debate state)
   const refinementState = useRefinementState();
 
@@ -231,6 +253,10 @@ export default function PuzzleDiscussion() {
         variant: "destructive",
       });
     }
+  };
+
+  const handleLaunchpadRefine = (puzzleId: string, explanationId: number) => {
+    navigate(`/discussion/${puzzleId}?select=${explanationId}`);
   };
 
   useEffect(() => {
@@ -429,59 +455,69 @@ export default function PuzzleDiscussion() {
         </Alert>
 
         {/* Recent Eligible Explanations */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Recent Eligible Analyses</CardTitle>
-          </CardHeader>
-          <CardContent>
-            {isLoadingEligible ? (
-              <div className="flex items-center justify-center py-8">
-                <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+        <Card className="border-0 bg-gradient-to-br from-slate-950 via-indigo-950 to-slate-900 text-white shadow-xl">
+          <CardHeader className="pb-0">
+            <CardTitle className="text-xl font-semibold">Recent Eligible Analyses</CardTitle>
+            <p className="text-sm text-indigo-100/80">
+              Pick up where the models left off. These reasoning runs retain encrypted provider memory for seamless refinement.
+            </p>
+            <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-xs uppercase tracking-wide text-indigo-200/70">
+                {eligibleExplanations.length} analyses in the last 30 days
               </div>
-            ) : eligibleExplanations.length > 0 ? (
-              <div className="space-y-2">
-                {eligibleExplanations.map(exp => (
-                  <Card key={exp.id} className="hover:shadow-sm transition-shadow">
-                    <CardContent className="p-4">
-                      <div className="flex items-center justify-between gap-4">
-                        {/* Left: Model info and status */}
-                        <div className="flex items-center gap-3 flex-1 min-w-0">
-                          <Link 
-                            href={`/discussion/${exp.puzzleId}`} 
-                            className="text-blue-600 hover:underline font-mono text-sm font-medium"
-                          >
-                            {exp.puzzleId}
-                          </Link>
-                          <Badge variant="outline" className="font-mono text-xs">
-                            {exp.modelName}
-                          </Badge>
-                          <Badge variant={exp.isCorrect ? "default" : "secondary"} className="text-xs">
-                            {exp.isCorrect ? "Correct" : "Incorrect"}
-                          </Badge>
-                          <Badge variant="outline" className="text-xs">
-                            {exp.provider.toUpperCase()}
-                          </Badge>
-                          <span className="text-xs text-gray-500">{Math.floor(exp.hoursOld)}h {Math.floor((exp.hoursOld % 1) * 60)}m ago</span>
-                        </div>
-                        
-                        {/* Right: Action */}
-                        <Button
-                          size="sm"
-                          onClick={() => navigate(`/discussion/${exp.puzzleId}?select=${exp.id}`)}
-                          className="bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white"
-                        >
-                          <Sparkles className="h-4 w-4 mr-1.5" />
-                          Refine
-                        </Button>
-                      </div>
-                    </CardContent>
-                  </Card>
+              <div className="flex items-center gap-2">
+                <label htmlFor="recent-provider-filter" className="text-xs font-medium text-indigo-100/70">
+                  Provider
+                </label>
+                <select
+                  id="recent-provider-filter"
+                  className="select select-sm select-bordered w-40 border-indigo-400/40 bg-slate-900/60 text-indigo-50"
+                  value={recentProviderFilter}
+                  onChange={(event) => setRecentProviderFilter(event.target.value)}
+                >
+                  <option value="all">All providers</option>
+                  {availableRecentProviders.map((provider) => (
+                    <option key={provider} value={provider}>
+                      {provider.toUpperCase()}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="pt-6">
+            {isLoadingEligible ? (
+              <div className="grid gap-4 sm:grid-cols-1 lg:grid-cols-2">
+                {Array.from({ length: 4 }).map((_, index) => (
+                  <div
+                    key={index}
+                    className="h-40 animate-pulse rounded-2xl border border-indigo-400/30 bg-indigo-500/10"
+                  />
                 ))}
               </div>
+            ) : filteredEligibleExplanations.length > 0 ? (
+              <div className="space-y-4">
+                <div className="hidden grid-cols-[1.25fr,1fr,1fr,1fr,1.1fr] gap-4 text-[11px] font-semibold uppercase tracking-wide text-indigo-200/60 lg:grid">
+                  <span>Puzzle</span>
+                  <span>Model</span>
+                  <span>Status</span>
+                  <span>Provider</span>
+                  <span className="text-right">Last Updated</span>
+                </div>
+                <div className="grid gap-4 sm:grid-cols-1 lg:grid-cols-2">
+                  {filteredEligibleExplanations.map((exp) => (
+                    <EligibleAnalysisLaunchpadCard
+                      key={exp.id}
+                      explanation={exp}
+                      onRefine={handleLaunchpadRefine}
+                    />
+                  ))}
+                </div>
+              </div>
             ) : (
-              <p className="text-sm text-muted-foreground text-center py-8">
-                No eligible analyses found. Generate new analyses from reasoning models (GPT-5, o-series, Grok-4).
-              </p>
+              <div className="rounded-2xl border border-indigo-400/40 bg-indigo-500/10 p-6 text-center text-sm text-indigo-100/80">
+                No eligible analyses found for the selected provider. Generate a new reasoning run with GPT-5, o-series, or Grok-4 to seed the launchpad.
+              </div>
             )}
           </CardContent>
         </Card>

--- a/server/controllers/explanationController.ts
+++ b/server/controllers/explanationController.ts
@@ -58,19 +58,51 @@ export const explanationController = {
     try {
       const { puzzleId } = req.params;
       const explanation = await explanationService.getExplanationForPuzzle(puzzleId);
-      
+
       if (!explanation) {
         return res.status(404).json(formatResponse.error(
-          'NOT_FOUND', 
+          'NOT_FOUND',
           'No explanation found for this puzzle'
         ));
       }
-      
+
       res.json(formatResponse.success(explanation));
     } catch (error) {
       console.error('Error in explanationController.getOne:', error);
       res.status(500).json(formatResponse.error(
-        'INTERNAL_ERROR', 
+        'INTERNAL_ERROR',
+        'Failed to retrieve explanation',
+        { error: error instanceof Error ? error.message : 'Unknown error' }
+      ));
+    }
+  },
+
+  /**
+   * Get a single explanation by its ID
+   */
+  async getById(req: Request, res: Response) {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (Number.isNaN(id)) {
+        return res.status(400).json(formatResponse.error(
+          'INVALID_ID',
+          'Explanation id must be a number'
+        ));
+      }
+
+      const explanation = await explanationService.getExplanationById(id);
+      if (!explanation) {
+        return res.status(404).json(formatResponse.error(
+          'NOT_FOUND',
+          'Explanation not found'
+        ));
+      }
+
+      res.json(formatResponse.success(explanation));
+    } catch (error) {
+      console.error('Error in explanationController.getById:', error);
+      res.status(500).json(formatResponse.error(
+        'INTERNAL_ERROR',
         'Failed to retrieve explanation',
         { error: error instanceof Error ? error.message : 'Unknown error' }
       ));

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -137,6 +137,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   
   // Explanation routes
   app.get("/api/puzzle/:puzzleId/explanations", asyncHandler(explanationController.getAll));
+  app.get("/api/explanations/:id", asyncHandler(explanationController.getById));
   app.get("/api/puzzle/:puzzleId/explanation", asyncHandler(explanationController.getOne));
   app.post("/api/puzzle/save-explained/:puzzleId", validation.explanationCreate, asyncHandler(explanationController.create));
 

--- a/server/services/explanationService.ts
+++ b/server/services/explanationService.ts
@@ -119,6 +119,25 @@ export const explanationService = {
   },
 
   /**
+   * Get a single explanation by database identifier.
+   *
+   * @param explanationId - Numeric primary key for the explanation record
+   * @returns Explanation object or null when not found / DB unavailable
+   */
+  async getExplanationById(explanationId: number) {
+    if (!Number.isInteger(explanationId)) {
+      throw new AppError('Invalid explanation id', 400, 'INVALID_EXPLANATION_ID');
+    }
+
+    const explanation = await repositoryService.explanations.getExplanationById(explanationId);
+    if (explanation === null) {
+      return null;
+    }
+
+    return explanation;
+  },
+
+  /**
    * Save an explanation for a puzzle
    * 
    * @param puzzleId - The ID of the puzzle


### PR DESCRIPTION
## Summary
- expose a `GET /api/explanations/:id` controller/service path so the client can fetch individual analyses for previews
- add `useExplanationById` and the `EligibleAnalysisLaunchpadCard` wrapper to reuse `AnalysisResultListCard` in the recent analyses grid with DaisyUI styling
- overhaul the discussion landing card to include provider filtering, responsive headings, and hero-themed loading/empty states while allowing the list card to disable expansion when context is unavailable

## Testing
- `npm run lint` *(fails: script missing in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68f3e7741a8c8326a7318b22908b2218