### PR TITLE
feat: Reveal Sherlock Think Alpha as Grok 4.1 Fast Reasoning

### DIFF
--- a/analyze-openrouter-free-models.ts
+++ b/analyze-openrouter-free-models.ts
@@ -1,10 +1,10 @@
 /**
  * Author: Claude Code using Sonnet 4.5
- * Date: 2025-11-15
- * PURPOSE: Analyze ARC Eval puzzles using the free Sherlock Think Alpha cloaked model from OpenRouter.
- * Pulls ARC1 / ARC2 evaluation puzzle IDs, runs Sherlock Think Alpha with rate-limited launch spacing,
+ * Date: 2025-11-20
+ * PURPOSE: Analyze ARC Eval puzzles using the Grok 4.1 Fast Reasoning model from OpenRouter.
+ * Pulls ARC1 / ARC2 evaluation puzzle IDs, runs Grok 4.1 Fast Reasoning with rate-limited launch spacing,
  * and persists explanations through the existing analysis + save endpoints.
- * UPDATED: Now skips puzzles that already have explanations from Sherlock Think Alpha.
+ * UPDATED: Now skips puzzles that already have explanations from Grok 4.1 Fast Reasoning.
  * SRP/DRY check: Pass — shared helpers are reused from the paid-model script with
  * model iteration generalized.
  */
@@ -16,12 +16,12 @@ dotenv.config();
 
 type SourceKey = 'ARC1-Eval' | 'ARC2-Eval';
 
-type ModelKey = 'openrouter/sherlock-think-alpha';
+type ModelKey = 'x-ai/grok-4.1-fast';
 
 const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:5000';
 const SOURCES: SourceKey[] = ['ARC2-Eval', 'ARC1-Eval'];
 
-const DEFAULT_MODEL_KEYS: ModelKey[] = ['openrouter/sherlock-think-alpha'];
+const DEFAULT_MODEL_KEYS: ModelKey[] = ['x-ai/grok-4.1-fast'];
 
 const RATE_LIMIT_DELAY_MS = Number(process.env.OPENROUTER_RATE_LIMIT_MS) || 5000;
 const MODEL_SWITCH_DELAY_MS = Number(process.env.OPENROUTER_MODEL_SWITCH_DELAY_MS) || 3000;
@@ -42,7 +42,7 @@ function parseModelKeys(raw?: string): ModelKey[] {
 
   if (parsed.length === 0) {
     console.warn(
-      'OPENROUTER_FREE_MODELS provided but contained no recognized model keys; falling back to Sherlock Think Alpha.'
+      'OPENROUTER_FREE_MODELS provided but contained no recognized model keys; falling back to Grok 4.1 Fast Reasoning.'
     );
     return DEFAULT_MODEL_KEYS;
   }
@@ -345,12 +345,11 @@ function summarizeByModel(results: AnalysisResult[]): void {
 
 async function main(): Promise<void> {
   try {
-    console.log('🔬 Sherlock Think Alpha - ARC Eval Analyzer');
+    console.log('🔬 Grok 4.1 Fast Reasoning - ARC Eval Analyzer');
     console.log('='.repeat(60));
     console.log(`🌐 API base URL: ${API_BASE_URL}`);
     console.log(`🤖 Model: ${MODEL_KEYS.join(', ')}`);
     console.log(`📚 Sources: ${SOURCES.join(', ')}`);
-    console.log(`🎭 Note: Sherlock Think Alpha is a CLOAKED model - identity TBD`);
     console.log(`⏭️  Strategy: Skip puzzles with existing explanations`);
     console.log('='.repeat(60));
 

--- a/server/config/models.ts
+++ b/server/config/models.ts
@@ -1,9 +1,9 @@
 /*
  *
  * Author: Claude Code using Sonnet 4.5
- * Date: 2025-11-15
+ * Date: 2025-11-20
  * PURPOSE: Centralized AI model configuration list consumed by ModelDefinitions and provider lookup utilities.
- *          Added Sherlock Think Alpha (cloaked OpenRouter model) - will need normalization when revealed.
+ *          Updated Sherlock Think Alpha → Grok 4.1 Fast Reasoning (revealed Nov 20, 2025).
  * SRP/DRY check: Pass - file encapsulates shared model metadata without duplication.
  * shadcn/ui: Pass - configuration only.
  */
@@ -827,21 +827,20 @@ export const MODELS: ModelConfig[] = [
   },
 
   {
-    key: 'openrouter/sherlock-think-alpha',
-    name: 'Sherlock Think Alpha',
+    key: 'x-ai/grok-4.1-fast',
+    name: 'Grok 4.1 Fast Reasoning',
     color: 'bg-fuchsia-600',
     premium: false,
-    cost: { input: '$0.00', output: '$0.00' },
+    cost: { input: '$0.20', output: '$0.50' },
     supportsTemperature: true,
     provider: 'OpenRouter',
     responseTime: { speed: 'moderate', estimate: '1-2 min' },
     isReasoning: true,
-    apiModelName: 'openrouter/sherlock-think-alpha',
+    apiModelName: 'x-ai/grok-4.1-fast',
     modelType: 'openrouter',
-    contextWindow: 1840000,
-    maxOutputTokens: 120000,
-    releaseDate: "2025-11",
-    notes: 'CLOAKED MODEL - identity will be revealed soon. Free promotional access.'
+    contextWindow: 2000000,
+    maxOutputTokens: 50000,
+    releaseDate: "2025-11"
   },
 
 ];

--- a/server/utils/modelNormalizer.ts
+++ b/server/utils/modelNormalizer.ts
@@ -60,6 +60,11 @@ export function normalizeModelName(modelName: string): string {
     normalized = 'openai/gpt-5.1';
   }
 
+  // Sherlock Think Alpha was revealed to be Grok 4.1 Fast Reasoning on Nov 20, 2025
+  if (normalized === 'openrouter/sherlock-think-alpha' || normalized.startsWith('openrouter/sherlock-think-alpha')) {
+    normalized = 'x-ai/grok-4.1-fast';
+  }
+
   return attemptSuffix ? `${normalized}${attemptSuffix}` : normalized;
 }
 


### PR DESCRIPTION
Sherlock Think Alpha was officially revealed to be xAI's Grok 4.1 Fast Reasoning model on November 20, 2025. Updated model configuration and added normalization mapping to preserve database integrity.

Changes:
- server/config/models.ts (lines 3-6, 830-843):
  * Updated model key: openrouter/sherlock-think-alpha → x-ai/grok-4.1-fast
  * Updated model name: "Sherlock Think Alpha" → "Grok 4.1 Fast Reasoning"
  * Updated pricing: $0.00 → $0.20 input, $0.50 output
  * Updated context window: 1,840,000 → 2,000,000 tokens
  * Updated maxOutputTokens: 120,000 → 50,000 tokens
  * Removed "CLOAKED MODEL" notes
  * Updated file header with reveal date

- server/utils/modelNormalizer.ts (lines 63-66):
  * Added normalization mapping for openrouter/sherlock-think-alpha → x-ai/grok-4.1-fast
  * Ensures existing database entries automatically resolve to new model name
  * Preserves analytics continuity with historical data

- analyze-openrouter-free-models.ts (lines 3-7, 19, 24, 45, 348-353):
  * Updated PURPOSE header and all references
  * Changed ModelKey type definition
  * Updated DEFAULT_MODEL_KEYS array
  * Updated console log messages

Model specs (Grok 4.1 Fast Reasoning):
- Context: 2M tokens
- Max output: 50k tokens
- Pricing: $0.20/M input, $0.50/M output
- Features: 28% faster latency, 50% lower hallucination rate vs Grok 4 Fast
- Tool-calling capabilities with Agent Tools API

Impact:
- Zero downtime (normalization at query time)
- Analytics continuity (historical data seamlessly merged)
- Data integrity preserved (existing DB entries unchanged)