### PR TITLE
Fix React hook order in SaturnVisualSolver

### DIFF
--- a/client/src/pages/SaturnVisualSolver.tsx
+++ b/client/src/pages/SaturnVisualSolver.tsx
@@ -53,6 +53,10 @@ export default function SaturnVisualSolver() {
     return state.result as Record<string, unknown>;
   }, [state.result]);
 
+  const expectedOutputs = React.useMemo(() => {
+    return (task?.test ?? []).map((testCase) => testCase.output);
+  }, [task]);
+
   // Error states
   if (!taskId) {
     return (
@@ -84,10 +88,6 @@ export default function SaturnVisualSolver() {
       </div>
     );
   }
-
-  const expectedOutputs = React.useMemo(() => {
-    return (task?.test ?? []).map((testCase) => testCase.output);
-  }, [task]);
 
   const onStart = () => start({
     model,


### PR DESCRIPTION
## Summary
- ensure SaturnVisualSolver always registers the expectedOutputs hook before conditional returns to honor React's Rules of Hooks and stop the minified error #310 crash

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6e294220c83268387c44dec5d0813