### PR TITLE
Fix confidence stat formatting and refinable filter duplication

### DIFF
--- a/client/src/pages/Leaderboards.tsx
+++ b/client/src/pages/Leaderboards.tsx
@@ -593,9 +593,9 @@ const Leaderboards: React.FC = () => {
             ? `${(confidenceStats.confidenceCalibrationGap).toFixed(1)} pts`
             : '—',
         description: confidenceStats
-          ? `${formatPercentage(confidenceStats.avgConfidenceWhenCorrect, { decimals: 1 })} when correct vs ${formatPercentage(
+          ? `${formatPercentage(confidenceStats.avgConfidenceWhenCorrect, { decimals: 1, treatAsFraction: true })} when correct vs ${formatPercentage(
               confidenceStats.avgConfidenceWhenIncorrect,
-              { decimals: 1 }
+              { decimals: 1, treatAsFraction: true }
             )} when incorrect`
           : 'Confidence analytics populate from recorded solver confidence.',
         icon: GaugeCircle,
@@ -843,7 +843,7 @@ const Leaderboards: React.FC = () => {
                       Avg when correct
                     </p>
                     <p className="text-2xl font-semibold text-base-content">
-                      {formatPercentage(confidenceStats.avgConfidenceWhenCorrect, { decimals: 1 })}
+                      {formatPercentage(confidenceStats.avgConfidenceWhenCorrect, { decimals: 1, treatAsFraction: true })}
                     </p>
                   </div>
                   <div className="rounded-lg border border-base-200 bg-base-200/40 p-4 text-left">
@@ -851,7 +851,7 @@ const Leaderboards: React.FC = () => {
                       Avg when incorrect
                     </p>
                     <p className="text-2xl font-semibold text-base-content">
-                      {formatPercentage(confidenceStats.avgConfidenceWhenIncorrect, { decimals: 1 })}
+                      {formatPercentage(confidenceStats.avgConfidenceWhenIncorrect, { decimals: 1, treatAsFraction: true })}
                     </p>
                   </div>
                   <div className="rounded-lg border border-base-200 bg-base-200/40 p-4 text-left">
@@ -859,7 +859,7 @@ const Leaderboards: React.FC = () => {
                       Overall avg confidence
                     </p>
                     <p className="text-2xl font-semibold text-base-content">
-                      {formatPercentage(confidenceStats.overallAvgConfidence, { decimals: 1 })}
+                      {formatPercentage(confidenceStats.overallAvgConfidence, { decimals: 1, treatAsFraction: true })}
                     </p>
                   </div>
                   <div className="rounded-lg border border-base-200 bg-base-200/40 p-4 text-left">

--- a/client/src/pages/PuzzleDiscussion.tsx
+++ b/client/src/pages/PuzzleDiscussion.tsx
@@ -343,7 +343,7 @@ export default function PuzzleDiscussion() {
   };
 
   // Filter explanations to only show eligible ones (has provider response ID + within 30-day retention window)
-  const filteredEligibleExplanations = useMemo(() => {
+  const refinableExplanations = useMemo(() => {
     if (!explanations) return [];
 
     const thirtyDaysAgo = new Date();
@@ -675,9 +675,9 @@ export default function PuzzleDiscussion() {
             </>
           );
         })()
-      ) : filteredEligibleExplanations.length > 0 ? (
+      ) : refinableExplanations.length > 0 ? (
         <AnalysisSelector
-          explanations={filteredEligibleExplanations}
+          explanations={refinableExplanations}
           models={models}
           testCases={task!.test}
           correctnessFilter={refinementState.correctnessFilter}


### PR DESCRIPTION
## Summary
- ensure confidence calibration metrics scale fractions before formatting to percentages
- rename the puzzle refinable explanations filter to prevent duplicate declarations during builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f40518ea188326bd5c7c54ae0903c8