### PR TITLE
Fix Saturn solver render loop

### DIFF
--- a/client/src/pages/SaturnVisualSolver.tsx
+++ b/client/src/pages/SaturnVisualSolver.tsx
@@ -35,8 +35,6 @@ export default function SaturnVisualSolver() {
   const [reasoningEffort, setReasoningEffort] = React.useState<'minimal' | 'low' | 'medium' | 'high'>('high');
   const [reasoningVerbosity, setReasoningVerbosity] = React.useState<'low' | 'medium' | 'high'>('high');
   const [reasoningSummaryType, setReasoningSummaryType] = React.useState<'auto' | 'detailed'>('detailed');
-  const [startTime, setStartTime] = React.useState<Date | null>(null);
-
   // Track running state
   const isRunning = state.status === 'running';
   const isDone = state.status === 'completed';
@@ -54,17 +52,6 @@ export default function SaturnVisualSolver() {
 
     return state.result as Record<string, unknown>;
   }, [state.result]);
-
-  // Track start time for elapsed calculation
-  // Note: startTime intentionally NOT in dependency array to avoid infinite loop
-  React.useEffect(() => {
-    if (state.status === 'running' && !startTime) {
-      setStartTime(new Date());
-    } else if (state.status !== 'running') {
-      setStartTime(null);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.status]);
 
   // Error states
   if (!taskId) {


### PR DESCRIPTION
## Summary
- remove unused start time state that triggered repeated updates in `SaturnVisualSolver`
- rely on `useSaturnProgress` status flags alone to avoid infinite re-render on the Saturn page

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68f6df16a884832680c754dbb536d493