### PR TITLE
Allow Vite preview server from any host

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -81,6 +81,7 @@ export default defineConfig(async ({ mode }): Promise<import('vite').UserConfig>
     preview: {
       port: process.env.PORT ? parseInt(process.env.PORT, 10) : 3000,
       strictPort: true,
+      allowedHosts: true,
     },
     server: {
       allowedHosts: true, // Allow all hosts for deployment flexibility


### PR DESCRIPTION
## Summary
- enable Vite preview server to accept requests from any host by setting `preview.allowedHosts` to true

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f50e8568b08326b46d4f13b04722b9