### PR TITLE
feat: add versioned caching and auto-refresh for model comparison page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG - Uses semantic versioning (MAJOR.MINOR.PATCH)
 
+# [4.12.6] - 2025-11-02
+### 🔄 Model Comparison Auto-Refresh
+
+- Added versioned caching and automatic refresh for the Model Comparison page so cached snapshots are invalidated and a new `/api/metrics/compare` request runs after deployment.
+- Cleared persisted comparison data on errors to prevent stale/mismatched metrics from reloading.
+
+#### Verification
+- ⚠️ Not run (frontend behaviour change)
+
 # [4.12.5] - 2025-11-02
 ### 🧮 Model Comparison Latest-Attempt Alignment
 


### PR DESCRIPTION
- Added cache versioning system with COMPARISON_CACHE_VERSION to invalidate stale data after deployments
- Implemented auto-refresh mechanism to fetch fresh metrics when cached data is loaded
- Added error handling to clear cached data when API requests fail
- Updated cache storage to use versioned envelope format for both localStorage and history state
- Modified comparison data persistence to maintain version consistency across