### PR TITLE
Restore aurora styling to analysis results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [4.8.39] - 2025-10-22
+### 🎨 UI/UX: Restore aurora warmth to analysis result surfaces
+
+- Reimagined AnalysisResultCard with the September aurora gradient shell, warm linen raw data drawer, and jewel-toned accents so the card no longer feels stark white.
+- Reintroduced honeyglass backgrounds, apricot hover states, and jewel badges throughout AnalysisResultGrid to match the revived hero card styling while keeping diff controls legible.
+- Harmonized the compact AnalysisResultListCard and its collapse header with the same gradient, badge treatments, and button tints for a consistent experience across list and full views.
+
+#### Verification
+- Not run (visual change only)
+
+---
+
 ## [4.8.38] - 2025-10-22
 ### ?? Feature: Multi-model comparison (add/remove inline)
 
@@ -16,7 +28,9 @@
 - Max 4 models enforced to match backend capabilities (metricsController and MetricsRepository).
 - No server changes required; leverages existing model1..model4 query pattern.
 
----## [4.8.37] - 2025-10-21
+---
+
+## [4.8.37] - 2025-10-21
 ### 🎨 UI/UX: Amplify Puzzle Browser clarity
 
 #### Summary

--- a/client/src/components/puzzle/AnalysisResultCard.tsx
+++ b/client/src/components/puzzle/AnalysisResultCard.tsx
@@ -8,6 +8,8 @@
  * correctly shows "Incorrect" (not "Some Incorrect") when 0/N tests are correct. Simplified fallback
  * logic to rely on multiTestAllCorrect flag when detailed validation data is unavailable.
  * ADDED: Deep linking support - each card has id="explanation-{id}" and data-explanation-id for direct URLs.
+ * UPDATED (2025-10-22T00:00:00Z) by gpt-5-codex: Reintroduced last month's aurora gradient shell, warm accent borders,
+ * and linen-inspired drawer treatments to remove the stark white regression while preserving dark mode balance.
  * SRP/DRY check: Pass - Single responsibility (orchestration), reuses child components
  * shadcn/ui: Pass - Converted to DaisyUI badge
  */
@@ -157,9 +159,9 @@ export const AnalysisResultCard = React.memo(function AnalysisResultCard({ model
   const isGroverResult = Boolean(result.groverIterations || result.groverBestProgram || result.iterationCount);
 
   return (
-    <div 
+    <div
       id={result.id ? `explanation-${result.id}` : undefined}
-      className="border rounded-lg p-4 space-y-3 scroll-mt-20 transition-all"
+      className="relative overflow-hidden rounded-3xl border border-amber-100/70 bg-[radial-gradient(circle_at_top,_rgba(254,243,199,0.92),_rgba(255,228,230,0.86)_45%,_rgba(219,234,254,0.82))] p-4 sm:p-6 space-y-5 scroll-mt-24 shadow-[0_28px_65px_-40px_rgba(146,64,14,0.55)] transition-all hover:shadow-[0_34px_78px_-42px_rgba(30,64,175,0.55)] supports-[backdrop-filter]:bg-white/80 supports-[backdrop-filter]:backdrop-blur-md dark:border-violet-800/60 dark:bg-[radial-gradient(circle_at_top,_rgba(17,24,39,0.92),_rgba(76,29,149,0.62)_45%,_rgba(15,118,110,0.54))] dark:shadow-[0_28px_70px_-40px_rgba(12,74,110,0.65)] dark:hover:shadow-[0_34px_82px_-44px_rgba(94,234,212,0.55)]"
       data-explanation-id={result.id}
     >
       <AnalysisResultHeader
@@ -178,19 +180,19 @@ export const AnalysisResultCard = React.memo(function AnalysisResultCard({ model
       />
 
       {showRawDb && (
-        <div className="bg-gray-50 border border-gray-200 rounded">
-          <div className="p-3 border-b border-gray-200 flex items-center justify-between">
-            <h5 className="font-semibold text-gray-800">Raw DB record</h5>
-            <div className="badge badge-outline text-xs bg-gray-50">
+        <div className="rounded-2xl border border-amber-200/70 bg-amber-50/80 shadow-[inset_0_12px_28px_-24px_rgba(120,53,15,0.45)] dark:border-violet-900/70 dark:bg-violet-950/40">
+          <div className="flex items-center justify-between gap-3 border-b border-amber-200/70 bg-gradient-to-r from-amber-100/70 via-rose-100/50 to-sky-100/60 px-4 py-3 dark:border-violet-900/70 dark:from-violet-950/80 dark:via-slate-900/40 dark:to-emerald-900/40">
+            <h5 className="font-semibold text-amber-900 dark:text-emerald-200">Raw DB record</h5>
+            <div className="badge badge-outline text-xs bg-white/60 text-amber-800 shadow-sm dark:bg-violet-900/60 dark:text-sky-100">
               {result.id ? `id: ${result.id}` : 'unsaved'}
             </div>
           </div>
-          <div className="p-3 max-h-64 overflow-y-auto">
-            <pre className="text-xs text-gray-700 whitespace-pre-wrap font-mono leading-relaxed">
+          <div className="max-h-64 overflow-y-auto px-4 py-3">
+            <pre className="font-mono text-xs leading-relaxed text-amber-900/90 dark:text-emerald-200 whitespace-pre-wrap">
               {JSON.stringify(result, null, 2)}
             </pre>
           </div>
-          <p className="text-xs text-gray-500 px-3 pb-3">This shows the raw explanation object as stored/returned by the backend.</p>
+          <p className="px-4 pb-4 text-xs text-amber-700/80 dark:text-emerald-300/80">This shows the raw explanation object as stored/returned by the backend.</p>
         </div>
       )}
 
@@ -226,7 +228,7 @@ export const AnalysisResultCard = React.memo(function AnalysisResultCard({ model
       {isSaturnResult && <AnalysisResultMetrics result={result} isSaturnResult={isSaturnResult} />}
 
       {/* Always show feedback actions - useful for comparison evaluation */}
-      <div className="border-t pt-3">
+      <div className="border-t border-rose-200/60 pt-4 dark:border-violet-900/60">
         <AnalysisResultActions result={result} showExistingFeedback={showExistingFeedback} />
       </div>
     </div>

--- a/client/src/components/puzzle/AnalysisResultGrid.tsx
+++ b/client/src/components/puzzle/AnalysisResultGrid.tsx
@@ -8,6 +8,8 @@
  * FIXED: Removed multiTestAverageAccuracy check in fallback logic - now uses ONLY multiTestAllCorrect flag.
  * Displays "Incorrect" (not "Some Incorrect") when we can't determine exact count without validation data.
  * Handles optimistic UI states with skeleton loaders during analysis/saving.
+ * UPDATED (2025-10-22T00:00:00Z) by gpt-5-codex: Restored September's warm honeyglass panels, apricot hover states,
+ * and jewel-toned badges so nested grids inherit the aurora glow from AnalysisResultCard.
  * SRP/DRY check: Pass - Single responsibility (grid display), reuses PuzzleGrid component
  * shadcn/ui: Pass - Converted to DaisyUI badge and button
  */
@@ -37,7 +39,7 @@ interface AnalysisResultGridProps {
 
 // Skeleton loader component
 const SkeletonGrid = () => (
-  <div className="w-32 h-32 bg-gray-200 rounded animate-pulse" />
+  <div className="h-32 w-32 animate-pulse rounded-xl bg-gradient-to-br from-amber-200/70 via-rose-200/60 to-sky-200/60 shadow-[inset_0_8px_20px_-16px_rgba(146,64,14,0.45)] dark:from-violet-900/60 dark:via-slate-900/50 dark:to-emerald-900/50" />
 );
 
 export const AnalysisResultGrid: React.FC<AnalysisResultGridProps> = ({
@@ -64,16 +66,16 @@ export const AnalysisResultGrid: React.FC<AnalysisResultGridProps> = ({
   if (isOptimistic && (status === 'analyzing' || status === 'saving')) {
     return (
       <div className="space-y-3">
-        <div className="border rounded bg-gray-50 border-gray-200">
-          <div className="p-3">
-            <h5 className="font-semibold text-gray-800 mb-3">AI Prediction</h5>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
+        <div className="rounded-3xl border border-amber-100/70 bg-[radial-gradient(circle_at_top,_rgba(253,230,138,0.8),_rgba(255,237,213,0.7))] px-4 py-4 shadow-[inset_0_18px_38px_-32px_rgba(146,64,14,0.5)] dark:border-violet-900/70 dark:bg-[radial-gradient(circle_at_top,_rgba(30,41,59,0.78),_rgba(76,29,149,0.55))]">
+          <div className="pb-2">
+            <h5 className="mb-3 font-semibold text-amber-900 dark:text-emerald-200">AI Prediction</h5>
+            <div className="grid grid-cols-1 items-start gap-4 md:grid-cols-2">
               <div>
-                <h6 className="font-medium text-center mb-2">Predicted Output</h6>
+                <h6 className="mb-2 text-center font-medium text-amber-800 dark:text-emerald-200">Predicted Output</h6>
                 <SkeletonGrid />
               </div>
               <div>
-                <h6 className="font-medium text-center mb-2">Expected Output</h6>
+                <h6 className="mb-2 text-center font-medium text-amber-800 dark:text-emerald-200">Expected Output</h6>
                 <SkeletonGrid />
               </div>
             </div>
@@ -87,20 +89,20 @@ export const AnalysisResultGrid: React.FC<AnalysisResultGridProps> = ({
     <div className="space-y-2">
       {/* Single prediction display */}
       {predictedGrid && expectedOutputGrids.length === 1 && (
-        <div className="border rounded bg-gray-50 border-gray-200">
-          <button
-            onClick={() => setShowPrediction(!showPrediction)}
-            className="w-full flex items-center justify-between p-2 text-left hover:bg-gray-100 transition-colors"
-          >
-            <h5 className="font-semibold text-sm text-gray-800">AI Prediction</h5>
-            {showPrediction ? (
-              <ChevronUp className="h-4 w-4 text-gray-600" />
-            ) : (
-              <ChevronDown className="h-4 w-4 text-gray-600" />
-            )}
-          </button>
+        <div className="rounded-3xl border border-amber-100/70 bg-[radial-gradient(circle_at_top,_rgba(253,230,138,0.78),_rgba(255,237,213,0.7))] shadow-[inset_0_18px_38px_-32px_rgba(146,64,14,0.45)] dark:border-violet-900/70 dark:bg-[radial-gradient(circle_at_top,_rgba(30,41,59,0.78),_rgba(76,29,149,0.55))]">
+            <button
+              onClick={() => setShowPrediction(!showPrediction)}
+              className="flex w-full items-center justify-between rounded-t-3xl px-4 py-3 text-left transition-colors hover:bg-amber-100/70 dark:hover:bg-violet-900/40"
+            >
+              <h5 className="text-sm font-semibold text-amber-900 dark:text-emerald-200">AI Prediction</h5>
+              {showPrediction ? (
+                <ChevronUp className="h-4 w-4 text-amber-600 dark:text-emerald-300" />
+              ) : (
+                <ChevronDown className="h-4 w-4 text-amber-600 dark:text-emerald-300" />
+              )}
+            </button>
           {showPrediction && (
-            <div className={`p-2 grid grid-cols-1 ${eloMode ? '' : 'md:grid-cols-2'} gap-2 items-start`}>
+            <div className={`grid grid-cols-1 items-start gap-3 px-4 pb-4 pt-3 ${eloMode ? '' : 'md:grid-cols-2'}`}>
               <div>
                 <PuzzleGrid grid={predictedGrid} diffMask={showDiff ? diffMask : undefined} title="Predicted Output" showEmojis={false} />
               </div>
@@ -110,8 +112,8 @@ export const AnalysisResultGrid: React.FC<AnalysisResultGridProps> = ({
                 </div>
               )}
               {!eloMode && (
-                <div className="md:col-span-2 mt-1">
-                  <button className="btn btn-outline btn-sm" onClick={() => setShowDiff(!showDiff)}>
+                <div className="mt-1 md:col-span-2">
+                  <button className="btn btn-sm border-amber-300/70 bg-white/70 text-amber-800 hover:border-rose-300/70 hover:bg-rose-50/70 dark:border-violet-700/70 dark:bg-slate-900/50 dark:text-emerald-200 dark:hover:bg-violet-900/50" onClick={() => setShowDiff(!showDiff)}>
                     {showDiff ? 'Hide' : 'Show'} Mismatches
                   </button>
                 </div>
@@ -123,23 +125,23 @@ export const AnalysisResultGrid: React.FC<AnalysisResultGridProps> = ({
 
       {/* Multi-test answer display */}
       {expectedOutputGrids.length > 1 && (
-        <div className="border rounded bg-gray-50 border-gray-200">
+        <div className="rounded-3xl border border-amber-100/70 bg-[radial-gradient(circle_at_top,_rgba(253,230,138,0.78),_rgba(255,237,213,0.7))] shadow-[inset_0_18px_38px_-32px_rgba(146,64,14,0.45)] dark:border-violet-900/70 dark:bg-[radial-gradient(circle_at_top,_rgba(30,41,59,0.78),_rgba(76,29,149,0.55))]">
           <button
             onClick={() => setShowMultiTest(!showMultiTest)}
-            className="w-full flex items-center justify-between p-2 text-left hover:bg-gray-100 transition-colors"
+            className="flex w-full items-center justify-between rounded-t-3xl px-4 py-3 text-left transition-colors hover:bg-amber-100/70 dark:hover:bg-violet-900/40"
           >
-            <div className="flex items-center gap-2 flex-wrap">
-              <h5 className="font-semibold text-sm text-gray-800">Multi-Test Results ({predictedGrids?.length || 0} predictions, {expectedOutputGrids.length} tests{multiTestStats.totalCount > 0 ? ` • ${multiTestStats.correctCount}/${multiTestStats.totalCount} correct` : ''})</h5>
+            <div className="flex flex-wrap items-center gap-2">
+              <h5 className="text-sm font-semibold text-amber-900 dark:text-emerald-200">Multi-Test Results ({predictedGrids?.length || 0} predictions, {expectedOutputGrids.length} tests{multiTestStats.totalCount > 0 ? ` • ${multiTestStats.correctCount}/${multiTestStats.totalCount} correct` : ''})</h5>
               {!eloMode && (result.multiTestAllCorrect !== undefined || result.allPredictionsCorrect !== undefined || multiTestStats.totalCount > 0) && (
                 <div
                   className={`badge badge-outline flex items-center gap-1 text-xs ${
-                    multiTestStats.accuracyLevel === 'all_correct' || (!multiTestStats.totalCount && (result.multiTestAllCorrect ?? result.allPredictionsCorrect)) 
-                      ? 'bg-green-50 border-green-200 text-green-700' 
-                      : multiTestStats.accuracyLevel === 'all_incorrect' || (!multiTestStats.totalCount && result.multiTestAverageAccuracy === 0) 
-                        ? 'bg-red-50 border-red-200 text-red-700' 
-                        : multiTestStats.accuracyLevel === 'some_incorrect' 
-                          ? 'bg-orange-50 border-orange-200 text-orange-700' 
-                          : 'bg-red-50 border-red-200 text-red-700'
+                      multiTestStats.accuracyLevel === 'all_correct' || (!multiTestStats.totalCount && (result.multiTestAllCorrect ?? result.allPredictionsCorrect))
+                        ? 'bg-emerald-100/80 border-emerald-200/70 text-emerald-800'
+                        : multiTestStats.accuracyLevel === 'all_incorrect' || (!multiTestStats.totalCount && result.multiTestAverageAccuracy === 0)
+                          ? 'bg-rose-100/80 border-rose-200/70 text-rose-800'
+                          : multiTestStats.accuracyLevel === 'some_incorrect'
+                            ? 'bg-amber-100/80 border-amber-200/70 text-amber-800'
+                            : 'bg-rose-100/80 border-rose-200/70 text-rose-800'
                   }`}>
                   {(() => {
                     const isAllCorrect = multiTestStats.accuracyLevel === 'all_correct' || (!multiTestStats.totalCount && (result.multiTestAllCorrect ?? result.allPredictionsCorrect));
@@ -165,19 +167,23 @@ export const AnalysisResultGrid: React.FC<AnalysisResultGridProps> = ({
                 </div>
               )}
             </div>
-            {showMultiTest ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+            {showMultiTest ? (
+              <ChevronUp className="h-4 w-4 text-amber-600 dark:text-emerald-300" />
+            ) : (
+              <ChevronDown className="h-4 w-4 text-amber-600 dark:text-emerald-300" />
+            )}
           </button>
           {showMultiTest && (
-            <div className="p-2 space-y-2">
-              {!eloMode && (
-                <div className="md:col-span-2 mb-1">
-                  <button className="btn btn-outline btn-sm" onClick={() => setShowDiff(!showDiff)}>
-                    {showDiff ? 'Hide' : 'Show'} Mismatches
-                  </button>
-                </div>
-              )}
+            <div className="space-y-2 px-4 pb-4 pt-3">
+                {!eloMode && (
+                  <div className="mb-1 md:col-span-2">
+                    <button className="btn btn-sm border-amber-300/70 bg-white/70 text-amber-800 hover:border-rose-300/70 hover:bg-rose-50/70 dark:border-violet-700/70 dark:bg-slate-900/50 dark:text-emerald-200 dark:hover:bg-violet-900/50" onClick={() => setShowDiff(!showDiff)}>
+                      {showDiff ? 'Hide' : 'Show'} Mismatches
+                    </button>
+                  </div>
+                )}
               {expectedOutputGrids.map((expectedGrid, index) => (
-                <div key={index} className={`grid grid-cols-1 ${eloMode ? '' : 'md:grid-cols-2'} gap-2 items-start border-t pt-2 first:border-t-0 first:pt-0`}>
+                <div key={index} className={`grid grid-cols-1 items-start gap-3 border-t border-amber-100/70 pt-3 first:border-t-0 first:pt-0 dark:border-violet-900/60 ${eloMode ? '' : 'md:grid-cols-2'}`}>
                   <div>
                     {predictedGrids && predictedGrids[index] ? (
                       <PuzzleGrid
@@ -187,7 +193,7 @@ export const AnalysisResultGrid: React.FC<AnalysisResultGridProps> = ({
                         diffMask={showDiff && multiDiffMasks ? multiDiffMasks[index] : undefined}
                       />
                     ) : (
-                      <div className="text-center text-gray-500 italic text-xs">No prediction</div>
+                      <div className="text-center text-xs italic text-amber-700 dark:text-emerald-300">No prediction</div>
                     )}
                   </div>
                   {!eloMode && (

--- a/client/src/components/puzzle/AnalysisResultListCard.tsx
+++ b/client/src/components/puzzle/AnalysisResultListCard.tsx
@@ -7,6 +7,8 @@
  * Shows key information (model, confidence, accuracy, date) with optional "Start Debate" trigger.
  * Uses shared correctness logic to match AccuracyRepository. FIXED: Removed trophy emoji from
  * confidence display for cleaner UI.
+ * UPDATED (2025-10-22T00:00:00Z) by gpt-5-codex: Brought back September's honey-rose gradient shell,
+ * glowing separators, and jewel badges so list cards mirror the revived AnalysisResultCard warmth.
  * SRP/DRY check: Pass - Reuses shared correctness utility, focused on list display concerns only
  * shadcn/ui: Pass - Uses shadcn/ui components throughout
  */
@@ -117,15 +119,15 @@ export const AnalysisResultListCard: React.FC<AnalysisResultListCardProps> = ({
 
   if (compact && !isExpanded) {
     return (
-      <Card className="hover:shadow-sm transition-shadow">
-        <CardContent className="p-4">
+      <Card className="relative overflow-hidden border border-amber-100/70 bg-[radial-gradient(circle_at_top,_rgba(253,230,138,0.9),_rgba(255,228,230,0.85)_45%,_rgba(219,234,254,0.8))] shadow-[0_20px_48px_-32px_rgba(146,64,14,0.55)] transition-all hover:shadow-[0_26px_60px_-34px_rgba(30,64,175,0.55)] supports-[backdrop-filter]:bg-white/75 supports-[backdrop-filter]:backdrop-blur-md dark:border-violet-900/60 dark:bg-[radial-gradient(circle_at_top,_rgba(17,24,39,0.92),_rgba(76,29,149,0.62)_45%,_rgba(15,118,110,0.54))] dark:shadow-[0_20px_52px_-32px_rgba(12,74,110,0.65)] dark:hover:shadow-[0_26px_68px_-36px_rgba(94,234,212,0.55)]">
+        <CardContent className="p-4 sm:p-5">
           <div className="flex items-center justify-between gap-4">
             {/* Left side: Model info and accuracy */}
             <div className="flex items-center gap-3 flex-1 min-w-0">
-              <div className="flex items-center gap-2 flex-wrap">
-                <Badge variant="outline" className="font-mono text-xs">
-                  {result.modelName}
-                </Badge>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="outline" className="font-mono text-xs border-amber-300/70 text-amber-800 dark:border-violet-700/70 dark:text-emerald-200">
+                    {result.modelName}
+                  </Badge>
                 
                 {/* Rebuttal badge - shows if this is challenging another explanation */}
                 {result.rebuttingExplanationId && (
@@ -135,22 +137,22 @@ export const AnalysisResultListCard: React.FC<AnalysisResultListCardProps> = ({
                   </Badge>
                 )}
                 
-                <div className={`flex items-center gap-1 ${accuracyStatus.color}`}>
-                  <accuracyStatus.icon className="h-4 w-4" />
-                  <span className="text-xs font-medium">{accuracyStatus.label}</span>
+                  <div className="flex items-center gap-1 text-amber-900 dark:text-emerald-200">
+                    <accuracyStatus.icon className={`h-4 w-4 ${accuracyStatus.color}`} />
+                    <span className={`text-xs font-medium ${accuracyStatus.color}`}>{accuracyStatus.label}</span>
+                  </div>
                 </div>
-              </div>
 
-              {/* Confidence and basic stats -DONT SHOW CONFIDENCE!!! */}
-              <div className="flex items-center gap-3 text-xs text-gray-500">
+                {/* Confidence and basic stats -DONT SHOW CONFIDENCE!!! */}
+                <div className="flex items-center gap-3 text-xs text-amber-700 dark:text-emerald-300">
                 <span>
                   
                 </span>
-                <span className="flex items-center gap-1">
-                  <Clock className="h-3 w-3" />
-                  {formatDate(result.createdAt)}
-                </span>
-              </div>
+                  <span className="flex items-center gap-1">
+                    <Clock className="h-3 w-3 text-amber-600 dark:text-emerald-300" />
+                    {formatDate(result.createdAt)}
+                  </span>
+                </div>
             </div>
 
             {/* Right side: Actions */}
@@ -164,7 +166,7 @@ export const AnalysisResultListCard: React.FC<AnalysisResultListCardProps> = ({
                     size="sm"
                     variant="outline"
                     onClick={handleDebateClick}
-                    className="text-xs"
+                    className="text-xs border-rose-200/70 text-rose-700 hover:bg-rose-50/60 dark:border-violet-800/70 dark:text-emerald-200 dark:hover:bg-violet-900/40"
                   >
                     <MessageSquare className="h-3 w-3 mr-1" />
                     {debateButtonText}
@@ -173,26 +175,26 @@ export const AnalysisResultListCard: React.FC<AnalysisResultListCardProps> = ({
               )}
 
               {enableExpansion && (
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  onClick={() => setIsExpanded(true)}
-                  className="text-xs"
-                >
-                  <ChevronRight className="h-3 w-3 mr-1" />
-                  Expand
-                </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setIsExpanded(true)}
+                    className="text-xs text-amber-800 hover:bg-rose-50/50 dark:text-emerald-200 dark:hover:bg-violet-900/40"
+                  >
+                    <ChevronRight className="h-3 w-3 mr-1" />
+                    Expand
+                  </Button>
               )}
             </div>
           </div>
 
           {/* Quick preview of pattern description */}
-          {result.patternDescription && (
-            <div className="mt-2 pt-2 border-t border-gray-100">
-              <p className="text-xs text-gray-600 line-clamp-2">
-                <strong>Pattern:</strong> {result.patternDescription}
-              </p>
-            </div>
+            {result.patternDescription && (
+              <div className="mt-3 border-t border-rose-200/70 pt-3 dark:border-violet-900/60">
+                <p className="line-clamp-2 text-xs text-amber-800 dark:text-emerald-200">
+                  <strong>Pattern:</strong> {result.patternDescription}
+                </p>
+              </div>
           )}
         </CardContent>
       </Card>
@@ -200,17 +202,17 @@ export const AnalysisResultListCard: React.FC<AnalysisResultListCardProps> = ({
   }
 
   // Expanded view - show full AnalysisResultCard with collapse option
-  if (!enableExpansion) {
-    return (
-      <Card className="hover:shadow-sm transition-shadow">
-        <CardContent className="p-4">
+    if (!enableExpansion) {
+      return (
+        <Card className="relative overflow-hidden border border-amber-100/70 bg-[radial-gradient(circle_at_top,_rgba(253,230,138,0.9),_rgba(255,228,230,0.85)_45%,_rgba(219,234,254,0.8))] shadow-[0_20px_48px_-32px_rgba(146,64,14,0.55)] transition-all hover:shadow-[0_26px_60px_-34px_rgba(30,64,175,0.55)] supports-[backdrop-filter]:bg-white/75 supports-[backdrop-filter]:backdrop-blur-md dark:border-violet-900/60 dark:bg-[radial-gradient(circle_at_top,_rgba(17,24,39,0.92),_rgba(76,29,149,0.62)_45%,_rgba(15,118,110,0.54))] dark:shadow-[0_20px_52px_-32px_rgba(12,74,110,0.65)] dark:hover:shadow-[0_26px_68px_-36px_rgba(94,234,212,0.55)]">
+          <CardContent className="p-4 sm:p-5">
           <div className="flex items-center justify-between gap-4">
             {/* Left side: Model info and accuracy */}
             <div className="flex items-center gap-3 flex-1 min-w-0">
-              <div className="flex items-center gap-2 flex-wrap">
-                <Badge variant="outline" className="font-mono text-xs">
-                  {result.modelName}
-                </Badge>
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="outline" className="font-mono text-xs border-amber-300/70 text-amber-800 dark:border-violet-700/70 dark:text-emerald-200">
+                    {result.modelName}
+                  </Badge>
 
                 {/* Rebuttal badge - shows if this is challenging another explanation */}
                 {result.rebuttingExplanationId && (
@@ -220,22 +222,22 @@ export const AnalysisResultListCard: React.FC<AnalysisResultListCardProps> = ({
                   </Badge>
                 )}
 
-                <div className={`flex items-center gap-1 ${accuracyStatus.color}`}>
-                  <accuracyStatus.icon className="h-4 w-4" />
-                  <span className="text-xs font-medium">{accuracyStatus.label}</span>
+                  <div className="flex items-center gap-1 text-amber-900 dark:text-emerald-200">
+                    <accuracyStatus.icon className={`h-4 w-4 ${accuracyStatus.color}`} />
+                    <span className={`text-xs font-medium ${accuracyStatus.color}`}>{accuracyStatus.label}</span>
+                  </div>
                 </div>
-              </div>
 
-              {/* Confidence and basic stats -DONT SHOW CONFIDENCE!!! */}
-              <div className="flex items-center gap-3 text-xs text-gray-500">
+                {/* Confidence and basic stats -DONT SHOW CONFIDENCE!!! */}
+                <div className="flex items-center gap-3 text-xs text-amber-700 dark:text-emerald-300">
                 <span>
 
                 </span>
-                <span className="flex items-center gap-1">
-                  <Clock className="h-3 w-3" />
-                  {formatDate(result.createdAt)}
-                </span>
-              </div>
+                  <span className="flex items-center gap-1">
+                    <Clock className="h-3 w-3 text-amber-600 dark:text-emerald-300" />
+                    {formatDate(result.createdAt)}
+                  </span>
+                </div>
             </div>
 
             {/* Right side: Actions */}
@@ -249,7 +251,7 @@ export const AnalysisResultListCard: React.FC<AnalysisResultListCardProps> = ({
                     size="sm"
                     variant="outline"
                     onClick={handleDebateClick}
-                    className="text-xs"
+                    className="text-xs border-rose-200/70 text-rose-700 hover:bg-rose-50/60 dark:border-violet-800/70 dark:text-emerald-200 dark:hover:bg-violet-900/40"
                   >
                     <MessageSquare className="h-3 w-3 mr-1" />
                     {debateButtonText}
@@ -260,26 +262,26 @@ export const AnalysisResultListCard: React.FC<AnalysisResultListCardProps> = ({
           </div>
 
           {/* Quick preview of pattern description */}
-          {result.patternDescription && (
-            <div className="mt-2 pt-2 border-t border-gray-100">
-              <p className="text-xs text-gray-600 line-clamp-2">
-                <strong>Pattern:</strong> {result.patternDescription}
-              </p>
-            </div>
+            {result.patternDescription && (
+              <div className="mt-3 border-t border-rose-200/70 pt-3 dark:border-violet-900/60">
+                <p className="line-clamp-2 text-xs text-amber-800 dark:text-emerald-200">
+                  <strong>Pattern:</strong> {result.patternDescription}
+                </p>
+              </div>
           )}
         </CardContent>
       </Card>
     );
   }
 
-  return (
-    <div className="space-y-2">
-      {/* Compact header with collapse button */}
-      <div className="flex items-center justify-between p-2 bg-gray-50 rounded">
-        <div className="flex items-center gap-2 flex-wrap">
-          <Badge variant="outline" className="font-mono text-xs">
-            {result.modelName}
-          </Badge>
+    return (
+      <div className="space-y-3">
+        {/* Compact header with collapse button */}
+        <div className="flex items-center justify-between gap-3 rounded-2xl border border-amber-100/70 bg-[radial-gradient(circle_at_top,_rgba(253,230,138,0.78),_rgba(255,228,230,0.7))] px-3 py-2 dark:border-violet-900/60 dark:bg-[radial-gradient(circle_at_top,_rgba(30,41,59,0.78),_rgba(76,29,149,0.55))]">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="outline" className="font-mono text-xs border-amber-300/70 text-amber-800 dark:border-violet-700/70 dark:text-emerald-200">
+              {result.modelName}
+            </Badge>
           
           {/* Rebuttal badge - shows if this is challenging another explanation */}
           {result.rebuttingExplanationId && (
@@ -289,40 +291,40 @@ export const AnalysisResultListCard: React.FC<AnalysisResultListCardProps> = ({
             </Badge>
           )}
           
-          <div className={`flex items-center gap-1 ${accuracyStatus.color}`}>
-            <accuracyStatus.icon className="h-4 w-4" />
-            <span className="text-xs font-medium">{accuracyStatus.label}</span>
+            <div className="flex items-center gap-1 text-amber-900 dark:text-emerald-200">
+              <accuracyStatus.icon className={`h-4 w-4 ${accuracyStatus.color}`} />
+              <span className={`text-xs font-medium ${accuracyStatus.color}`}>{accuracyStatus.label}</span>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            {/* Show custom action button if provided, otherwise show debate button */}
+            {actionButton ? (
+              actionButton
+            ) : (
+              showDebateButton && canDebate && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleDebateClick}
+                  className="text-xs border-rose-200/70 text-rose-700 hover:bg-rose-50/60 dark:border-violet-800/70 dark:text-emerald-200 dark:hover:bg-violet-900/40"
+                >
+                  <MessageSquare className="h-3 w-3 mr-1" />
+                  {debateButtonText}
+                </Button>
+              )
+            )}
+
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => setIsExpanded(false)}
+              className="text-xs text-amber-800 hover:bg-rose-50/50 dark:text-emerald-200 dark:hover:bg-violet-900/40"
+            >
+              Collapse
+            </Button>
           </div>
         </div>
-
-        <div className="flex items-center gap-2">
-          {/* Show custom action button if provided, otherwise show debate button */}
-          {actionButton ? (
-            actionButton
-          ) : (
-            showDebateButton && canDebate && (
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={handleDebateClick}
-                className="text-xs"
-              >
-                <MessageSquare className="h-3 w-3 mr-1" />
-                {debateButtonText}
-              </Button>
-            )
-          )}
-
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={() => setIsExpanded(false)}
-            className="text-xs"
-          >
-            Collapse
-          </Button>
-        </div>
-      </div>
 
       {/* Full AnalysisResultCard with proper grid components */}
       <AnalysisResultCard


### PR DESCRIPTION
## Summary
- revive the aurora gradient shell, warm raw DB drawer, and rosy dividers on the primary AnalysisResultCard to eliminate the stark white regression
- bathe AnalysisResultGrid surfaces, skeletons, diff controls, and accuracy badges in the September honeyglass palette for consistent warmth
- harmonize the compact AnalysisResultListCard and its headers with the same gradient, badge, and button treatments to match the refreshed card aesthetic
- document the UI refresh in the changelog as v4.8.39 (2025-10-22)

## Testing
- not run (visual change only)


------
https://chatgpt.com/codex/tasks/task_e_68f96e238b3c8326bd44f66f0e0103f3