### PR TITLE
Restore prompt preview confirmations before model runs

### DIFF
--- a/client/src/components/puzzle/debate/IndividualDebate.tsx
+++ b/client/src/components/puzzle/debate/IndividualDebate.tsx
@@ -98,6 +98,7 @@ export const IndividualDebate: React.FC<IndividualDebateProps> = ({
   challengeButtonText = 'Generate Challenge' // Default for ModelDebate
 }) => {
   const [showPromptPreview, setShowPromptPreview] = useState(false);
+  const [previewMode, setPreviewMode] = useState<'view' | 'run' | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   // Auto-scroll to newest message when debate updates
@@ -119,8 +120,27 @@ export const IndividualDebate: React.FC<IndividualDebateProps> = ({
   });
 
   // Handle prompt preview - now uses API-based prompt generation
-  const handlePreviewPrompt = () => {
+  const openPromptPreview = (mode: 'view' | 'run') => {
+    setPreviewMode(mode);
     setShowPromptPreview(true);
+  };
+
+  const handlePreviewPrompt = () => {
+    openPromptPreview('view');
+  };
+
+  const handleGenerateChallengeClick = () => {
+    openPromptPreview('run');
+  };
+
+  const handleClosePromptPreview = () => {
+    setShowPromptPreview(false);
+    setPreviewMode(null);
+  };
+
+  const handleConfirmChallenge = async () => {
+    await Promise.resolve(onGenerateChallenge());
+    handleClosePromptPreview();
   };
 
   // Everything is debatable unless explicitly correct
@@ -266,7 +286,7 @@ export const IndividualDebate: React.FC<IndividualDebateProps> = ({
                   Preview
                 </Button>
                 <Button
-                  onClick={onGenerateChallenge}
+                  onClick={handleGenerateChallengeClick}
                   disabled={!challengerModel || processingModels.has(challengerModel)}
                   className="h-[72px] text-sm bg-gradient-to-r from-red-600 to-orange-600 hover:from-red-700 hover:to-orange-700"
                 >
@@ -333,7 +353,7 @@ export const IndividualDebate: React.FC<IndividualDebateProps> = ({
       {task && (
         <PromptPreviewModal
           isOpen={showPromptPreview}
-          onClose={() => setShowPromptPreview(false)}
+          onClose={handleClosePromptPreview}
           task={task}
           taskId={taskId}
           promptId="debate"
@@ -342,6 +362,9 @@ export const IndividualDebate: React.FC<IndividualDebateProps> = ({
             originalExplanation: originalExplanation,
             customChallenge: customChallenge
           }}
+          confirmMode={previewMode === 'run'}
+          onConfirm={previewMode === 'run' ? handleConfirmChallenge : undefined}
+          confirmButtonText="Send Challenge"
         />
       )}
     </div>

--- a/client/src/components/puzzle/refinement/ProfessionalRefinementUI.tsx
+++ b/client/src/components/puzzle/refinement/ProfessionalRefinementUI.tsx
@@ -113,6 +113,7 @@ export const ProfessionalRefinementUI: React.FC<ProfessionalRefinementUIProps> =
   onContinueRefinement
 }) => {
   const [showPromptPreview, setShowPromptPreview] = React.useState(false);
+  const [previewMode, setPreviewMode] = React.useState<'view' | 'run' | null>(null);
   const [showInlinePreview, setShowInlinePreview] = React.useState(false);
   const [promptPreviewData, setPromptPreviewData] = React.useState<any>(null);
   const [isLoadingPreview, setIsLoadingPreview] = React.useState(false);
@@ -297,7 +298,10 @@ export const ProfessionalRefinementUI: React.FC<ProfessionalRefinementUIProps> =
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => setShowPromptPreview(true)}
+                onClick={() => {
+                  setPreviewMode('view');
+                  setShowPromptPreview(true);
+                }}
                 disabled={isProcessing}
                 className="text-xs h-8"
               >
@@ -459,13 +463,25 @@ export const ProfessionalRefinementUI: React.FC<ProfessionalRefinementUIProps> =
       {/* Prompt Preview Modal */}
       <PromptPreviewModal
         isOpen={showPromptPreview}
-        onClose={() => setShowPromptPreview(false)}
+        onClose={() => {
+          setShowPromptPreview(false);
+          setPreviewMode(null);
+        }}
         task={task}
         taskId={taskId}
         promptId={promptId}
         options={{
           customChallenge: userGuidance
         }}
+        confirmMode={previewMode === 'run'}
+        onConfirm={previewMode === 'run'
+          ? async () => {
+              await Promise.resolve(onContinueRefinement());
+              setShowPromptPreview(false);
+              setPreviewMode(null);
+            }
+          : undefined}
+        confirmButtonText="Send Refinement Request"
       />
 
       {/* Iteration Data Table */}
@@ -513,7 +529,10 @@ export const ProfessionalRefinementUI: React.FC<ProfessionalRefinementUIProps> =
             </div>
 
             <Button
-              onClick={onContinueRefinement}
+              onClick={() => {
+                setPreviewMode('run');
+                setShowPromptPreview(true);
+              }}
               disabled={isProcessing}
               className="w-full h-11 bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700"
             >

--- a/client/src/components/puzzle/refinement/RefinementThread.tsx
+++ b/client/src/components/puzzle/refinement/RefinementThread.tsx
@@ -98,6 +98,7 @@ export const RefinementThread: React.FC<RefinementThreadProps> = ({
 }) => {
   const threadEndRef = useRef<HTMLDivElement>(null);
   const [showPromptPreview, setShowPromptPreview] = useState(false);
+  const [previewMode, setPreviewMode] = useState<'view' | 'run' | null>(null);
 
   // Auto-scroll to newest iteration when thread updates
   useEffect(() => {
@@ -285,7 +286,10 @@ export const RefinementThread: React.FC<RefinementThreadProps> = ({
                 <div className="flex justify-center">
                   <button
                     className="btn btn-outline btn-sm flex items-center gap-1 h-8 text-xs"
-                    onClick={() => setShowPromptPreview(true)}
+                    onClick={() => {
+                      setPreviewMode('view');
+                      setShowPromptPreview(true);
+                    }}
                     disabled={isProcessing}
                   >
                     <Eye className="h-3.5 w-3.5" />
@@ -317,7 +321,10 @@ export const RefinementThread: React.FC<RefinementThreadProps> = ({
               <div>
                 <button
                   className="btn w-full h-[72px] text-sm bg-gradient-to-r from-purple-600 to-blue-600 hover:from-purple-700 hover:to-blue-700 text-white"
-                  onClick={onContinueRefinement}
+                  onClick={() => {
+                    setPreviewMode('run');
+                    setShowPromptPreview(true);
+                  }}
                   disabled={isProcessing}
                 >
                   {isProcessing ? (
@@ -386,7 +393,10 @@ export const RefinementThread: React.FC<RefinementThreadProps> = ({
       {/* Prompt Preview Modal */}
       <PromptPreviewModal
         isOpen={showPromptPreview}
-        onClose={() => setShowPromptPreview(false)}
+        onClose={() => {
+          setShowPromptPreview(false);
+          setPreviewMode(null);
+        }}
         task={task}
         taskId={taskId}
         promptId={promptId}
@@ -394,6 +404,15 @@ export const RefinementThread: React.FC<RefinementThreadProps> = ({
           originalExplanation: originalExplanation,
           customChallenge: userGuidance
         }}
+        confirmMode={previewMode === 'run'}
+        onConfirm={previewMode === 'run'
+          ? async () => {
+              await Promise.resolve(onContinueRefinement());
+              setShowPromptPreview(false);
+              setPreviewMode(null);
+            }
+          : undefined}
+        confirmButtonText="Send Refinement Request"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- require the prompt preview modal confirmation before triggering puzzle analysis runs from the model table
- gate debate challenge actions behind the prompt preview modal with an explicit confirmation step
- reuse the preview modal’s confirmation mode when continuing refinement flows so every LLM request is reviewed first

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f426cb1c6083269e848ddae2125bfd