### PR TITLE
Restore full-size prompt picker on PuzzleExaminer

### DIFF
--- a/client/src/pages/PuzzleExaminer.tsx
+++ b/client/src/pages/PuzzleExaminer.tsx
@@ -14,7 +14,7 @@
 
 import React, { useState, useMemo } from 'react';
 import { useParams } from 'wouter';
-import { Loader2 } from 'lucide-react';
+import { Loader2, Brain, Settings } from 'lucide-react';
 import { getPuzzleName } from '@shared/utils/puzzleNames';
 import { DEFAULT_EMOJI_SET } from '@/lib/spaceEmojis';
 import type { EmojiSet } from '@/lib/spaceEmojis';
@@ -29,12 +29,14 @@ import { useAnalysisResults } from '@/hooks/useAnalysisResults';
 
 // UI Components (SRP-compliant)
 import { PuzzleHeader } from '@/components/puzzle/PuzzleHeader';
-import { CompactControls } from '@/components/puzzle/CompactControls';
 import { ModelSelection } from '@/components/puzzle/ModelSelection';
 import { AnalysisResults } from '@/components/puzzle/AnalysisResults';
 import { StreamingAnalysisPanel } from '@/components/puzzle/StreamingAnalysisPanel';
 import { PromptPreviewModal } from '@/components/PromptPreviewModal';
 import { PuzzleGridDisplay } from '@/components/puzzle/PuzzleGridDisplay';
+import { CollapsibleCard } from '@/components/ui/collapsible-card';
+import { PromptConfiguration } from '@/components/puzzle/PromptConfiguration';
+import { AdvancedControls } from '@/components/puzzle/AdvancedControls';
 
 // Types
 import type { CorrectnessFilter } from '@/hooks/useFilteredResults';
@@ -288,37 +290,62 @@ export default function PuzzleExaminer() {
           />
         </div>
 
-        {/* Compact Controls - Prompt & Advanced Parameters */}
-        <div className="mb-2">
-          <CompactControls
-        promptId={promptId}
-        onPromptChange={setPromptId}
-        customPrompt={customPrompt}
-        onCustomPromptChange={setCustomPrompt}
-        disabled={isAnalyzing}
-        sendAsEmojis={sendAsEmojis}
-        onSendAsEmojisChange={setSendAsEmojis}
-        omitAnswer={omitAnswer}
-        onOmitAnswerChange={setOmitAnswer}
-        onPreviewClick={() => {
-          setPendingAnalysis(null);
-          setIsPromptPreviewOpen(true);
-        }}
-        temperature={temperature}
-        onTemperatureChange={setTemperature}
-        topP={topP}
-        onTopPChange={setTopP}
-        candidateCount={candidateCount}
-        onCandidateCountChange={setCandidateCount}
-        thinkingBudget={thinkingBudget}
-        onThinkingBudgetChange={setThinkingBudget}
-        reasoningEffort={reasoningEffort}
-        onReasoningEffortChange={setReasoningEffort}
-        reasoningVerbosity={reasoningVerbosity}
-        onReasoningVerbosityChange={setReasoningVerbosity}
-        reasoningSummaryType={reasoningSummaryType}
-        onReasoningSummaryTypeChange={setReasoningSummaryType}
-          />
+        {/* Prompt Configuration */}
+        <div className="mb-4">
+          <CollapsibleCard
+            title="Prompt Style"
+            icon={Brain}
+            defaultOpen
+            headerDescription={
+              <p className="text-sm opacity-70">
+                Choose how the AI should analyze the puzzle and preview the full instructions before sending.
+              </p>
+            }
+          >
+            <PromptConfiguration
+              promptId={promptId}
+              onPromptChange={setPromptId}
+              customPrompt={customPrompt}
+              onCustomPromptChange={setCustomPrompt}
+              disabled={isAnalyzing}
+              sendAsEmojis={sendAsEmojis}
+              onSendAsEmojisChange={setSendAsEmojis}
+              omitAnswer={omitAnswer}
+              onOmitAnswerChange={setOmitAnswer}
+              onPreviewClick={() => {
+                setPendingAnalysis(null);
+                setIsPromptPreviewOpen(true);
+              }}
+            />
+          </CollapsibleCard>
+        </div>
+
+        {/* Advanced Controls */}
+        <div className="mb-4">
+          <CollapsibleCard
+            title="Advanced Controls"
+            icon={Settings}
+            headerDescription={
+              <p className="text-sm opacity-70">Fine-tune model behavior with detailed parameter controls.</p>
+            }
+          >
+            <AdvancedControls
+              temperature={temperature}
+              onTemperatureChange={setTemperature}
+              topP={topP}
+              onTopPChange={setTopP}
+              candidateCount={candidateCount}
+              onCandidateCountChange={setCandidateCount}
+              thinkingBudget={thinkingBudget}
+              onThinkingBudgetChange={setThinkingBudget}
+              reasoningEffort={reasoningEffort}
+              onReasoningEffortChange={setReasoningEffort}
+              reasoningVerbosity={reasoningVerbosity}
+              onReasoningVerbosityChange={setReasoningVerbosity}
+              reasoningSummaryType={reasoningSummaryType}
+              onReasoningSummaryTypeChange={setReasoningSummaryType}
+            />
+          </CollapsibleCard>
         </div>
 
         {/* Model Selection - Card Grid */}

--- a/docs/2025-10-28-puzzleexaminer-prompt-options-plan.md
+++ b/docs/2025-10-28-puzzleexaminer-prompt-options-plan.md
@@ -1,0 +1,26 @@
+# PuzzleExaminer Prompt Options Restoration Plan (2025-10-28)
+
+## Goal
+Restore the full-size prompt configuration experience on PuzzleExaminer to match the prior August 2022 style, replacing the compact dropdown UI that shipped with the recent refactor. Capture historical visuals to document the regression.
+
+## Context & References
+- Current implementation: `client/src/pages/PuzzleExaminer.tsx` (uses `CompactControls` component)
+- Legacy layout components: `PromptConfiguration`, `AdvancedControls`, `CollapsibleCard`
+- Prompt picker UI: `client/src/components/PromptPicker.tsx`
+
+## Tasks
+1. Inspect historical commit (pre-`CompactControls` refactor) to confirm expected layout and identify necessary JSX structure.
+2. Update `PuzzleExaminer.tsx` to swap the `CompactControls` block with `CollapsibleCard` sections that render `PromptConfiguration` and `AdvancedControls`, ensuring preview + confirm workflow still functions.
+3. Verify DaisyUI classes allow prompt options to render full width on desktop and responsive on mobile; adjust spacing if needed.
+4. Retain streaming modal + prompt preview logic introduced in recent commits.
+5. Capture screenshots:
+   - Legacy (Aug 2022) layout reference via historical commit checkout/render.
+   - Updated current page after restoration to confirm parity.
+6. Run lint/build sanity check if available.
+
+## Validation Checklist
+- [ ] Prompt options render as full-width radio list instead of compact select.
+- [ ] Advanced controls remain accessible via collapsible card.
+- [ ] Prompt preview workflow still triggers modal and confirm action.
+- [ ] Streaming modal unaffected by layout changes.
+- [ ] Screenshots stored for both legacy and updated UIs.


### PR DESCRIPTION
## Summary
- restore the PuzzleExaminer prompt configuration to the legacy CollapsibleCard layout so prompt options display full width again
- keep advanced controls in their dedicated card with DaisyUI styling and icons for clarity
- add a restoration plan document outlining tasks, validation checkpoints, and screenshot requirements

## Testing
- npm run check *(fails: HighRiskModelsList lucide icon title props missing)*

------
https://chatgpt.com/codex/tasks/task_e_6900f93aa02c83268ce1e299c3129ac8