### PR TITLE
fix: Add missing TypeScript properties for intelligent accordion system

### DIFF
--- a/client/src/components/puzzle/ModelProviderGroup.tsx
+++ b/client/src/components/puzzle/ModelProviderGroup.tsx
@@ -23,9 +23,11 @@ interface ModelProviderGroupProps {
       name: string;
       description?: string;
       models: ModelConfig[];
+      useInlineLabel?: boolean;
     }>;
     modelCount: number;
     totalModelCount: number;
+    shouldFlatten: boolean;
   };
   isExpanded: boolean;
   onToggle: () => void;


### PR DESCRIPTION
Added shouldFlatten and useInlineLabel to ModelProviderGroupProps interface to match the properties added by useModelGrouping hook. This fixes TypeScript compilation errors.