### PR TITLE
Add ARC3 agent playground driven by OpenAI Agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG - Uses semantic versioning (MAJOR.MINOR.PATCH)
 
+# [5.1.0] - 2025-11-06
+### 🎮 ARC3 Agent Playground
+- Added `/arc3/playground` React page with configurable agent instructions, model selection, and live simulator playback driven by the OpenAI Agents SDK.
+- Introduced `useArc3AgentRun` hook plus typed payload/response models to integrate the playground with React Query.
+- Updated navigation and the ARC3 landing page with quick links to the playground.
+
+### 🧠 Backend Agent Runner & Simulator
+- Created deterministic ARC3 "Color Hunt" simulator with scanner actions, coordinate probes, history snapshots, and scoring.
+- Implemented `Arc3AgentRunner` service that wires the simulator to the OpenAI Agents SDK, capturing timeline, usage, and frames for the client.
+- Added `/api/arc3/agent-playground/run` route with Zod validation returning formatted responses for the UI.
+
+### 🧹 Type Safety
+- Adjusted Saturn work table phase tracking to satisfy strict TypeScript inference after the new build run.
+
 # [5.0.4] - 2025-11-05
 ### 🧵 Streaming Experience
 - Keep the streaming analysis modal open after completion so reviewers can read results and dismiss manually.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ARC-AGI Explainer Platform
 
-**Version 4.8.41** — October 25, 2025
+**Version 5.1.0** — November 6, 2025
 
 
 A research platform for analyzing Abstract Reasoning Corpus (ARC-AGI) puzzles using state-of-the-art AI models with deep reasoning capture, conversation chaining, and comprehensive performance analytics.
@@ -9,20 +9,19 @@ A research platform for analyzing Abstract Reasoning Corpus (ARC-AGI) puzzles us
 
 ---
 
-## What's New in v4.8.41
+## What's New in v5.1.0
 
-### 🎨 Research surfaces refreshed
-- Split training example cards eliminate scrollbars and ensure consistent sizing across galleries and zoom modals.
-- Analysis results regain the aurora gradient, honeyglass backgrounds, and warm accent palette for a consistent look across layouts.
-- Leaderboards dashboard is now denser, with compact typography and inline metadata that keeps key metrics above the fold.
+### 🎮 ARC3 Agent Playground (Beta)
+- `/arc3/playground` introduces an interactive lab powered by the new OpenAI Agents SDK. Configure instructions, pick a model, and watch the agent drive the local "Color Hunt" ARC-AGI-3 simulator step-by-step.
+- Real-time simulator playback with color-coded 8×8 grids, action history, and token usage telemetry makes debugging agent behavior straightforward.
+- Global navigation and the ARC3 landing page now link directly to the playground for quick access.
 
-### ⚙️ Solver and streaming stability
-- Saturn Visual Solver no longer triggers React re-render loops thanks to a corrected effect dependency list.
-- Grover solver requests sanitize internal options before hitting the OpenAI Responses API, preventing 400 errors from unsupported fields.
-- Grid sizing utilities adapt to extreme aspect ratios so vertical and horizontal puzzles render without scrollbars.
+### 🧠 Backend Agent Runner
+- Deterministic "Color Hunt" mini-game simulator emulates ARC-AGI-3 interactions (reset, scanner actions, ACTION6 coordinate probes) without requiring a remote ARC API key.
+- Express route `/api/arc3/agent-playground/run` validates payloads with Zod, orchestrates the OpenAI agent, and returns timeline, frame snapshots, and token usage for the UI.
 
-### 📚 Traceability
-- Recent rollbacks and UI changes are documented in accompanying plans under `docs/2025-10-1x-*` for quick historical context.
+### 🧹 Type Safety Improvements
+- Hardened Saturn work table state transitions to satisfy strict TypeScript checks after the new build pass.
 
 For additional release notes, see [Changelog](./CHANGELOG.md).
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -27,6 +27,7 @@ import ModelDebate from "@/pages/ModelDebate";
 import ModelComparisonPage from "@/pages/ModelComparisonPage";
 import About from "@/pages/About";
 import ARC3Browser from "@/pages/ARC3Browser";
+import ARC3AgentPlayground from "@/pages/ARC3AgentPlayground";
 
 function Router() {
   return (
@@ -64,6 +65,7 @@ function Router() {
         <Route path="/model-comparison" component={ModelComparisonPage} />
         <Route path="/about" component={About} />
         <Route path="/arc3" component={ARC3Browser} />
+        <Route path="/arc3/playground" component={ARC3AgentPlayground} />
         <Route path="/puzzle/:taskId" component={PuzzleExaminer} />
         <Route path="/examine/:taskId" component={PuzzleExaminer} />
         <Route component={NotFound} />

--- a/client/src/components/layout/AppNavigation.tsx
+++ b/client/src/components/layout/AppNavigation.tsx
@@ -21,7 +21,8 @@ import {
   MessageSquare,
   Info,
   Award,
-  Gamepad2
+  Gamepad2,
+  FlaskConical
 } from 'lucide-react';
 
 interface NavItem {
@@ -97,6 +98,12 @@ const navigationItems: NavItem[] = [
     href: '/arc3',
     icon: Gamepad2,
     description: 'Interactive reasoning benchmark for AI agents (game-based, not puzzles)'
+  },
+  {
+    title: 'ARC3 Playground',
+    href: '/arc3/playground',
+    icon: FlaskConical,
+    description: 'Launch the Color Hunt simulator powered by the OpenAI Agents SDK'
   }
 ];
 

--- a/client/src/components/saturn/SaturnWorkTable.tsx
+++ b/client/src/components/saturn/SaturnWorkTable.tsx
@@ -27,32 +27,36 @@ export default function SaturnWorkTable({ state, isRunning, compact }: Props) {
 
   // Update phase history when phase changes
   React.useEffect(() => {
-    if (state.phase) {
-      setPhaseHistory(prev => {
-        // Check if this phase already exists
-        const existingIndex = prev.findIndex(p => p.phase === state.phase);
-
-        if (existingIndex >= 0) {
-          // Update existing phase
-          const updated = [...prev];
-          updated[existingIndex] = {
-            phase: state.phase,
-            message: state.streamingMessage || state.message,
-            status: isRunning ? 'in_progress' : state.status || 'completed',
-            timestamp: new Date().toLocaleTimeString()
-          };
-          return updated;
-        } else {
-          // Add new phase
-          return [...prev, {
-            phase: state.phase,
-            message: state.streamingMessage || state.message,
-            status: isRunning ? 'in_progress' : 'completed',
-            timestamp: new Date().toLocaleTimeString()
-          }];
-        }
-      });
+    const nextPhase = state.phase;
+    if (!nextPhase) {
+      return;
     }
+
+    setPhaseHistory(prev => {
+      const existingIndex = prev.findIndex(p => p.phase === nextPhase);
+      const baseEntry = {
+        phase: nextPhase,
+        message: state.streamingMessage || state.message,
+        timestamp: new Date().toLocaleTimeString()
+      } as const;
+
+      if (existingIndex >= 0) {
+        const updated = [...prev];
+        updated[existingIndex] = {
+          ...baseEntry,
+          status: isRunning ? 'in_progress' : state.status || 'completed'
+        };
+        return updated;
+      }
+
+      return [
+        ...prev,
+        {
+          ...baseEntry,
+          status: isRunning ? 'in_progress' : 'completed'
+        }
+      ];
+    });
   }, [state.phase, state.message, state.streamingMessage, state.status, isRunning]);
 
   // Reset history when returning to idle

--- a/client/src/hooks/useArc3AgentRun.ts
+++ b/client/src/hooks/useArc3AgentRun.ts
@@ -1,0 +1,37 @@
+/*
+Author: gpt-5-codex
+Date: 2025-11-06
+PURPOSE: React Query mutation for triggering ARC3 playground agent runs from the UI.
+SRP/DRY check: Pass — encapsulates fetch logic and error handling for reuse across components.
+*/
+
+import { useMutation } from '@tanstack/react-query';
+import type { Arc3AgentRunPayload, Arc3AgentRunData, Arc3AgentRunResponse } from '@/types/arc3';
+
+async function runArc3Agent(payload: Arc3AgentRunPayload): Promise<Arc3AgentRunData> {
+  const response = await fetch('/api/arc3/agent-playground/run', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(`ARC3 agent run failed with status ${response.status}`);
+  }
+
+  const result: Arc3AgentRunResponse = await response.json();
+  if (!result.success) {
+    throw new Error('ARC3 agent run failed');
+  }
+
+  return result.data;
+}
+
+export function useArc3AgentRun() {
+  return useMutation({
+    mutationKey: ['arc3-agent-run'],
+    mutationFn: runArc3Agent,
+  });
+}

--- a/client/src/pages/ARC3AgentPlayground.tsx
+++ b/client/src/pages/ARC3AgentPlayground.tsx
@@ -1,0 +1,391 @@
+/*
+Author: gpt-5-codex
+Date: 2025-11-06
+PURPOSE: ARC-AGI-3 playground page letting users configure an OpenAI agent and run it against the local Color Hunt simulator.
+SRP/DRY check: Pass — UI logic focused on configuring runs, showing summaries, and visualizing simulator frames.
+*/
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Badge } from '@/components/ui/badge';
+import { Label } from '@/components/ui/label';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Separator } from '@/components/ui/separator';
+import { Loader2, Cpu, Target, ActivitySquare, Flag, Map, Binary, Layers, List } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { useArc3AgentRun } from '@/hooks/useArc3AgentRun';
+import type { Arc3AgentRunData, Arc3FrameSnapshot, Arc3GameState, Arc3RunTimelineEntry } from '@/types/arc3';
+
+const DEFAULT_INSTRUCTIONS = `Gather a snapshot with inspect_board, then apply scanners conservatively until the energized node's row, column, and local neighborhood are clear. Avoid repeated scanners. Confirm coordinates before firing ACTION6 and provide a concise post-run summary with the final score.`;
+
+const DEFAULT_MODEL = 'o4-mini';
+const COLOR_CLASSES: Record<number, string> = {
+  0: 'bg-slate-900',
+  1: 'bg-slate-700',
+  2: 'bg-sky-600',
+  3: 'bg-orange-500',
+  4: 'bg-amber-400',
+  5: 'bg-amber-500',
+  6: 'bg-teal-500',
+  7: 'bg-purple-500',
+  8: 'bg-emerald-400',
+  9: 'bg-rose-500',
+};
+
+const STATE_BADGE_VARIANT: Record<Arc3GameState, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  NOT_STARTED: 'outline',
+  IN_PROGRESS: 'secondary',
+  WIN: 'default',
+  GAME_OVER: 'destructive',
+};
+
+function formatTimelineLabel(entry: Arc3RunTimelineEntry) {
+  switch (entry.type) {
+    case 'assistant_message':
+      return 'Agent Message';
+    case 'tool_call':
+      return 'Tool Call';
+    case 'tool_result':
+      return 'Tool Result';
+    case 'reasoning':
+      return 'Reasoning';
+    default:
+      return 'Event';
+  }
+}
+
+function BoardView({ frame }: { frame: Arc3FrameSnapshot }) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Layers className="h-4 w-4" />
+          <span>Step {frame.step}</span>
+        </div>
+        <div className="flex items-center gap-2 text-sm">
+          <Badge variant="secondary">Score {frame.score}</Badge>
+          <Badge variant="outline">Remaining {frame.remainingSteps}</Badge>
+        </div>
+      </div>
+      <div className="grid grid-cols-8 gap-[2px] rounded-md border border-border bg-muted/60 p-2">
+        {frame.board.flat().map((value, index) => (
+          <div
+            key={`${frame.step}-${index}`}
+            className={cn(
+              'flex aspect-square items-center justify-center rounded-sm text-[10px] font-semibold text-white/90',
+              COLOR_CLASSES[value] ?? 'bg-neutral-500',
+            )}
+          >
+            {value}
+          </div>
+        ))}
+      </div>
+      <p className="text-sm text-muted-foreground">{frame.narrative}</p>
+    </div>
+  );
+}
+
+interface PlaygroundFormState {
+  agentName: string;
+  instructions: string;
+  model: string;
+  maxTurns: number;
+}
+
+export default function ARC3AgentPlayground() {
+  const [formState, setFormState] = useState<PlaygroundFormState>({
+    agentName: 'Color Hunt Scout',
+    instructions: DEFAULT_INSTRUCTIONS,
+    model: DEFAULT_MODEL,
+    maxTurns: 12,
+  });
+  const [selectedFrameIndex, setSelectedFrameIndex] = useState(0);
+
+  const mutation = useArc3AgentRun();
+  const runResult = mutation.data;
+
+  useEffect(() => {
+    if (runResult && runResult.frames.length > 0) {
+      setSelectedFrameIndex(runResult.frames.length - 1);
+    }
+  }, [runResult]);
+
+  const selectedFrame = useMemo(() => {
+    if (!runResult || runResult.frames.length === 0) {
+      return undefined;
+    }
+    return runResult.frames[Math.min(selectedFrameIndex, runResult.frames.length - 1)];
+  }, [runResult, selectedFrameIndex]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!formState.instructions.trim()) {
+      return;
+    }
+    mutation.mutate({
+      agentName: formState.agentName.trim() || undefined,
+      instructions: formState.instructions,
+      model: formState.model.trim() || undefined,
+      maxTurns: formState.maxTurns,
+    });
+  };
+
+  const isRunning = mutation.isPending;
+  const errorMessage = mutation.error instanceof Error ? mutation.error.message : undefined;
+
+  return (
+    <div className="container mx-auto max-w-6xl px-4 py-10 space-y-8">
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center justify-between flex-wrap gap-4">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight flex items-center gap-2">
+              <Cpu className="h-7 w-7 text-primary" /> ARC-AGI-3 Agent Playground
+            </h1>
+            <p className="text-muted-foreground mt-2 max-w-2xl">
+              Configure a lightweight OpenAI agent with the new Agents SDK, run it against the local "Color Hunt" simulator, and
+              inspect every decision the agent makes. Coordinates are zero-indexed — call <code>inspect_board</code> before
+              firing probes.
+            </p>
+          </div>
+          <Badge variant="secondary" className="flex items-center gap-2 text-sm py-2 px-3">
+            <Binary className="h-4 w-4" /> Powered by @openai/agents
+          </Badge>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[380px_1fr]">
+        <Card className="h-full">
+          <CardHeader>
+            <CardTitle>Agent configuration</CardTitle>
+            <CardDescription>Provide guidance, choose a model, and launch a run. OpenAI API key must be configured server-side.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-4" onSubmit={handleSubmit}>
+              <div className="space-y-2">
+                <Label htmlFor="agentName">Agent name</Label>
+                <Input
+                  id="agentName"
+                  value={formState.agentName}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, agentName: event.target.value }))}
+                  placeholder="Color Hunt Scout"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="instructions">Custom instructions</Label>
+                <Textarea
+                  id="instructions"
+                  className="min-h-[160px]"
+                  value={formState.instructions}
+                  onChange={(event) => setFormState((prev) => ({ ...prev, instructions: event.target.value }))}
+                />
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="model">Model</Label>
+                  <Input
+                    id="model"
+                    value={formState.model}
+                    onChange={(event) => setFormState((prev) => ({ ...prev, model: event.target.value }))}
+                    placeholder="o4-mini"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="maxTurns">Max turns</Label>
+                  <Input
+                    id="maxTurns"
+                    type="number"
+                    min={2}
+                    max={24}
+                    value={formState.maxTurns}
+                    onChange={(event) =>
+                      setFormState((prev) => ({ ...prev, maxTurns: Number(event.target.value) || prev.maxTurns }))
+                    }
+                  />
+                </div>
+              </div>
+
+              {errorMessage ? (
+                <p className="text-sm text-destructive">{errorMessage}</p>
+              ) : null}
+
+              <Button type="submit" className="w-full" disabled={isRunning}>
+                {isRunning ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Running
+                  </>
+                ) : (
+                  'Run agent'
+                )}
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+
+        <div className="space-y-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Run summary</CardTitle>
+              <CardDescription>Outcome, score, and usage details from the latest run.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {runResult ? (
+                <RunSummary result={runResult} />
+              ) : (
+                <div className="text-sm text-muted-foreground flex items-center gap-2">
+                  <Target className="h-4 w-4" /> Launch a run to populate the summary.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Simulation playback</CardTitle>
+              <CardDescription>Review each simulator snapshot, including scanner effects and coordinate probes.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {runResult && runResult.frames.length > 0 && selectedFrame ? (
+                <div className="space-y-4">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="flex items-center gap-2">
+                      <Select
+                        value={String(selectedFrameIndex)}
+                        onValueChange={(value) => setSelectedFrameIndex(Number(value))}
+                      >
+                        <SelectTrigger className="w-[220px]">
+                          <SelectValue placeholder="Select step" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {runResult.frames.map((frame) => (
+                            <SelectItem key={frame.step} value={String(frame.step)}>
+                              Step {frame.step} — {frame.actionLabel}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <Badge variant={STATE_BADGE_VARIANT[selectedFrame.state]}>State: {selectedFrame.state}</Badge>
+                  </div>
+                  <BoardView frame={selectedFrame} />
+                </div>
+              ) : (
+                <div className="text-sm text-muted-foreground flex items-center gap-2">
+                  <Map className="h-4 w-4" /> Run the agent to view frame-by-frame playback.
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Reasoning & tool log</CardTitle>
+              <CardDescription>Complete transcript of model messages, tool calls, and simulator outputs.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {runResult ? (
+                <Tabs defaultValue="timeline">
+                  <TabsList>
+                    <TabsTrigger value="timeline">Timeline</TabsTrigger>
+                    <TabsTrigger value="final">Final summary</TabsTrigger>
+                  </TabsList>
+                  <TabsContent value="timeline" className="mt-4">
+                    <ScrollArea className="h-[280px] pr-3">
+                      <div className="space-y-3">
+                        {runResult.timeline.map((entry) => (
+                          <div key={entry.index} className="rounded-lg border border-border bg-muted/40 p-3">
+                            <div className="flex items-center justify-between gap-2">
+                              <Badge variant="outline">{formatTimelineLabel(entry)}</Badge>
+                              <span className="text-xs text-muted-foreground">#{entry.index}</span>
+                            </div>
+                            <Separator className="my-2" />
+                            <pre className="whitespace-pre-wrap text-xs text-foreground/90">
+                              {entry.content || '∅'}
+                            </pre>
+                            <p className="mt-2 text-xs text-muted-foreground">{entry.label}</p>
+                          </div>
+                        ))}
+                      </div>
+                    </ScrollArea>
+                  </TabsContent>
+                  <TabsContent value="final" className="mt-4">
+                    {runResult.finalOutput ? (
+                      <div className="rounded-lg border border-border bg-muted/40 p-4 text-sm whitespace-pre-wrap">
+                        {runResult.finalOutput}
+                      </div>
+                    ) : (
+                      <p className="text-sm text-muted-foreground flex items-center gap-2">
+                        <List className="h-4 w-4" /> No final message returned.
+                      </p>
+                    )}
+                  </TabsContent>
+                </Tabs>
+              ) : (
+                <p className="text-sm text-muted-foreground flex items-center gap-2">
+                  <ActivitySquare className="h-4 w-4" /> Run the agent to populate the log.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function RunSummary({ result }: { result: Arc3AgentRunData }) {
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <Badge variant={STATE_BADGE_VARIANT[result.summary.state]}>State: {result.summary.state}</Badge>
+        <Badge variant="secondary">Score {result.summary.score}</Badge>
+        <Badge variant="outline">Steps {result.summary.stepsTaken}</Badge>
+        <Badge variant="outline">Coordinate guesses {result.summary.coordinateGuesses}</Badge>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="space-y-2 text-sm">
+          <div className="font-semibold flex items-center gap-2">
+            <Flag className="h-4 w-4" /> Scenario
+          </div>
+          <p className="text-muted-foreground">
+            {result.summary.scenarioName} <span className="text-xs">({result.summary.scenarioId})</span>
+          </p>
+          <div className="font-semibold flex items-center gap-2 mt-3">
+            <Target className="h-4 w-4" /> Simple actions used
+          </div>
+          <p className="text-muted-foreground">
+            {result.summary.simpleActionsUsed.length > 0
+              ? result.summary.simpleActionsUsed.join(', ')
+              : 'None'}
+          </p>
+        </div>
+        <div className="space-y-2 text-sm">
+          <div className="font-semibold flex items-center gap-2">
+            <Binary className="h-4 w-4" /> Usage
+          </div>
+          <div className="grid grid-cols-2 gap-2 text-muted-foreground">
+            <span>Requests</span>
+            <span className="text-right">{result.usage.requests}</span>
+            <span>Input tokens</span>
+            <span className="text-right">{result.usage.inputTokens}</span>
+            <span>Output tokens</span>
+            <span className="text-right">{result.usage.outputTokens}</span>
+            <span>Total tokens</span>
+            <span className="text-right">{result.usage.totalTokens}</span>
+          </div>
+        </div>
+      </div>
+      {result.finalOutput ? (
+        <div className="rounded-md border border-border bg-muted/50 p-4 text-sm whitespace-pre-wrap">
+          {result.finalOutput}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/client/src/pages/ARC3Browser.tsx
+++ b/client/src/pages/ARC3Browser.tsx
@@ -45,6 +45,11 @@ export default function ARC3Browser() {
           A groundbreaking benchmark that tests AI systems through game-based environments,
           evaluating exploration, memory, planning, and goal acquisition—not static puzzle solving.
         </p>
+        <div className="mt-6 flex justify-center">
+          <Button asChild>
+            <Link href="/arc3/playground">Launch ARC3 Playground</Link>
+          </Button>
+        </div>
       </div>
 
       {/* Key Difference Alert */}

--- a/client/src/types/arc3.ts
+++ b/client/src/types/arc3.ts
@@ -1,0 +1,62 @@
+/*
+Author: gpt-5-codex
+Date: 2025-11-06
+PURPOSE: Shared frontend TypeScript types mirroring the ARC3 playground API payloads.
+SRP/DRY check: Pass — isolates API contracts from UI components for reuse.
+*/
+
+export type Arc3GameState = 'NOT_STARTED' | 'IN_PROGRESS' | 'WIN' | 'GAME_OVER';
+
+export interface Arc3FrameSnapshot {
+  step: number;
+  state: Arc3GameState;
+  score: number;
+  board: number[][];
+  actionLabel: string;
+  narrative: string;
+  remainingSteps: number;
+}
+
+export interface Arc3RunSummary {
+  state: Arc3GameState;
+  score: number;
+  stepsTaken: number;
+  simpleActionsUsed: string[];
+  coordinateGuesses: number;
+  scenarioId: string;
+  scenarioName: string;
+}
+
+export interface Arc3RunTimelineEntry {
+  index: number;
+  type: 'assistant_message' | 'tool_call' | 'tool_result' | 'reasoning';
+  label: string;
+  content: string;
+}
+
+export interface Arc3AgentRunData {
+  runId: string;
+  finalOutput?: string;
+  timeline: Arc3RunTimelineEntry[];
+  frames: Arc3FrameSnapshot[];
+  summary: Arc3RunSummary;
+  usage: {
+    requests: number;
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+  };
+}
+
+export interface Arc3AgentRunResponse {
+  success: boolean;
+  data: Arc3AgentRunData;
+}
+
+export interface Arc3AgentRunPayload {
+  agentName?: string;
+  instructions: string;
+  model?: string;
+  maxTurns?: number;
+  scenarioId?: string;
+}

--- a/docs/2025-11-06-arc3-agent-ui-plan.md
+++ b/docs/2025-11-06-arc3-agent-ui-plan.md
@@ -1,0 +1,34 @@
+# ARC3 Agent Playground Integration Plan (2025-11-06)
+
+## Objective
+Build an interactive ARC-AGI-3 agent testing playground inside ARC Explainer that leverages the OpenAI Agents SDK to let users configure and run a basic agent against a sample ARC3 game experience from the browser.
+
+## Key Tasks & Target Files
+
+1. **Establish backend agent runner with OpenAI Agents SDK**
+   - Files: `server/routes/arc3.ts` (new), `server/index.ts`, `server/routes.ts`, `server/services/arc3/Arc3AgentRunner.ts` (new), `server/services/arc3/Arc3GameSimulator.ts` (new), `server/services/arc3/types.ts` (new), `server/config/index.ts` (if env wiring needed)
+   - Todos:
+     - Model a lightweight ARC3 game simulator (deterministic mini-scenario) that exposes reset, simple actions, coordinate action.
+     - Wrap simulator in service that can be driven by tool calls from the OpenAI Agents SDK.
+     - Implement runner function that instantiates an agent with user instructions and streams step logs.
+     - Add REST endpoint to trigger a run and return aggregated output (logs, frames, score summary).
+
+2. **Expose configuration and results to the frontend**
+   - Files: `client/src/pages/ARC3AgentPlayground.tsx` (new), `client/src/App.tsx`, `client/src/components/layout/AppNavigation.tsx`, `client/src/types/arc3.ts` (new), `client/src/lib/api.ts` (if needed), `client/src/hooks/useArc3AgentRun.ts` (new hook)
+   - Todos:
+     - Create React page with form inputs (agent name, instructions, game selection, step limit) and run controls.
+     - Display simulator board snapshots, action history, and textual reasoning returned by backend.
+     - Wire up API client + React Query mutation for running agents and handling loading/error states.
+     - Update router/navigation to surface the new page under ARC3 section.
+
+3. **Documentation & project hygiene**
+   - Files: `CHANGELOG.md`, `docs/README.md` (section link), `README.md` (if top-level mention needed)
+   - Todos:
+     - Document new ARC3 Agent Playground feature and backend simulator constraints.
+     - Ensure instructions for environment variables (OPENAI_API_KEY) are clear.
+
+## Open Questions / Assumptions
+- Rely on OPENAI_API_KEY already used elsewhere in the project; no ARC_API_KEY requirement because simulator is local.
+- Simulator will mimic a single ARC3-style mini-game (“Color Hunt”) suitable for deterministic evaluation and safe demo runs.
+- Initial implementation will return full run output at once (non-streaming) to keep backend simple; future work can leverage streaming events.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,8 @@ The `docs/` directory is now organized around active focus areas. Use the table 
 
 > Tip: Each folder contains the most recent (≤ 7 days old) documentation for that topic so you can jump straight to the current state of work.
 
+📌 For the ARC-AGI-3 playground rollout, see the standalone plan `docs/2025-11-06-arc3-agent-ui-plan.md`.
+
 ## Reference material (`docs/reference/`)
 
 - `api/` – External and internal API contracts, streaming guides, and integration notes.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -32,6 +32,7 @@ import modelDatasetController from "./controllers/modelDatasetController.ts";
 // Import route modules
 import modelsRouter from "./routes/models.js";
 import metricsRouter from './routes/metricsRoutes.ts';
+import arc3Router from "./routes/arc3";
 
 // Import middleware
 import { errorHandler } from "./middleware/errorHandler";
@@ -56,6 +57,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
   
   // Models API routes
   app.use("/api/models", modelsRouter);
+
+  // ARC3 playground routes
+  app.use("/api/arc3", arc3Router);
   
   // Model Management GUI API routes
   app.get("/api/model-management/list", asyncHandler(modelManagementController.listModels));

--- a/server/routes/arc3.ts
+++ b/server/routes/arc3.ts
@@ -1,0 +1,42 @@
+/*
+Author: gpt-5-codex
+Date: 2025-11-06
+PURPOSE: Express router exposing the ARC3 agent playground API backed by the OpenAI Agents SDK runner.
+SRP/DRY check: Pass — isolates HTTP contract and validation for ARC3 playground endpoints.
+*/
+
+import { Router, type Request, type Response } from 'express';
+import { z } from 'zod';
+import { asyncHandler } from '../middleware/asyncHandler';
+import { Arc3AgentRunner } from '../services/arc3/Arc3AgentRunner';
+import { formatResponse } from '../utils/responseFormatter';
+
+const router = Router();
+const runner = new Arc3AgentRunner();
+
+const runSchema = z.object({
+  agentName: z.string().trim().max(60).optional(),
+  instructions: z
+    .string({ required_error: 'instructions is required' })
+    .trim()
+    .min(1, 'instructions must not be empty'),
+  model: z.string().trim().max(120).optional(),
+  maxTurns: z
+    .coerce.number()
+    .int()
+    .min(2)
+    .max(24)
+    .optional(),
+  scenarioId: z.string().trim().max(120).optional(),
+});
+
+router.post(
+  '/agent-playground/run',
+  asyncHandler(async (req: Request, res: Response) => {
+    const payload = runSchema.parse(req.body);
+    const result = await runner.run(payload);
+    res.json(formatResponse.success(result));
+  }),
+);
+
+export default router;

--- a/server/services/arc3/Arc3AgentRunner.ts
+++ b/server/services/arc3/Arc3AgentRunner.ts
@@ -1,0 +1,194 @@
+/*
+Author: gpt-5-codex
+Date: 2025-11-06
+PURPOSE: Runs OpenAI Agents SDK workflows against the ARC3 simulator, returning structured logs for the web UI.
+SRP/DRY check: Pass — isolates agent orchestration from HTTP routing and simulator implementation.
+*/
+
+import { randomUUID } from 'node:crypto';
+import { Agent, run, tool, extractAllTextOutput } from '@openai/agents';
+import { z } from 'zod';
+import { Arc3GameSimulator } from './Arc3GameSimulator';
+import {
+  ARC3_SIMPLE_ACTIONS,
+  Arc3AgentRunConfig,
+  Arc3AgentRunResult,
+  Arc3RunTimelineEntry,
+} from './types';
+
+const DEFAULT_MODEL = 'o4-mini';
+const DEFAULT_MAX_TURNS = 12;
+
+export class Arc3AgentRunner {
+  async run(config: Arc3AgentRunConfig): Promise<Arc3AgentRunResult> {
+    const simulator = new Arc3GameSimulator(config.scenarioId);
+    const agentName = config.agentName?.trim() || 'ARC3 Playground Operator';
+    const maxTurns = Math.max(2, Math.min(config.maxTurns ?? DEFAULT_MAX_TURNS, 24));
+
+    const inspectTool = tool({
+      name: 'inspect_board',
+      description:
+        'Inspect the current board state, remaining steps, available simple actions, and scenario metadata. Always call before making decisions.',
+      parameters: z.object({
+        note: z
+          .string()
+          .max(240)
+          .optional()
+          .describe('Optional reason for requesting a snapshot (used in the activity log).'),
+      }),
+      execute: async (input) => simulator.inspect(input.note),
+    });
+
+    const scannerTool = tool({
+      name: 'use_scanner_action',
+      description:
+        'Trigger one of the simple scanner actions ACTION1-ACTION5 to reveal structural hints about the energized node.',
+      parameters: z.object({
+        actionId: z.enum(ARC3_SIMPLE_ACTIONS),
+      }),
+      execute: async ({ actionId }) => simulator.applyAction({ kind: 'simple', id: actionId }),
+    });
+
+    const coordinateTool = tool({
+      name: 'submit_coordinate_action',
+      description:
+        'Fire ACTION6 at a zero-indexed coordinate (x column, y row). Use after gathering enough evidence. Values outside the grid will be clamped.',
+      parameters: z.object({
+        x: z.number().int().describe('Column index (0 on the left).'),
+        y: z.number().int().describe('Row index (0 at the top).'),
+      }),
+      execute: async ({ x, y }) => simulator.applyAction({ kind: 'coordinate', x, y }),
+    });
+
+    const resetTool = tool({
+      name: 'reset_simulation',
+      description: 'Start a fresh attempt on the simulator. Use sparingly — state and score reset.',
+      parameters: z.object({}),
+      execute: async () => simulator.applyAction({ kind: 'reset' }),
+    });
+
+    const baseInstructions = [
+      'You control a single-agent ARC-AGI-3 mini-game called "Color Hunt".',
+      'Goals:',
+      '- Locate and stabilize the energized node within the 8×8 grid.',
+      '- Use inspect_board first to understand the current state.',
+      '- Scanner tools (ACTION1-ACTION5) reveal hints but reduce score slightly.',
+      '- ACTION6 submits a coordinate guess. Coordinates are zero-indexed with x=column (left→right) and y=row (top→bottom).',
+      '- Stop when the simulator reports WIN or when no useful actions remain.',
+      'Return a concise final summary covering key actions, outcome, and score.',
+    ].join('\n');
+
+    const operatorGuidance = config.instructions?.trim();
+    const combinedInstructions = operatorGuidance
+      ? `${baseInstructions}\n\nOperator guidance: ${operatorGuidance}`
+      : baseInstructions;
+
+    const agent = new Agent({
+      name: agentName,
+      instructions: combinedInstructions,
+      handoffDescription: 'Operates the ARC3 Color Hunt simulator.',
+      model: config.model ?? DEFAULT_MODEL,
+      tools: [inspectTool, scannerTool, coordinateTool, resetTool],
+    });
+
+    const result = await run(
+      agent,
+      'Begin the Color Hunt session. Report status updates and end with a final mission summary.',
+      {
+        maxTurns,
+      },
+    );
+
+    const timeline: Arc3RunTimelineEntry[] = result.newItems.map((item, index) => {
+      switch (item.type) {
+        case 'message_output_item':
+          return {
+            index,
+            type: 'assistant_message',
+            label: `${item.agent.name} → user`,
+            content: item.content,
+          };
+        case 'tool_call_item':
+          {
+            const rawItem = item.rawItem;
+            let content = '';
+            const args = 'arguments' in rawItem ? rawItem.arguments : undefined;
+            if (typeof args === 'string') {
+              try {
+                content = JSON.stringify(JSON.parse(args), null, 2);
+              } catch {
+                content = args;
+              }
+            } else if (args) {
+              content = JSON.stringify(args, null, 2);
+            }
+
+            const label = `${item.agent.name} called ${'name' in rawItem ? rawItem.name : rawItem.type}`;
+
+            return {
+              index,
+              type: 'tool_call',
+              label,
+              content,
+            };
+          }
+        case 'tool_call_output_item':
+          {
+            const rawItem = item.rawItem;
+            let content = '';
+            if (typeof item.output === 'string') {
+              content = item.output;
+            } else if (item.output) {
+              content = JSON.stringify(item.output, null, 2);
+            } else if ('output' in rawItem && typeof rawItem.output === 'string') {
+              content = rawItem.output;
+            } else {
+              content = JSON.stringify(rawItem, null, 2);
+            }
+            return {
+              index,
+              type: 'tool_result',
+              label: `${item.agent.name} received ${rawItem.type}`,
+              content,
+            };
+          }
+        case 'reasoning_item':
+          return {
+            index,
+            type: 'reasoning',
+            label: `${item.agent.name} reasoning`,
+            content: JSON.stringify(item.rawItem, null, 2),
+          };
+        default:
+          return {
+            index,
+            type: 'assistant_message',
+            label: 'Unknown item',
+            content: JSON.stringify(item.toJSON(), null, 2),
+          };
+      }
+    });
+
+    const frames = simulator.getHistory();
+    const summary = simulator.getSummary();
+    const usage = result.state._context.usage;
+    const finalOutputCandidate = result.finalOutput;
+    const finalOutput = typeof finalOutputCandidate === 'string'
+      ? finalOutputCandidate
+      : extractAllTextOutput(result.newItems);
+
+    return {
+      runId: randomUUID(),
+      finalOutput: finalOutput?.trim() ? finalOutput.trim() : undefined,
+      timeline,
+      frames,
+      summary,
+      usage: {
+        requests: usage.requests,
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        totalTokens: usage.totalTokens,
+      },
+    };
+  }
+}

--- a/server/services/arc3/Arc3GameSimulator.ts
+++ b/server/services/arc3/Arc3GameSimulator.ts
@@ -1,0 +1,300 @@
+/*
+Author: gpt-5-codex
+Date: 2025-11-06
+PURPOSE: Deterministic mini-game simulator inspired by ARC-AGI-3 to power the playground agent workflow.
+SRP/DRY check: Pass — encapsulates game state, rule processing, and snapshot recording separate from transport logic.
+*/
+
+import {
+  ARC3_SIMPLE_ACTIONS,
+  Arc3Action,
+  Arc3FrameSnapshot,
+  Arc3GameState,
+  Arc3RunSummary,
+  Arc3ScenarioDefinition,
+  Arc3SimpleActionId,
+} from './types';
+
+interface Arc3InspectionPayload {
+  state: Arc3GameState;
+  score: number;
+  stepsTaken: number;
+  remainingSteps: number;
+  simpleActionsAvailable: Arc3SimpleActionId[];
+  coordinateGuesses: number;
+  scenario: Pick<Arc3ScenarioDefinition, 'id' | 'name' | 'description' | 'legend'>;
+  board: number[][];
+  note?: string;
+}
+
+const MAX_STEPS = 24;
+
+const DEFAULT_SCENARIOS: Arc3ScenarioDefinition[] = [
+  {
+    id: 'color-hunt-alpha',
+    name: 'Color Hunt Alpha',
+    description:
+      'A shimmering lattice hides a single energized node. Use the scanners to isolate its row, column, and local neighborhood before committing to a coordinate action.',
+    target: { x: 4, y: 4 },
+    baseGrid: [
+      [0, 0, 1, 1, 1, 0, 0, 0],
+      [0, 1, 2, 2, 2, 1, 1, 0],
+      [0, 1, 3, 3, 2, 1, 1, 0],
+      [0, 1, 3, 4, 3, 1, 1, 0],
+      [0, 1, 2, 3, 2, 1, 1, 0],
+      [0, 1, 2, 2, 2, 1, 1, 0],
+      [0, 1, 1, 1, 1, 1, 1, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0],
+    ],
+    textHint:
+      'The energized node sits where the warmest diagonal intersects the brightest column. Observe the gradient as you activate scanners.',
+    legend: {
+      0: 'Void',
+      1: 'Low-energy lattice',
+      2: 'Warm flux',
+      3: 'Hot flux',
+      4: 'Energized core candidate',
+      5: 'Row scanner highlight',
+      6: 'Column scanner highlight',
+      7: 'Quadrant triangulation',
+      8: 'Stabilized target',
+      9: 'Spent probe',
+    },
+  },
+  {
+    id: 'color-hunt-beta',
+    name: 'Color Hunt Beta',
+    description:
+      'A cooler lattice hides the node at the overlap of a vertical coolant vein and a diagonal charge line.',
+    target: { x: 2, y: 5 },
+    baseGrid: [
+      [0, 0, 0, 1, 1, 0, 0, 0],
+      [0, 1, 2, 2, 1, 0, 0, 0],
+      [0, 1, 2, 3, 2, 1, 0, 0],
+      [0, 0, 1, 2, 3, 2, 1, 0],
+      [0, 0, 0, 1, 2, 2, 1, 0],
+      [0, 1, 2, 2, 2, 1, 0, 0],
+      [0, 1, 1, 1, 1, 0, 0, 0],
+      [0, 0, 0, 0, 0, 0, 0, 0],
+    ],
+    textHint:
+      'The coolant vein glows softly in one column. The energized node aligns with the only diagonal that brightens as it descends.',
+    legend: {
+      0: 'Void',
+      1: 'Cool lattice',
+      2: 'Warm resonance',
+      3: 'Hot resonance',
+      4: 'Core candidate',
+      5: 'Row scanner highlight',
+      6: 'Column scanner highlight',
+      7: 'Quadrant triangulation',
+      8: 'Stabilized target',
+      9: 'Spent probe',
+    },
+  },
+];
+
+function cloneGrid(grid: number[][]): number[][] {
+  return grid.map((row) => [...row]);
+}
+
+export class Arc3GameSimulator {
+  private scenarioIndex = 0;
+  private scenario: Arc3ScenarioDefinition;
+  private board: number[][] = [];
+  private state: Arc3GameState = 'NOT_STARTED';
+  private score = 0;
+  private steps = 0;
+  private history: Arc3FrameSnapshot[] = [];
+  private readonly maxSteps = MAX_STEPS;
+  private readonly simpleActionsUsed = new Set<Arc3SimpleActionId>();
+  private coordinateGuesses = 0;
+
+  constructor(private readonly scenarioId?: string) {
+    if (scenarioId) {
+      const foundIndex = DEFAULT_SCENARIOS.findIndex((scenario) => scenario.id === scenarioId);
+      if (foundIndex !== -1) {
+        this.scenarioIndex = foundIndex;
+      }
+    }
+    this.scenario = DEFAULT_SCENARIOS[this.scenarioIndex];
+    this.reset();
+  }
+
+  reset(): Arc3FrameSnapshot {
+    if (this.scenarioId === undefined) {
+      this.scenarioIndex = (this.scenarioIndex + 1) % DEFAULT_SCENARIOS.length;
+      this.scenario = DEFAULT_SCENARIOS[this.scenarioIndex];
+    }
+    this.board = cloneGrid(this.scenario.baseGrid);
+    this.state = 'IN_PROGRESS';
+    this.score = 0;
+    this.steps = 0;
+    this.history = [];
+    this.simpleActionsUsed.clear();
+    this.coordinateGuesses = 0;
+    const snapshot = this.recordSnapshot('RESET', 'Simulation reset. Activate scanners to gather clues before taking ACTION6.');
+    return snapshot;
+  }
+
+  inspect(note?: string): Arc3InspectionPayload {
+    return {
+      state: this.state,
+      score: this.score,
+      stepsTaken: this.steps,
+      remainingSteps: Math.max(this.maxSteps - this.steps, 0),
+      simpleActionsAvailable: ARC3_SIMPLE_ACTIONS.filter((id) => !this.simpleActionsUsed.has(id)),
+      coordinateGuesses: this.coordinateGuesses,
+      scenario: {
+        id: this.scenario.id,
+        name: this.scenario.name,
+        description: this.scenario.description,
+        legend: this.scenario.legend,
+      },
+      board: cloneGrid(this.board),
+      note,
+    };
+  }
+
+  applyAction(action: Arc3Action): Arc3FrameSnapshot {
+    if (this.state === 'GAME_OVER' || this.state === 'WIN') {
+      return this.recordSnapshot(
+        'NO_OP',
+        'Game already concluded. Reset to start a new attempt.',
+      );
+    }
+
+    switch (action.kind) {
+      case 'reset':
+        return this.reset();
+      case 'simple':
+        return this.handleSimpleAction(action.id);
+      case 'coordinate':
+        return this.handleCoordinateAction(action.x, action.y);
+      default:
+        return this.recordSnapshot('NO_OP', 'Unknown action requested.');
+    }
+  }
+
+  getHistory(): Arc3FrameSnapshot[] {
+    return [...this.history];
+  }
+
+  getSummary(): Arc3RunSummary {
+    return {
+      state: this.state,
+      score: this.score,
+      stepsTaken: this.steps,
+      simpleActionsUsed: Array.from(this.simpleActionsUsed.values()),
+      coordinateGuesses: this.coordinateGuesses,
+      scenarioId: this.scenario.id,
+      scenarioName: this.scenario.name,
+    };
+  }
+
+  private handleSimpleAction(id: Arc3SimpleActionId): Arc3FrameSnapshot {
+    if (this.simpleActionsUsed.has(id)) {
+      return this.recordSnapshot(id, `${id} already used in this run.`);
+    }
+
+    this.simpleActionsUsed.add(id);
+    this.steps += 1;
+    let narrative = '';
+
+    switch (id) {
+      case 'ACTION1': {
+        this.board[this.scenario.target.y] = this.board[this.scenario.target.y].map(() => 5);
+        narrative = 'Row scanner activated. The energized row glows amber.';
+        break;
+      }
+      case 'ACTION2': {
+        for (let y = 0; y < this.board.length; y += 1) {
+          this.board[y][this.scenario.target.x] = 6;
+        }
+        narrative = 'Column scanner activated. The energized column emits teal light.';
+        break;
+      }
+      case 'ACTION3': {
+        const { x, y } = this.scenario.target;
+        for (let yy = y - 1; yy <= y + 1; yy += 1) {
+          if (yy < 0 || yy >= this.board.length) continue;
+          for (let xx = x - 1; xx <= x + 1; xx += 1) {
+            if (xx < 0 || xx >= this.board[yy].length) continue;
+            if (!(yy === y && xx === x)) {
+              this.board[yy][xx] = 7;
+            }
+          }
+        }
+        narrative = 'Triangulation pulse reveals a 3×3 halo around the energized node.';
+        break;
+      }
+      case 'ACTION4': {
+        const { x, y } = this.scenario.target;
+        const value = this.board[y][x];
+        this.board[y][x] = value === 8 ? 8 : 8;
+        narrative = 'Stability probe peaks. The energized node emits a golden flare at its exact location.';
+        break;
+      }
+      case 'ACTION5': {
+        narrative = `Telemetry analysis: ${this.scenario.textHint}`;
+        break;
+      }
+      default: {
+        narrative = 'Scanner malfunctioned with an undefined pattern.';
+      }
+    }
+
+    this.score = Math.max(this.score - 1, -10);
+    this.enforceStepLimit();
+    return this.recordSnapshot(id, narrative);
+  }
+
+  private handleCoordinateAction(x: number, y: number): Arc3FrameSnapshot {
+    this.steps += 1;
+    this.coordinateGuesses += 1;
+
+    if (!Number.isFinite(x) || !Number.isFinite(y)) {
+      return this.recordSnapshot('ACTION6', 'Coordinate guess rejected: coordinates must be numeric within the grid.');
+    }
+
+    const maxY = this.board.length - 1;
+    const maxX = this.board[0]?.length ? this.board[0].length - 1 : 0;
+    const boundedX = Math.max(0, Math.min(maxX, Math.round(x)));
+    const boundedY = Math.max(0, Math.min(maxY, Math.round(y)));
+
+    if (boundedX === this.scenario.target.x && boundedY === this.scenario.target.y) {
+      this.board[boundedY][boundedX] = 8;
+      this.state = 'WIN';
+      this.score += 12;
+      return this.recordSnapshot('ACTION6', 'Direct hit! The energized node is stabilized. Mission complete.');
+    }
+
+    this.score = Math.max(this.score - 3, -15);
+    this.board[boundedY][boundedX] = 9;
+    this.enforceStepLimit();
+    return this.recordSnapshot(
+      'ACTION6',
+      `Probe at (${boundedX}, ${boundedY}) dissipated without impact. Adjust strategy and try again.`,
+    );
+  }
+
+  private enforceStepLimit(): void {
+    if (this.steps >= this.maxSteps && this.state !== 'WIN') {
+      this.state = 'GAME_OVER';
+    }
+  }
+
+  private recordSnapshot(actionLabel: string, narrative: string): Arc3FrameSnapshot {
+    const snapshot: Arc3FrameSnapshot = {
+      step: this.history.length,
+      state: this.state,
+      score: this.score,
+      board: cloneGrid(this.board),
+      actionLabel,
+      narrative,
+      remainingSteps: Math.max(this.maxSteps - this.steps, 0),
+    };
+    this.history.push(snapshot);
+    return snapshot;
+  }
+}

--- a/server/services/arc3/types.ts
+++ b/server/services/arc3/types.ts
@@ -1,0 +1,100 @@
+/*
+Author: gpt-5-codex
+Date: 2025-11-06
+PURPOSE: Shared type definitions for the ARC-AGI-3 playground simulator and agent runner services.
+SRP/DRY check: Pass — centralizes enums and interfaces used by the new ARC3 backend modules.
+*/
+
+export const ARC3_SIMPLE_ACTIONS = [
+  'ACTION1',
+  'ACTION2',
+  'ACTION3',
+  'ACTION4',
+  'ACTION5',
+] as const;
+
+export type Arc3SimpleActionId = (typeof ARC3_SIMPLE_ACTIONS)[number];
+
+export type Arc3ActionKind = 'reset' | 'simple' | 'coordinate';
+
+export type Arc3GameState =
+  | 'NOT_STARTED'
+  | 'IN_PROGRESS'
+  | 'WIN'
+  | 'GAME_OVER';
+
+export interface Arc3CoordinateAction {
+  kind: 'coordinate';
+  x: number;
+  y: number;
+}
+
+export interface Arc3SimpleAction {
+  kind: 'simple';
+  id: Arc3SimpleActionId;
+}
+
+export interface Arc3ResetAction {
+  kind: 'reset';
+}
+
+export type Arc3Action = Arc3CoordinateAction | Arc3SimpleAction | Arc3ResetAction;
+
+export interface Arc3ScenarioDefinition {
+  id: string;
+  name: string;
+  description: string;
+  target: { x: number; y: number };
+  baseGrid: number[][];
+  textHint: string;
+  legend: Record<number, string>;
+}
+
+export interface Arc3FrameSnapshot {
+  step: number;
+  state: Arc3GameState;
+  score: number;
+  board: number[][];
+  actionLabel: string;
+  narrative: string;
+  remainingSteps: number;
+}
+
+export interface Arc3RunSummary {
+  state: Arc3GameState;
+  score: number;
+  stepsTaken: number;
+  simpleActionsUsed: Arc3SimpleActionId[];
+  coordinateGuesses: number;
+  scenarioId: string;
+  scenarioName: string;
+}
+
+export interface Arc3RunTimelineEntry {
+  index: number;
+  type: 'assistant_message' | 'tool_call' | 'tool_result' | 'reasoning';
+  label: string;
+  content: string;
+}
+
+export interface Arc3AgentRunResult {
+  runId: string;
+  finalOutput?: string;
+  timeline: Arc3RunTimelineEntry[];
+  frames: Arc3FrameSnapshot[];
+  summary: Arc3RunSummary;
+  usage: {
+    requests: number;
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+  };
+}
+
+export interface Arc3AgentRunConfig {
+  agentName?: string;
+  instructions: string;
+  model?: string;
+  maxTurns?: number;
+  scenarioId?: string;
+}


### PR DESCRIPTION
## Summary
- add deterministic ARC3 "Color Hunt" simulator and OpenAI Agents runner service
- expose `/api/arc3/agent-playground/run` endpoint and React playground page with timeline + board playback
- update navigation, ARC3 landing page, and docs to surface the new workflow

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_690c3ef738c48326bd50944f0f0b29f9