### PR TITLE
Improve PuzzleBrowser page header layout

### DIFF
--- a/client/src/components/browser/ReferenceMaterial.tsx
+++ b/client/src/components/browser/ReferenceMaterial.tsx
@@ -1,0 +1,187 @@
+/**
+ * Author: Claude Code using Haiku 4.5
+ * Date: 2025-11-10
+ * PURPOSE: Renders Reference Material section with light theme for PuzzleBrowser page.
+ *          Provides reusable ReferenceLink and ReferenceSection components to avoid duplication.
+ *          Includes Research Papers, Data Sources, Tools, Solution References, and Community Notes.
+ * SRP/DRY check: Pass - Extracted link rendering and section layout into reusable components.
+ *                      Reduced code duplication in PuzzleBrowser and centralizes styling.
+ */
+import React from 'react';
+import { ExternalLink, Sparkles } from 'lucide-react';
+
+// ============================================================================
+// TYPE DEFINITIONS
+// ============================================================================
+
+interface ReferenceLink {
+  label: string;
+  href: string;
+}
+
+interface ReferenceSectionProps {
+  title: string;
+  links: ReferenceLink[];
+}
+
+// ============================================================================
+// REUSABLE COMPONENTS
+// ============================================================================
+
+/**
+ * ReferenceLink - Individual link with external link icon
+ * Provides consistent styling for all reference links
+ */
+const ReferenceLink: React.FC<{ link: ReferenceLink }> = ({ link }) => (
+  <li>
+    <a
+      href={link.href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group inline-flex items-center gap-2 text-slate-700 hover:text-sky-600 transition-colors"
+    >
+      {link.label}
+      <ExternalLink className="h-3 w-3 text-slate-400 group-hover:text-sky-600" />
+    </a>
+  </li>
+);
+
+/**
+ * ReferenceSection - Category of reference links
+ * Displays a section title and list of links
+ */
+const ReferenceSection: React.FC<ReferenceSectionProps> = ({ title, links }) => (
+  <div className="space-y-1">
+    <p className="text-xs font-semibold uppercase tracking-wide text-slate-600">
+      {title}
+    </p>
+    <ul className="space-y-0.5">
+      {links.map((link) => (
+        <ReferenceLink key={link.href} link={link} />
+      ))}
+    </ul>
+  </div>
+);
+
+// ============================================================================
+// REFERENCE DATA
+// ============================================================================
+
+const REFERENCE_SECTIONS: ReferenceSectionProps[] = [
+  {
+    title: 'Research Papers',
+    links: [
+      {
+        label: 'ARC-AGI-2 Technical Report',
+        href: 'https://www.arxiv.org/pdf/2505.11831',
+      },
+    ],
+  },
+  {
+    title: 'Data Sources',
+    links: [
+      {
+        label: 'HuggingFace datasets',
+        href: 'https://huggingface.co/arcprize',
+      },
+      {
+        label: 'Official repository',
+        href: 'https://github.com/fchollet/ARC-AGI',
+      },
+    ],
+  },
+  {
+    title: 'Tools',
+    links: [
+      {
+        label: 'arckit',
+        href: 'https://github.com/mxbi/arckit',
+      },
+      {
+        label: 'objarc',
+        href: 'https://github.com/pwspen/objarc',
+      },
+      {
+        label: 'Synapsomorphy ARC',
+        href: 'https://synapsomorphy.com/arc/',
+      },
+    ],
+  },
+  {
+    title: 'Solution References',
+    links: [
+      {
+        label: 'zoecarver\'s approach',
+        href: 'https://github.com/zoecarver',
+      },
+      {
+        label: 'jerber\'s solutions',
+        href: 'https://github.com/jerber',
+      },
+      {
+        label: 'Eric Pang\'s SOTA solution',
+        href: 'https://github.com/epang080516/arc_agi',
+      },
+    ],
+  },
+  {
+    title: 'Community Notes',
+    links: [
+      {
+        label: 'Puzzle nomenclature',
+        href: 'https://github.com/google/ARC-GEN/blob/main/task_list.py#L422',
+      },
+      {
+        label: 'Synthetic Data',
+        href: 'https://cdg.openai.nl/',
+      },
+      {
+        label: 'ARC notes by @neoneye',
+        href: 'https://github.com/neoneye/arc-notes',
+      },
+      {
+        label: 'Abstraction dataset',
+        href: 'https://github.com/cristianoc/arc-agi-2-abstraction-dataset',
+      },
+    ],
+  },
+];
+
+// ============================================================================
+// MAIN COMPONENT
+// ============================================================================
+
+/**
+ * ReferenceMaterial - Main section component with light theme
+ * Displays all reference materials organized by category
+ */
+export const ReferenceMaterial: React.FC = () => {
+  return (
+    <section className="rounded-lg border border-slate-200 bg-white p-3">
+      {/* Header */}
+      <div className="flex items-center gap-3 text-sm font-semibold text-slate-900">
+        <Sparkles className="h-4 w-4 text-slate-600" />
+        <span>Reference material</span>
+      </div>
+
+      {/* Grid of reference sections */}
+      <div className="mt-2 grid gap-3 text-xs text-slate-600 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+        {REFERENCE_SECTIONS.map((section) => (
+          <ReferenceSection
+            key={section.title}
+            title={section.title}
+            links={section.links}
+          />
+        ))}
+      </div>
+
+      {/* Footer acknowledgement */}
+      <p className="mt-2 text-xs text-slate-500">
+        Special Acknowledgement: Simon Strandgaard (@neoneye) for his invaluable
+        support, feedback, and collection of resources.
+      </p>
+    </section>
+  );
+};
+
+export default ReferenceMaterial;

--- a/client/src/pages/PuzzleBrowser.tsx
+++ b/client/src/pages/PuzzleBrowser.tsx
@@ -1,14 +1,16 @@
 /**
- * Author: gpt-5-codex
- * Date: 2025-02-15
- * PURPOSE: Restores the research-focused Puzzle Browser layout with muted slate styling, compact filters, and plain-text resource references.
- * SRP/DRY check: Pass - Verified filter logic, navigation, and rendering after UI refinements.
+ * Author: Claude Code using Haiku 4.5
+ * Date: 2025-11-10
+ * PURPOSE: Research-focused Puzzle Browser page with filters, puzzle results, and light-themed reference materials.
+ *          Extracted Reference Material section into a reusable component for better maintainability.
+ * SRP/DRY check: Pass - Verified filter logic, navigation, rendering, and delegated reference material to ReferenceMaterial component.
  */
 import React, { useState, useCallback } from 'react';
 import { Link, useLocation } from 'wouter';
 import { usePuzzleList } from '@/hooks/usePuzzle';
-import { Loader2, Grid3X3, ExternalLink, Sparkles } from 'lucide-react';
+import { Loader2, Grid3X3 } from 'lucide-react';
 import { EmojiMosaicAccent } from '@/components/browser/EmojiMosaicAccent';
+import { ReferenceMaterial } from '@/components/browser/ReferenceMaterial';
 import type { PuzzleMetadata } from '@shared/types';
 import { CollapsibleMission } from '@/components/ui/collapsible-mission';
 import { PuzzleCard } from '@/components/puzzle/PuzzleCard';
@@ -208,152 +210,7 @@ export default function PuzzleBrowser() {
             <CollapsibleMission />
           </div>
 
-          <section className="rounded-lg border border-slate-800 bg-slate-900/60 p-3">
-            <div className="flex items-center gap-3 text-sm font-semibold text-slate-200">
-              <Sparkles className="h-4 w-4 text-slate-300" />
-              <span>Reference material</span>
-            </div>
-
-            <div className="mt-2 grid gap-3 text-xs text-slate-300 sm:grid-cols-2 lg:grid-cols-4">
-              <div className="space-y-1">
-                <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Research Papers</p>
-                <ul className="space-y-0.5">
-                  <li>
-                    <a
-                      href="https://www.arxiv.org/pdf/2505.11831"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="group inline-flex items-center gap-2 text-slate-200 hover:text-sky-300"
-                    >
-                      ARC-AGI-2 Technical Report
-                      <ExternalLink className="h-3 w-3 text-slate-500 group-hover:text-sky-300" />
-                    </a>
-                  </li>
-                </ul>
-              </div>
-
-              <div className="space-y-1">
-                <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Data Sources</p>
-                <ul className="space-y-0.5">
-                  <li>
-                    <a
-                      href="https://huggingface.co/arcprize"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="group inline-flex items-center gap-2 text-slate-200 hover:text-sky-300"
-                    >
-                      HuggingFace datasets
-                      <ExternalLink className="h-3 w-3 text-slate-500 group-hover:text-sky-300" />
-                    </a>
-                  </li>
-                  <li>
-                    <a
-                      href="https://github.com/fchollet/ARC-AGI"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="group inline-flex items-center gap-2 text-slate-200 hover:text-sky-300"
-                    >
-                      Official repository
-                      <ExternalLink className="h-3 w-3 text-slate-500 group-hover:text-sky-300" />
-                    </a>
-                  </li>
-                </ul>
-              </div>
-
-              <div className="space-y-1">
-                <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Solution References</p>
-                <ul className="space-y-0.5">
-                  <li>
-                    <a
-                      href="https://github.com/zoecarver"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="group inline-flex items-center gap-2 text-slate-200 hover:text-sky-300"
-                    >
-                      zoecarver's approach
-                      <ExternalLink className="h-3 w-3 text-slate-500 group-hover:text-sky-300" />
-                    </a>
-                  </li>
-                  <li>
-                    <a
-                      href="https://github.com/jerber"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="group inline-flex items-center gap-2 text-slate-200 hover:text-sky-300"
-                    >
-                      jerber's solutions
-                      <ExternalLink className="h-3 w-3 text-slate-500 group-hover:text-sky-300" />
-                    </a>
-                  </li>
-                  <li>
-                    <a
-                      href="https://github.com/epang080516/arc_agi"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="group inline-flex items-center gap-2 text-slate-200 hover:text-sky-300"
-                    >
-                      Eric Pang's SOTA solution
-                      <ExternalLink className="h-3 w-3 text-slate-500 group-hover:text-sky-300" />
-                    </a>
-                  </li>
-                </ul>
-              </div>
-
-              <div className="space-y-1">
-                <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Community Notes</p>
-                <ul className="space-y-0.5">
-                  <li>
-                    <a
-                      href="https://github.com/google/ARC-GEN/blob/main/task_list.py#L422"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="group inline-flex items-center gap-2 text-slate-200 hover:text-sky-300"
-                    >
-                      Puzzle nomenclature
-                      <ExternalLink className="h-3 w-3 text-slate-500 group-hover:text-sky-300" />
-                    </a>
-                  </li>
-                  <li>
-                    <a
-                      href="https://cdg.openai.nl/"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="group inline-flex items-center gap-2 text-slate-200 hover:text-sky-300"
-                    >
-                      Synthetic Data
-                      <ExternalLink className="h-3 w-3 text-slate-500 group-hover:text-sky-300" />
-                    </a>
-                  </li>
-                  <li>
-                    <a
-                      href="https://github.com/neoneye/arc-notes"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="group inline-flex items-center gap-2 text-slate-200 hover:text-sky-300"
-                    >
-                      ARC notes by @neoneye
-                      <ExternalLink className="h-3 w-3 text-slate-500 group-hover:text-sky-300" />
-                    </a>
-                  </li>
-                  <li>
-                    <a
-                      href="https://github.com/cristianoc/arc-agi-2-abstraction-dataset"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="group inline-flex items-center gap-2 text-slate-200 hover:text-sky-300"
-                    >
-                      Abstraction dataset
-                      <ExternalLink className="h-3 w-3 text-slate-500 group-hover:text-sky-300" />
-                    </a>
-                  </li>
-                </ul>
-              </div>
-            </div>
-
-            <p className="mt-2 text-xs text-slate-500">
-              Special Acknowledgement: Simon Strandgaard (@neoneye) for his invaluable support, feedback, and collection of resources.
-            </p>
-          </section>
+          <ReferenceMaterial />
         </header>
 
         {/* Filters */}


### PR DESCRIPTION
- Create new ReferenceMaterial component (client/src/components/browser/ReferenceMaterial.tsx) with light color theme for better visual contrast
- Add reusable ReferenceLink and ReferenceSection components (DRY principle)
- Add Tools section with three new important resources:
  - arckit (https://github.com/mxbi/arckit)
  - objarc (https://github.com/pwspen/objarc)
  - Synapsomorphy ARC (https://synapsomorphy.com/arc/)
- Refactor PuzzleBrowser to use new component (reduces duplicate JSX)
- Update grid layout to support up to 5 columns on xl screens for new Tools section
- Light theme palette: white background, slate-900 text, sky-600 hover links