### PR TITLE
Remove page margin from Elo endpoint

### DIFF
--- a/client/src/components/elo/EloVoteResultsModal.tsx
+++ b/client/src/components/elo/EloVoteResultsModal.tsx
@@ -78,7 +78,7 @@ export const EloVoteResultsModal: React.FC<EloVoteResultsModalProps> = ({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-[95vw] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <CheckCircle className="h-5 w-5 text-green-600" />

--- a/client/src/pages/EloComparison.tsx
+++ b/client/src/pages/EloComparison.tsx
@@ -178,7 +178,7 @@ export default function EloComparison() {
   }
 
   return (
-    <div className="container mx-auto p-3 max-w-7xl space-y-4">
+    <div className="mx-auto space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>


### PR DESCRIPTION
- Remove container padding and max-width constraints from EloComparison page
- Expand EloVoteResultsModal from max-w-4xl to max-w-[95vw] for more horizontal space
- Fixes issue where grids were smooshed together in the modal
- Improves visual clarity for puzzle grid comparisons

Changes:
- client/src/pages/EloComparison.tsx: Remove container, p-3, max-w-7xl classes
- client/src/components/elo/EloVoteResultsModal.tsx: Change max-w-4xl to max-w-[95vw]