### PR TITLE
Review Arc3 Playground User Interaction Updates

### DIFF
--- a/client/src/hooks/useArc3AgentStream.ts
+++ b/client/src/hooks/useArc3AgentStream.ts
@@ -623,6 +623,7 @@ export function useArc3AgentStream() {
         setState(prev => ({
           ...prev,
           streamingMessage: errorMessage,
+          error: errorMessage,
         }));
         throw error;
       }

--- a/client/src/pages/ARC3AgentPlayground.tsx
+++ b/client/src/pages/ARC3AgentPlayground.tsx
@@ -201,6 +201,7 @@ export default function ARC3AgentPlayground() {
 
   // Manual action state
   const [showCoordinatePicker, setShowCoordinatePicker] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const handleStart = () => {
     start({
@@ -537,13 +538,21 @@ export default function ARC3AgentPlayground() {
 
         {/* CENTER: Action pills now occupy former game selector spot */}
         <div className="lg:col-span-5 space-y-3">
+          {/* Action Error Display */}
+          {actionError && (
+            <div className="p-2 bg-red-50 border border-red-200 rounded text-xs text-red-700">
+              <p className="font-semibold">Action Error:</p>
+              <p className="text-[10px] mt-1">{actionError}</p>
+            </div>
+          )}
+
           <Card>
             <CardContent className="p-3">
               <div className="flex flex-wrap items-center justify-center gap-1.5">
-                {['ACTION1', 'ACTION2', 'ACTION3', 'ACTION4', 'ACTION5', 'ACTION6', 'ACTION7'].map((actionName) => {
+                {['RESET', 'ACTION1', 'ACTION2', 'ACTION3', 'ACTION4', 'ACTION5', 'ACTION6', 'ACTION7'].map((actionName) => {
                   const usedCount = toolEntries.filter(e => e.label.includes(actionName)).length;
                   const isActive = isPlaying && state.streamingMessage?.includes(actionName);
-                  const displayName = actionName.replace('ACTION', 'Action ');
+                  const displayName = actionName === 'RESET' ? 'Reset' : actionName.replace('ACTION', 'Action ');
 
                   // Check if action is available according to the API
                   const isAvailable = !normalizedAvailableActions || normalizedAvailableActions.has(actionName);
@@ -553,8 +562,11 @@ export default function ARC3AgentPlayground() {
                       setShowCoordinatePicker(true);
                     } else {
                       try {
+                        setActionError(null);
                         await executeManualAction(actionName);
                       } catch (error) {
+                        const msg = error instanceof Error ? error.message : 'Failed to execute action';
+                        setActionError(msg);
                         console.error(`Failed to execute ${actionName}:`, error);
                       }
                     }


### PR DESCRIPTION
Three critical fixes to the ARC3 agent playground:

1. Add RESET button to available actions - The API returns RESET as an available action, but it was not being displayed to users. Now RESET appears as the first action button, allowing users to reset games.

2. Display action execution errors to users - When manual actions fail, errors are now shown in a red error box above the action buttons, instead of only logging to console. This gives users immediate feedback when actions fail.

3. Fix hook error state on manual action failures - The executeManualAction hook now properly sets state.error when actions fail, so the error display box in the main component will show errors from both streaming and manual actions.

These fixes address the issues where users couldn't see RESET options and had no feedback when actions failed due to invalid state or API errors.