### PR TITLE
Connect Saturn streaming UI to progress WebSocket

### DIFF
--- a/client/src/hooks/useSaturnProgress.ts
+++ b/client/src/hooks/useSaturnProgress.ts
@@ -270,6 +270,9 @@ export function useSaturnProgress(taskId: string | undefined) {
               createdAt: string;
             };
             setSessionId(payload.sessionId);
+            if (payload.sessionId) {
+              openWebSocket(payload.sessionId);
+            }
             setState((prev) => {
               // Add init message to logLines
               let nextLogs = prev.logLines ? [...prev.logLines] : [];


### PR DESCRIPTION
## Summary
- open the Saturn progress WebSocket as soon as the streaming init event provides a session id
- allow the gallery to receive incremental base64 images during solver execution
- rely on existing socket cleanup logic before reconnecting to avoid duplicate connections

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f6daf6db548326a822aeadd39747dc