### PR TITLE
fix: display final timestep in grid and add layer navigator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # CHANGELOG - Uses semantic versioning (MAJOR.MINOR.PATCH)`r`n
+# [5.8.5] - 2025-11-11
+### 🐞 Fixes
+- **ACTION6 Coordinate Picker Y Coordinate Bug**: Fixed critical bug where clicking on grid cells in the ACTION6 coordinate picker dialog always recorded Y coordinate as 0. The issue was caused by incorrectly accessing the 3D grid array dimensions - treating `resolvedCurrentFrame.length` (number of frames in time dimension) as height and `resolvedCurrentFrame[0]?.length` (actual height) as width. Now correctly extracts the 2D frame first (`frame2D = resolvedCurrentFrame[0]`) and uses proper dimensions (`height = frame2D.length`, `width = frame2D[0]?.length`). Clicking at position (21, 35) now correctly records as (21, 35) instead of (21, 0).
+
+- **Grid Timestep/Layer Display Bug**: Fixed critical issue where grid visualization only showed the first timestep/layer of multi-layer frames instead of the final state. The ARC3 API returns frames as 3D arrays `[layer/timestep][height][width]` where actions that cause cascading changes include multiple intermediate states. Previously, the UI always displayed `frameIndex={0}` (first state) instead of the final result. Changes:
+  - Now displays the **last layer** (final state after action) by default
+  - Added timestep navigator slider when frames have multiple layers (shows as amber-colored control)
+  - Users can now step through all intermediate states to see how actions evolved
+  - Applied fix to main grid display, ACTION6 coordinate picker, and initial grid
+  - Example: If an action creates 5 intermediate states, users now see state 5/5 by default instead of 1/5
+
 # [5.8.4] - 2025-11-09 17:05 EST
 ### 🔄 ARC3 Conversation Chaining
 - **Arc3RealGameRunner** now forwards `previousResponseId` into the OpenAI Agents SDK and captures the returned `response.id`, enabling seamless continuation runs.


### PR DESCRIPTION
Fixed critical issue where grid visualization only showed the first timestep/layer of multi-layer frames instead of the final state after an action.

ROOT CAUSE:
The ARC3 API returns frames as 3D arrays with structure:
- frame: number[][][] = [layer/timestep][height][width]

When actions cause cascading changes (e.g., falling blocks, spreading colors), the API returns multiple layers showing the progression from initial state to final state. Previously, all Arc3GridVisualization calls used frameIndex={0}, showing only the first intermediate state instead of the final result.

CHANGES:
1. Added currentLayerIndex state to track which layer to display
2. useEffect hook sets layer to LAST index when frame changes
3. All grid displays now show final state by default:
   - Main grid visualization
   - ACTION6 coordinate picker dialog
   - Initial grid display
4. Added timestep navigator UI:
   - Amber-colored slider appears when frame has multiple layers
   - Shows "Timestep: N / Total" with explanation text
   - Allows stepping through all intermediate states
5. Maintained frame navigator for switching between different actions

EXAMPLE:
Before: Action creates states 1→2→3→4→5, UI shows state 1 After: Action creates states 1→2→3→4→5, UI shows state 5
        (with slider to view 1, 2, 3, 4)

This ensures users see the actual result of their actions, not just the starting point of the transition.