### PR TITLE
Intensify PuzzleBrowser layout and enlarge cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [4.8.37] - 2025-10-21
+### 🎨 UI/UX: Amplify Puzzle Browser clarity
+
+#### Summary
+- Removed page-wide gutters so the Puzzle Browser now stretches edge-to-edge against a saturated twilight gradient background.
+- Reframed the knowledge hub, filters, and instructions in glassmorphism panels with brighter call-to-action buttons for unmistakable interactivity.
+- Enlarged PuzzleCard typography, grid previews, and primary "Examine" action so each tile reads as a prominent, clickable card.
+
+---
+
 ## [4.8.36] - 2025-10-20
 ### 🔧 BUGFIX: Fix infinite re-render loop in Saturn solver
 

--- a/client/src/components/puzzle/PuzzleCard.tsx
+++ b/client/src/components/puzzle/PuzzleCard.tsx
@@ -76,47 +76,47 @@ export const PuzzleCard: React.FC<PuzzleCardProps> = ({
   const firstTrainingExample = taskData?.train?.[0];
   const isExplained = Boolean(puzzle.hasExplanation);
   const statusGradient = isExplained
-    ? 'from-emerald-400/40 via-teal-400/30 to-sky-400/40'
-    : 'from-rose-400/40 via-amber-400/30 to-violet-400/35';
+    ? 'from-emerald-400/80 via-teal-400/70 to-sky-500/80'
+    : 'from-rose-500/80 via-amber-400/70 to-violet-600/80';
   const statusText = isExplained ? 'Explained' : 'Needs Analysis';
   const statusColorClass = isExplained ? 'text-emerald-600' : 'text-rose-600';
   const buttonGradient = isExplained
     ? 'from-emerald-500 via-teal-500 to-sky-500'
-    : 'from-rose-500 via-amber-500 to-violet-500';
+    : 'from-rose-600 via-amber-500 to-violet-600';
 
   return (
     <div
       ref={cardRef}
-      className={`group relative rounded-2xl bg-gradient-to-br ${statusGradient} p-[1px] transition-all duration-300 hover:shadow-xl focus-within:shadow-xl`}
+      className={`group relative rounded-[2.25rem] bg-gradient-to-br ${statusGradient} p-[3px] transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_30px_80px_-40px_rgba(15,23,42,0.65)] focus-within:-translate-y-1 focus-within:shadow-[0_30px_80px_-40px_rgba(15,23,42,0.65)]`}
     >
-      <div className="relative h-full rounded-[1.05rem] bg-gradient-to-br from-white via-slate-50/80 to-blue-50/60 p-4 backdrop-blur-sm shadow-sm transition-all duration-300 group-hover:from-white group-hover:to-white group-focus-within:from-white group-focus-within:to-white space-y-3">
-        <div className="pointer-events-none absolute right-4 top-4 flex items-center gap-2">
+      <div className="relative h-full rounded-[2rem] bg-gradient-to-br from-white via-slate-50 to-sky-50 p-7 backdrop-blur-sm shadow-lg transition-all duration-300 group-hover:translate-y-[-2px] group-hover:shadow-xl group-focus-within:translate-y-[-2px] group-focus-within:shadow-xl space-y-5">
+        <div className="pointer-events-none absolute right-7 top-7 flex items-center gap-2">
           <span className={`text-[11px] font-semibold uppercase tracking-wide ${statusColorClass}`}>
             {statusText}
           </span>
         </div>
 
         {/* Header - Name or ID */}
-        <div className="space-y-1 pr-14">
+        <div className="space-y-3 pr-24">
           {hasName && puzzleName ? (
             <>
-              <h3 className="text-base font-semibold text-gray-900 capitalize">
+              <h3 className="text-xl font-semibold text-gray-900 capitalize">
                 {puzzleName}
               </h3>
-              <code className="text-xs font-mono text-gray-500">
+              <code className="text-base font-mono text-gray-500">
                 {puzzle.id}
               </code>
             </>
           ) : (
-            <code className="text-sm font-mono font-semibold text-gray-900">
+            <code className="text-lg font-mono font-semibold text-gray-900">
               {puzzle.id}
             </code>
           )}
-          
+
           {/* Source badge */}
           {puzzle.source && (
             <div className="inline-block">
-              <span className="text-xs px-2 py-0.5 rounded bg-gray-100 text-gray-700">
+              <span className="rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-gray-700">
                 {puzzle.source.replace('-Eval', '').replace('-Heavy', '').replace('ARC', 'ARC-')}
               </span>
             </div>
@@ -125,22 +125,22 @@ export const PuzzleCard: React.FC<PuzzleCardProps> = ({
 
         {/* Grid Preview */}
         {showGridPreview && firstTrainingExample && (
-          <div className="rounded-xl bg-gradient-to-br from-slate-50/80 via-white/90 to-sky-50/80 p-2 ring-1 ring-sky-200/60 transition-all duration-200 group-hover:ring-sky-400/70 group-focus-within:ring-sky-400/70">
-            <div className="flex gap-2 items-start">
+          <div className="rounded-3xl bg-gradient-to-br from-slate-50 via-white to-sky-100/80 p-4 ring-1 ring-sky-200/80 transition-all duration-200 group-hover:ring-sky-400 group-focus-within:ring-sky-400">
+            <div className="flex items-start gap-4">
               <div className="flex-1 min-w-0">
-                <p className="text-xs text-gray-500 mb-1">Input</p>
-                <div className="w-full max-w-[80px]">
+                <p className="mb-1 text-sm font-semibold text-gray-500">Input</p>
+                <div className="w-full max-w-[140px]">
                   <TinyGrid grid={firstTrainingExample.input} />
                 </div>
               </div>
               <div className="flex items-center text-gray-400">
-                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
                 </svg>
               </div>
               <div className="flex-1 min-w-0">
-                <p className="text-xs text-gray-500 mb-1">Output</p>
-                <div className="w-full max-w-[80px]">
+                <p className="mb-1 text-sm font-semibold text-gray-500">Output</p>
+                <div className="w-full max-w-[140px]">
                   <TinyGrid grid={firstTrainingExample.output} />
                 </div>
               </div>
@@ -149,35 +149,35 @@ export const PuzzleCard: React.FC<PuzzleCardProps> = ({
         )}
 
         {/* Analysis Status */}
-        <div className="flex items-center gap-2 text-sm">
+        <div className="flex items-center gap-2 text-lg">
           {isExplained ? (
             <>
-              <span className="font-medium text-emerald-600">✓ Analyzed</span>
+              <span className="font-semibold text-emerald-600">✓ Analyzed</span>
               {puzzle.modelName && (
                 <span className="text-gray-500">by {puzzle.modelName.split('/').pop()}</span>
               )}
             </>
           ) : (
-            <span className="text-gray-500">Awaiting explanation</span>
+            <span className="font-medium text-gray-500">Awaiting explanation</span>
           )}
         </div>
 
         {/* Grid Info */}
-        <div className="flex items-center gap-4 text-sm text-gray-600">
-          <div className="flex items-center gap-1">
-            <Grid3X3 className="h-4 w-4" />
-            <span>{puzzle.maxGridSize}×{puzzle.maxGridSize}</span>
+        <div className="flex items-center gap-5 text-base text-gray-600">
+          <div className="flex items-center gap-1.5">
+            <Grid3X3 className="h-6 w-6" />
+            <span className="font-semibold">{puzzle.maxGridSize}×{puzzle.maxGridSize}</span>
           </div>
-          <span>{puzzle.gridSizeConsistent ? 'Consistent' : 'Variable'}</span>
+          <span className="font-medium">{puzzle.gridSizeConsistent ? 'Consistent grid' : 'Variable grid'}</span>
         </div>
 
         {/* Action Button */}
         <div>
           <Link
             href={`/puzzle/${puzzle.id}`}
-            className={`relative inline-flex w-full items-center justify-center gap-2 overflow-hidden rounded-lg bg-gradient-to-r ${buttonGradient} px-3 py-2 text-sm font-semibold text-white shadow-md transition-all duration-200 hover:scale-[1.02] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white`}
+            className={`relative inline-flex w-full items-center justify-center gap-3 overflow-hidden rounded-2xl bg-gradient-to-r ${buttonGradient} px-5 py-4 text-lg font-semibold text-white shadow-xl transition-all duration-200 hover:scale-[1.04] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white`}
           >
-            <Eye className="h-4 w-4" />
+            <Eye className="h-6 w-6" />
             Examine Puzzle
           </Link>
         </div>

--- a/client/src/pages/PuzzleBrowser.tsx
+++ b/client/src/pages/PuzzleBrowser.tsx
@@ -180,8 +180,8 @@ export default function PuzzleBrowser() {
 
   if (error) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 p-2">
-        <div className="mx-auto max-w-5xl space-y-2">
+      <div className="min-h-screen w-full bg-gradient-to-tr from-[#0f172a] via-[#312e81] to-[#7c3aed]">
+        <div className="flex w-full flex-col space-y-3 px-4 py-10 sm:px-8 lg:px-14 xl:px-20">
           <div role="alert" className="alert alert-error">
             <span>Failed to load puzzles. Please check your connection and try again.</span>
           </div>
@@ -191,12 +191,12 @@ export default function PuzzleBrowser() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 p-2">
-      <div className="mx-auto max-w-7xl space-y-4">
+    <div className="min-h-screen w-full bg-gradient-to-tr from-[#0f172a] via-[#312e81] to-[#7c3aed]">
+      <div className="flex min-h-screen w-full flex-col gap-12 pb-16">
 
-        <header className="text-center">
+        <header className="space-y-8 px-4 pt-10 sm:px-8 lg:px-14 xl:px-20">
           {/* Top decorative corner mosaics */}
-          <div className="-mb-4 flex items-start justify-between px-4">
+          <div className="flex items-start justify-between">
             <EmojiMosaicAccent
               pattern={HERO_STREAMER_PATTERN}
               columns={10}
@@ -215,14 +215,14 @@ export default function PuzzleBrowser() {
             />
           </div>
 
-          <div className="mx-auto flex max-w-4xl flex-col items-center justify-center gap-4">
-            <div className="flex items-center justify-center gap-4">
+          <div className="flex w-full flex-col items-center justify-center gap-5">
+            <div className="flex flex-wrap items-center justify-center gap-4">
               <EmojiMosaicAccent variant="rainbow" size="md" framed className="drop-shadow" />
-              <div>
-                <h1 className="text-3xl font-bold text-slate-900">
+              <div className="text-center sm:text-left">
+                <h1 className="text-4xl font-extrabold text-slate-900">
                   ARC-AGI Puzzle Explorer
                 </h1>
-                <p className="mt-1 text-sm font-medium text-slate-700">
+                <p className="mt-1 text-base font-medium text-slate-800">
                   Navigate the ARC datasets with streamlined filters and curated research links.
                 </p>
               </div>
@@ -232,10 +232,10 @@ export default function PuzzleBrowser() {
             <CollapsibleMission />
           </div>
 
-          <div className="mx-auto mt-6 max-w-5xl">
-            <div className="card border-0 bg-white/90 shadow-lg backdrop-blur-sm">
-              <div className="card-body space-y-4 p-4">
-                <div className="flex flex-wrap items-center justify-center gap-3 text-center">
+          <div className="mt-8">
+            <div className="card border-0 bg-white/90 shadow-[0_35px_80px_-40px_rgba(15,23,42,0.65)] backdrop-blur">
+              <div className="card-body space-y-5 px-6 py-7">
+                <div className="flex flex-wrap items-center justify-center gap-4 text-center">
                   <EmojiMosaicAccent variant="datasetSignal" size="sm" framed />
                   <Sparkles className="h-4 w-4 text-slate-600" />
                   <h3 className="text-base font-bold text-slate-900">
@@ -245,96 +245,136 @@ export default function PuzzleBrowser() {
                   <EmojiMosaicAccent variant="analysisSignal" size="sm" framed />
                 </div>
 
-                <div className="grid grid-cols-1 gap-3 text-left sm:grid-cols-2 lg:grid-cols-4">
-                <div className="rounded-lg border border-slate-200 bg-white/80 p-3 text-[11px]">
-                  <div className="flex items-center gap-2 mb-2">
-                    <EmojiMosaicAccent variant="statusExplained" size="xs" framed={false} />
-                    <p className="font-bold text-slate-900 uppercase tracking-wide">Research Papers</p>
+                <div className="grid grid-cols-1 gap-4 text-left sm:grid-cols-2 lg:grid-cols-4">
+                  <div className="rounded-2xl border-2 border-slate-200 bg-white/95 p-5 text-xs shadow-sm transition-all hover:-translate-y-1.5 hover:border-blue-500 hover:shadow-lg">
+                    <div className="mb-3 flex items-center gap-2">
+                      <EmojiMosaicAccent variant="statusExplained" size="xs" framed={false} />
+                      <p className="font-bold text-slate-900 uppercase tracking-wide">Research Papers</p>
+                    </div>
+                    <a
+                      href="https://www.arxiv.org/pdf/2505.11831"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="btn btn-sm justify-between gap-3 border-2 border-blue-500 bg-white text-blue-700 font-semibold transition-all hover:-translate-y-0.5 hover:bg-blue-500 hover:text-white"
+                    >
+                      ARC-AGI-2 Technical Report
+                      <ExternalLink className="h-3 w-3" />
+                    </a>
                   </div>
-                  <a href="https://www.arxiv.org/pdf/2505.11831" target="_blank" rel="noopener noreferrer" className="mt-1 inline-flex items-center gap-1 text-blue-700 hover:text-blue-900">
-                    ARC-AGI-2 Technical Report
-                    <ExternalLink className="h-3 w-3" />
-                  </a>
+
+                  <div className="rounded-2xl border-2 border-slate-200 bg-white/95 p-5 text-xs shadow-sm transition-all hover:-translate-y-1.5 hover:border-blue-500 hover:shadow-lg">
+                    <div className="mb-3 flex items-center gap-2">
+                      <EmojiMosaicAccent variant="sizeSignal" size="xs" framed={false} />
+                      <p className="font-bold text-slate-900 uppercase tracking-wide">Data Sources</p>
+                    </div>
+                    <div className="mt-1 space-y-2">
+                      <a
+                        href="https://huggingface.co/arcprize"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn btn-sm justify-between gap-3 border-2 border-blue-500 bg-white text-blue-700 font-semibold transition-all hover:-translate-y-0.5 hover:bg-blue-500 hover:text-white"
+                      >
+                        HuggingFace Datasets
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                      <a
+                        href="https://github.com/fchollet/ARC-AGI"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn btn-sm justify-between gap-3 border-2 border-blue-500 bg-white text-blue-700 font-semibold transition-all hover:-translate-y-0.5 hover:bg-blue-500 hover:text-white"
+                      >
+                        Official Repository
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    </div>
+                  </div>
+
+                  <div className="rounded-2xl border-2 border-slate-200 bg-white/95 p-5 text-xs shadow-sm transition-all hover:-translate-y-1.5 hover:border-emerald-500 hover:shadow-lg">
+                    <div className="mb-3 flex items-center gap-2">
+                      <EmojiMosaicAccent variant="searchSignal" size="xs" framed={false} />
+                      <p className="font-bold text-slate-900 uppercase tracking-wide">Top Solutions</p>
+                    </div>
+                    <div className="mt-1 space-y-2">
+                      <a
+                        href="https://github.com/zoecarver"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn btn-sm justify-between gap-3 border-2 border-emerald-500 bg-white text-emerald-700 font-semibold transition-all hover:-translate-y-0.5 hover:bg-emerald-500 hover:text-white"
+                      >
+                        zoecarver's approach
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                      <a
+                        href="https://github.com/jerber"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn btn-sm justify-between gap-3 border-2 border-emerald-500 bg-white text-emerald-700 font-semibold transition-all hover:-translate-y-0.5 hover:bg-emerald-500 hover:text-white"
+                      >
+                        jerber's solutions
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    </div>
+                  </div>
+
+                  <div className="rounded-2xl border-2 border-slate-200 bg-white/95 p-5 text-xs shadow-sm transition-all hover:-translate-y-1.5 hover:border-orange-500 hover:shadow-lg">
+                    <div className="mb-3 flex items-center gap-2">
+                      <EmojiMosaicAccent variant="statusUnexplained" size="xs" framed={false} />
+                      <p className="font-bold text-slate-900 uppercase tracking-wide">Community Knowledge</p>
+                    </div>
+                    <div className="mt-1 space-y-2">
+                      <a
+                        href="https://github.com/google/ARC-GEN/blob/main/task_list.py#L422"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn btn-sm justify-between gap-3 border-2 border-orange-500 bg-white text-orange-700 font-semibold transition-all hover:-translate-y-0.5 hover:bg-orange-500 hover:text-white"
+                      >
+                        Puzzle nomenclature
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                      <a
+                        href="https://github.com/neoneye/arc-notes"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn btn-sm justify-between gap-3 border-2 border-orange-500 bg-white text-orange-700 font-semibold transition-all hover:-translate-y-0.5 hover:bg-orange-500 hover:text-white"
+                      >
+                        ARC notes
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                      <a
+                        href="https://github.com/cristianoc/arc-agi-2-abstraction-dataset"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn btn-sm justify-between gap-3 border-2 border-orange-500 bg-white text-orange-700 font-semibold transition-all hover:-translate-y-0.5 hover:bg-orange-500 hover:text-white"
+                      >
+                        Abstraction dataset
+                        <ExternalLink className="h-3 w-3" />
+                      </a>
+                    </div>
+                  </div>
                 </div>
 
-                <div className="rounded-lg border border-slate-200 bg-white/80 p-3 text-[11px]">
-                  <div className="flex items-center gap-2 mb-2">
-                    <EmojiMosaicAccent variant="sizeSignal" size="xs" framed={false} />
-                    <p className="font-bold text-slate-900 uppercase tracking-wide">Data Sources</p>
-                  </div>
-                  <div className="mt-1 space-y-1">
-                    <a href="https://huggingface.co/arcprize" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-blue-700 hover:text-blue-900">
-                      HuggingFace Datasets
-                      <ExternalLink className="h-3 w-3" />
-                    </a>
-                    <a href="https://github.com/fchollet/ARC-AGI" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-blue-700 hover:text-blue-900">
-                      Official Repository
-                      <ExternalLink className="h-3 w-3" />
-                    </a>
-                  </div>
+                <div className="flex items-center justify-center gap-3 text-center">
+                  <EmojiMosaicAccent variant="heroTwilight" size="xs" framed={false} />
+                  <p className="text-xs font-medium text-slate-700">
+                    <strong>Special thanks to Simon Strandgaard (@neoneye)</strong> for his insights, support, and encouragement.
+                  </p>
+                  <EmojiMosaicAccent variant="heroSunrise" size="xs" framed={false} />
                 </div>
-
-                <div className="rounded-lg border border-slate-200 bg-white/80 p-3 text-[11px]">
-                  <div className="flex items-center gap-2 mb-2">
-                    <EmojiMosaicAccent variant="searchSignal" size="xs" framed={false} />
-                    <p className="font-bold text-slate-900 uppercase tracking-wide">Top Solutions</p>
-                  </div>
-                  <div className="mt-1 space-y-1">
-                    <a href="https://github.com/zoecarver" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-emerald-700 hover:text-emerald-900">
-                      zoecarver's approach
-                      <ExternalLink className="h-3 w-3" />
-                    </a>
-                    <a href="https://github.com/jerber" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-emerald-700 hover:text-emerald-900">
-                      jerber's solutions
-                      <ExternalLink className="h-3 w-3" />
-                    </a>
-                  </div>
-                </div>
-
-                <div className="rounded-lg border border-slate-200 bg-white/80 p-3 text-[11px]">
-                  <div className="flex items-center gap-2 mb-2">
-                    <EmojiMosaicAccent variant="statusUnexplained" size="xs" framed={false} />
-                    <p className="font-bold text-slate-900 uppercase tracking-wide">Community Knowledge</p>
-                  </div>
-                  <div className="mt-1 space-y-1">
-                    <a href="https://github.com/google/ARC-GEN/blob/main/task_list.py#L422" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-orange-700 hover:text-orange-900">
-                      Puzzle nomenclature
-                      <ExternalLink className="h-3 w-3" />
-                    </a>
-                    <a href="https://github.com/neoneye/arc-notes" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-orange-700 hover:text-orange-900">
-                      ARC notes
-                      <ExternalLink className="h-3 w-3" />
-                    </a>
-                    <a href="https://github.com/cristianoc/arc-agi-2-abstraction-dataset" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-orange-700 hover:text-orange-900">
-                      Abstraction dataset
-                      <ExternalLink className="h-3 w-3" />
-                    </a>
-                  </div>
-                </div>
-              </div>
-
-              <div className="text-center flex items-center justify-center gap-2">
-                <EmojiMosaicAccent variant="heroTwilight" size="xs" framed={false} />
-                <p className="text-[11px] text-slate-700 font-medium">
-                  <strong>Special thanks to Simon Strandgaard (@neoneye)</strong> for his insights, support, and encouragement.
-                </p>
-              <EmojiMosaicAccent variant="heroSunrise" size="xs" framed={false} />
               </div>
             </div>
           </div>
-        </div>
         </header>
 
         {/* Filters */}
 
-        <div className="card border-2 border-slate-300 bg-white shadow-md max-w-5xl mx-auto">
-          <div className="card-body py-3 px-4">
-            <div className="flex flex-wrap items-end justify-center gap-4">
+        <div className="card border-0 bg-white/95 shadow-[0_30px_70px_-40px_rgba(15,23,42,0.65)] backdrop-blur px-4 sm:px-8 lg:px-14 xl:px-20">
+          <div className="card-body px-0 py-6">
+            <div className="flex flex-wrap items-end justify-center gap-6">
               <div className="flex flex-col gap-1.5 min-w-[200px]">
                 <label htmlFor="puzzleSearch" className="text-xs font-bold text-slate-900 uppercase tracking-wide">Search by Puzzle ID</label>
                 <div className="flex items-center gap-2">
                   <input
-                    className="input input-sm input-bordered w-56 border-2 border-slate-400 bg-white text-slate-900 placeholder:text-slate-500 font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    className="input input-md input-bordered w-64 border-2 border-slate-300 bg-white text-slate-900 placeholder:text-slate-500 font-semibold shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     id="puzzleSearch"
                     placeholder="e.g., 1ae2feb7"
                     value={searchQuery}
@@ -350,8 +390,7 @@ export default function PuzzleBrowser() {
                   />
                   <button
                     type="button"
-                    className="btn btn-sm btn-primary normal-case font-semibold"
-
+                    className="btn btn-md bg-gradient-to-r from-sky-500 via-indigo-500 to-fuchsia-500 border-0 text-white font-semibold shadow-lg hover:from-sky-600 hover:via-indigo-600 hover:to-fuchsia-600"
                     onClick={handleSearch}
                   >
                     Search
@@ -363,11 +402,11 @@ export default function PuzzleBrowser() {
                 )}
               </div>
 
-              <div className="flex flex-wrap items-end justify-center gap-4">
-                <div className="flex flex-col gap-1.5 min-w-[140px]">
+              <div className="flex flex-wrap items-end justify-center gap-5">
+                <div className="flex flex-col gap-2 min-w-[160px]">
                   <label htmlFor="maxGridSize" className="text-xs font-bold text-slate-900 uppercase tracking-wide">Max Grid Size</label>
                   <select
-                    className="select select-sm select-bordered w-full border-2 border-slate-400 bg-white text-slate-900 font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    className="select select-md select-bordered w-full border-2 border-slate-300 bg-white text-slate-900 font-semibold focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     value={maxGridSize}
                     onChange={(e) => setMaxGridSize(e.target.value)}
                   >
@@ -380,10 +419,10 @@ export default function PuzzleBrowser() {
                   </select>
                 </div>
 
-                <div className="flex flex-col gap-1.5 min-w-[160px]">
+                <div className="flex flex-col gap-2 min-w-[170px]">
                   <label htmlFor="explanationFilter" className="text-xs font-bold text-slate-900 uppercase tracking-wide">Explanation Status</label>
                   <select
-                    className="select select-sm select-bordered w-full border-2 border-slate-400 bg-white text-slate-900 font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    className="select select-md select-bordered w-full border-2 border-slate-300 bg-white text-slate-900 font-semibold focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     value={explanationFilter}
                     onChange={(e) => setExplanationFilter(e.target.value)}
                   >
@@ -393,10 +432,10 @@ export default function PuzzleBrowser() {
                   </select>
                 </div>
 
-                <div className="flex flex-col gap-1.5 min-w-[170px]">
+                <div className="flex flex-col gap-2 min-w-[180px]">
                   <label htmlFor="gridConsistent" className="text-xs font-bold text-slate-900 uppercase tracking-wide">Grid Consistency</label>
                   <select
-                    className="select select-sm select-bordered w-full border-2 border-slate-400 bg-white text-slate-900 font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    className="select select-md select-bordered w-full border-2 border-slate-300 bg-white text-slate-900 font-semibold focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     value={gridSizeConsistent}
                     onChange={(e) => setGridSizeConsistent(e.target.value)}
                   >
@@ -406,10 +445,10 @@ export default function PuzzleBrowser() {
                   </select>
                 </div>
 
-                <div className="flex flex-col gap-1.5 min-w-[160px]">
+                <div className="flex flex-col gap-2 min-w-[180px]">
                   <label htmlFor="arcVersion" className="text-xs font-bold text-slate-900 uppercase tracking-wide">ARC Version</label>
                   <select
-                    className="select select-sm select-bordered w-full border-2 border-slate-400 bg-white text-slate-900 font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    className="select select-md select-bordered w-full border-2 border-slate-300 bg-white text-slate-900 font-semibold focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     value={arcVersion}
                     onChange={(e) => setArcVersion(e.target.value)}
                   >
@@ -423,10 +462,10 @@ export default function PuzzleBrowser() {
                   </select>
                 </div>
 
-                <div className="flex flex-col gap-1.5 min-w-[170px]">
+                <div className="flex flex-col gap-2 min-w-[190px]">
                   <label htmlFor="multiTestFilter" className="text-xs font-bold text-slate-900 uppercase tracking-wide">Test Cases</label>
                   <select
-                    className="select select-sm select-bordered w-full border-2 border-slate-400 bg-white text-slate-900 font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    className="select select-md select-bordered w-full border-2 border-slate-300 bg-white text-slate-900 font-semibold focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     value={multiTestFilter}
                     onChange={(e) => setMultiTestFilter(e.target.value)}
                   >
@@ -436,10 +475,10 @@ export default function PuzzleBrowser() {
                   </select>
                 </div>
 
-                <div className="flex flex-col gap-1.5 min-w-[200px]">
+                <div className="flex flex-col gap-2 min-w-[210px]">
                   <label htmlFor="sortBy" className="text-xs font-bold text-slate-900 uppercase tracking-wide">Sort By</label>
                   <select
-                    className="select select-sm select-bordered w-full border-2 border-slate-400 bg-white text-slate-900 font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    className="select select-md select-bordered w-full border-2 border-slate-300 bg-white text-slate-900 font-semibold focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     value={sortBy}
                     onChange={(e) => setSortBy(e.target.value)}
                   >
@@ -455,8 +494,8 @@ export default function PuzzleBrowser() {
               </div>
             </div>
 
-            <div className="mt-3 flex flex-wrap items-center justify-center gap-2 border-t border-slate-200 pt-3 text-[10px]">
-              <span className="text-xs font-bold text-slate-900">Active Filters:</span>
+            <div className="mt-5 flex flex-wrap items-center justify-center gap-2 border-t border-slate-200 pt-4 text-[10px]">
+              <span className="text-sm font-bold text-slate-900">Active Filters:</span>
               {[
                 { id: 'search', label: 'Search', active: searchQuery.trim().length > 0 },
                 { id: 'maxGridSize', label: 'Max grid', active: maxGridSize !== 'any' },
@@ -468,7 +507,7 @@ export default function PuzzleBrowser() {
               ].map((item) => (
                 <div
                   key={item.id}
-                  className={`flex items-center gap-1 rounded-full border px-2.5 py-1 font-semibold transition-colors ${ item.active ? 'border-blue-600 bg-blue-100 text-blue-900 shadow-sm' : 'border-slate-300 bg-slate-50 text-slate-500' }`}
+                  className={`flex items-center gap-2 rounded-full border px-3.5 py-1.5 text-xs font-semibold transition-all ${ item.active ? 'border-blue-600 bg-blue-100 text-blue-900 shadow-md' : 'border-slate-300 bg-slate-50 text-slate-500' }`}
                 >
                   <span>{item.label}</span>
                 </div>
@@ -477,31 +516,31 @@ export default function PuzzleBrowser() {
           </div>
         </div>
         {/* Results */}
-        <div className="card shadow-lg border-0 bg-white/80 backdrop-blur-sm max-w-6xl mx-auto">
-          <div className="card-body p-2">
-            <div className="mb-3 flex flex-wrap items-center justify-center gap-2 text-slate-800">
-              <h2 className="text-base font-semibold">Puzzle Results</h2>
+        <div className="card w-full border-0 bg-white/90 shadow-[0_45px_90px_-50px_rgba(15,23,42,0.75)] backdrop-blur px-4 sm:px-8 lg:px-14 xl:px-20">
+          <div className="card-body px-0 py-6">
+            <div className="mb-4 flex flex-wrap items-center justify-between gap-3 text-slate-800">
+              <h2 className="text-lg font-semibold">Puzzle Results</h2>
               {!isLoading && (
-                <div className="badge badge-sm badge-outline bg-blue-50 text-blue-700 border-blue-200">
+                <div className="badge badge-md border-0 bg-gradient-to-r from-sky-500 to-indigo-500 text-white shadow">
                   {filteredPuzzles.length} found
                 </div>
               )}
             </div>
             {isLoading ? (
-              <div className="text-center py-4">
+              <div className="py-8 text-center">
                 <Loader2 className="h-6 w-6 animate-spin mx-auto mb-2" />
                 <p className="text-xs">Loading puzzles...</p>
               </div>
             ) : filteredPuzzles.length === 0 ? (
-              <div className="text-center py-4">
-                <Grid3X3 className="h-8 w-8 mx-auto mb-2 text-gray-400" />
-                <p className="text-gray-600 text-sm">No puzzles match your current filters.</p>
-                <p className="text-xs text-gray-500 mt-1">
+              <div className="py-8 text-center">
+                <Grid3X3 className="mx-auto mb-3 h-10 w-10 text-gray-400" />
+                <p className="text-sm text-gray-600">No puzzles match your current filters.</p>
+                <p className="mt-1 text-xs text-gray-500">
                   Try adjusting your filters.
                 </p>
               </div>
             ) : (
-              <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+              <div className="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
                 {filteredPuzzles.map((puzzle: EnhancedPuzzleMetadata) => (
                   <PuzzleCard
                     key={puzzle.id}
@@ -515,19 +554,19 @@ export default function PuzzleBrowser() {
         </div>
 
         {/* Instructions */}
-        <div className="card max-w-5xl mx-auto">
-          <div className="card-body p-2">
-            <h2 className="card-title text-sm mb-1">How to Use</h2>
-            <div className="space-y-1 text-[10px]">
-            <p>
-              <strong>Goal:</strong> This tool helps you examine ARC-AGI puzzles to understand how they work, 
-              rather than trying to solve them yourself, but if you want to do that, visit <Link href="https://human-arc.gptpluspro.com/assessment">Puzzle Browser</Link>.
-            </p>
-            
-            <p>
-              <strong>AI Analysis:</strong> Click "Examine" on any puzzle to see the correct answers (from the .json file) and
-              have the AI try (and often fail!) to explain the logic behind the puzzle.
-            </p>
+        <div className="card w-full border-0 bg-white/85 shadow-[0_30px_70px_-50px_rgba(15,23,42,0.7)] backdrop-blur px-4 sm:px-8 lg:px-14 xl:px-20">
+          <div className="card-body px-0 py-6">
+            <h2 className="card-title mb-2 text-base">How to Use</h2>
+            <div className="space-y-2 text-xs leading-relaxed text-slate-700">
+              <p>
+                <strong>Goal:</strong> This tool helps you examine ARC-AGI puzzles to understand how they work,
+                rather than trying to solve them yourself, but if you want to do that, visit <Link href="https://human-arc.gptpluspro.com/assessment">Puzzle Browser</Link>.
+              </p>
+
+              <p>
+                <strong>AI Analysis:</strong> Click "Examine" on any puzzle to see the correct answers (from the .json file) and
+                have the AI try (and often fail!) to explain the logic behind the puzzle.
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Saturated the PuzzleBrowser background and removed page gutters so hero, filter, and results panels sit flush in glassy containers with clearer call-to-action buttons.
- Enlarged puzzle filters, badges, and card grid spacing to emphasize interactivity while retaining existing data hooks.
- Boosted PuzzleCard scale with bolder gradients, larger previews, and an oversized Examine button for unmistakably clickable tiles.

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68f7e658740c8326b33d654c9a4ffdf4