### PR TITLE
Guard OpenAI GPT-5 payloads from temperature fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Introduced summary cards, hero callouts, and operational panels that reuse the shared leaderboard and performance hooks while tightening loading and error handling.
 - Logged the refresh scope, dependencies, and follow-up questions in `docs/2025-10-18-leaderboards-refresh-plan.md` to guide future iterations.
 
+#### Fixes
+- Restored the previous safeguard that omits `temperature` and related sampling parameters when targeting any GPT-5 variant (including provider-prefixed keys), preventing unsupported parameter errors in the OpenAI Responses API payload builder.
+
 ---
 
 ## [4.8.29] - 2025-10-17

--- a/server/config/models/index.ts
+++ b/server/config/models/index.ts
@@ -12,6 +12,34 @@ import { ModelLookup, MODEL_DEFINITIONS } from './ModelDefinitions.js';
 import { modelCapabilities } from './ModelCapabilities.js';
 import { ProviderAdapters } from './ProviderAdapters.js';
 
+function resolveModelDefinition(modelKey: string) {
+  if (typeof modelKey !== 'string' || modelKey.length === 0) {
+    return undefined;
+  }
+
+  const trimmedKey = modelKey.trim();
+  if (!trimmedKey) {
+    return undefined;
+  }
+
+  const directMatch = ModelLookup.getById(trimmedKey);
+  if (directMatch) {
+    return directMatch;
+  }
+
+  const slashIndex = trimmedKey.indexOf('/');
+  if (slashIndex === -1) {
+    return undefined;
+  }
+
+  const providerStripped = trimmedKey.slice(slashIndex + 1);
+  if (!providerStripped) {
+    return undefined;
+  }
+
+  return ModelLookup.getById(providerStripped);
+}
+
 // Static definitions
 export {
   MODEL_DEFINITIONS,
@@ -51,7 +79,7 @@ export async function getModelInfo(modelKey: string): Promise<{
   capabilities: any;
   providerConfig: any;
 } | null> {
-  const definition = ModelLookup.getById(modelKey);
+  const definition = resolveModelDefinition(modelKey);
   if (!definition) return null;
 
   const [capabilities, providerConfig] = await Promise.all([
@@ -83,7 +111,7 @@ export async function getAvailableModels(): Promise<any[]> {
  * Check if a model supports a specific capability
  */
 export async function modelSupports(modelKey: string, capability: string): Promise<boolean> {
-  const definition = ModelLookup.getById(modelKey);
+  const definition = resolveModelDefinition(modelKey);
   if (!definition) return false;
 
   // Check static definition first
@@ -117,22 +145,23 @@ export async function modelSupports(modelKey: string, capability: string): Promi
 
 // Re-export core functions from the original models.ts interface
 export function getModelConfig(modelKey: string) {
-  return ModelLookup.getById(modelKey);
+  return resolveModelDefinition(modelKey);
 }
 
 export function modelSupportsTemperature(modelKey: string): boolean {
-  const definition = ModelLookup.getById(modelKey);
+  const definition = resolveModelDefinition(modelKey);
   return definition?.supportsTemperature ?? false;
 }
 
 export function modelSupportsReasoning(modelKey: string): boolean {
-  const definition = ModelLookup.getById(modelKey);
+  const definition = resolveModelDefinition(modelKey);
   return definition?.isReasoning ?? false;
 }
 
 export function getApiModelName(modelKey: string): string {
-  const definition = ModelLookup.getById(modelKey);
-  return definition?.apiModelName ?? modelKey;
+  const definition = resolveModelDefinition(modelKey);
+  const normalizedKey = typeof modelKey === 'string' ? modelKey.trim() : modelKey;
+  return definition?.apiModelName ?? normalizedKey;
 }
 
 export function getModelsByProvider(provider: string) {

--- a/server/services/openai/modelRegistry.ts
+++ b/server/services/openai/modelRegistry.ts
@@ -15,5 +15,23 @@ export const MODEL_ALIASES: Record<string, string> = {
 };
 
 export function normalizeModelKey(modelKey: string): string {
-  return MODEL_ALIASES[modelKey] ?? getApiModelName(modelKey) ?? modelKey;
+  if (typeof modelKey !== "string" || modelKey.length === 0) {
+    return modelKey;
+  }
+
+  const trimmedKey = modelKey.trim();
+  const slashIndex = trimmedKey.indexOf("/");
+  const providerStrippedKey = slashIndex > -1 ? trimmedKey.slice(slashIndex + 1) : trimmedKey;
+
+  const aliasResolved = MODEL_ALIASES[providerStrippedKey];
+  if (aliasResolved) {
+    return aliasResolved;
+  }
+
+  const apiModelName = getApiModelName(providerStrippedKey);
+  if (apiModelName) {
+    return apiModelName;
+  }
+
+  return providerStrippedKey;
 }

--- a/server/services/openai/payloadBuilder.ts
+++ b/server/services/openai/payloadBuilder.ts
@@ -160,6 +160,8 @@ export function buildResponsesPayload({
   const reasoningConfig = buildReasoningConfig(modelKey, serviceOpts);
   const textPayload = buildTextConfig(modelKey, testCount, serviceOpts);
   const isGPT5ChatModel = GPT5_CHAT_MODELS.has(normalizedKey);
+  const isGPT5Family = normalizedKey.startsWith("gpt-5");
+  const supportsTemperature = !isGPT5Family && modelSupportsTemperature(normalizedKey);
 
   const payload = removeUndefined({
     model: modelName,
@@ -167,8 +169,8 @@ export function buildResponsesPayload({
     instructions: promptPackage.systemPrompt || undefined,
     reasoning: reasoningConfig,
     text: textPayload,
-    temperature: modelSupportsTemperature(modelKey) ? (temperature ?? 0.2) : undefined,
-    top_p: modelSupportsTemperature(modelKey) && isGPT5ChatModel ? 1 : undefined,
+    temperature: supportsTemperature ? (temperature ?? 0.2) : undefined,
+    top_p: supportsTemperature && isGPT5ChatModel ? 1 : undefined,
     previous_response_id: serviceOpts.previousResponseId,
     store: serviceOpts.store !== false,
     parallel_tool_calls: false,

--- a/tests/openaiPayloadBuilder.test.ts
+++ b/tests/openaiPayloadBuilder.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Author: gpt-5-codex
+ * Date: 2025-10-18T00:00:00Z
+ * PURPOSE: Verifies Responses API payload construction omits unsupported parameters
+ *          for GPT-5 models and preserves temperature handling for legacy GPT-4.1 chat models.
+ * SRP/DRY check: Pass — focused unit coverage for OpenAI payload temperature gating.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildResponsesPayload } from "../server/services/openai/payloadBuilder.ts";
+import type { PromptPackage } from "../server/services/promptBuilder.ts";
+import type { ServiceOptions } from "../server/services/base/BaseAIService.ts";
+
+const promptPackage: PromptPackage = {
+  systemPrompt: "Stay structured",
+  userPrompt: "Solve the sample puzzle",
+  selectedTemplate: null,
+  isAlienMode: false,
+  isSolver: true,
+};
+
+const emptyServiceOpts = {} as ServiceOptions;
+
+function assertNoTemperature(payload: Record<string, unknown>) {
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(payload, "temperature"),
+    false,
+    "temperature field should be omitted for unsupported models",
+  );
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(payload, "top_p"),
+    false,
+    "top_p should also be omitted when temperature is unsupported",
+  );
+}
+
+test("GPT-5 reasoning models omit temperature", () => {
+  const { body } = buildResponsesPayload({
+    promptPackage,
+    modelKey: "gpt-5-2025-08-07",
+    temperature: 0.6,
+    serviceOpts: emptyServiceOpts,
+    testCount: 1,
+  });
+
+  assertNoTemperature(body);
+});
+
+test("Provider-prefixed GPT-5 chat omits temperature", () => {
+  const { body } = buildResponsesPayload({
+    promptPackage,
+    modelKey: "openai/gpt-5-chat-latest",
+    temperature: 0.4,
+    serviceOpts: emptyServiceOpts,
+    testCount: 2,
+  });
+
+  assertNoTemperature(body);
+});
+
+test("GPT-4.1 chat models still forward temperature", () => {
+  const { body } = buildResponsesPayload({
+    promptPackage,
+    modelKey: "gpt-4.1-mini-2025-04-14",
+    temperature: 0.3,
+    serviceOpts: emptyServiceOpts,
+    testCount: 1,
+  });
+
+  assert.equal(body.temperature, 0.3);
+  assert.equal(body.top_p, 1);
+});


### PR DESCRIPTION
## Summary
- normalize model capability lookups so provider-prefixed keys resolve before capability checks
- block temperature and related sampling parameters from GPT-5 payloads and metadata while preserving GPT-4.1 chat behaviour
- add regression coverage for GPT-5 temperature omission and update the changelog entry

## Testing
- npx tsx --test tests/openaiPayloadBuilder.test.ts
- node --import tsx --test tests/analysisStreamService.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68f41be9785c83269240824b588ea775