### PR TITLE
fix: Remove complex 10-query system and show all 10 featured puzzle IDs

### DIFF
--- a/client/src/pages/PuzzleBrowser.tsx
+++ b/client/src/pages/PuzzleBrowser.tsx
@@ -120,55 +120,18 @@ export default function PuzzleBrowser() {
 
   const { puzzles, isLoading, error } = usePuzzleList(filters);
 
-  // Fetch featured puzzles directly by ID - 10 individual API calls
-  const featured0 = useQuery<{ success: boolean; data: EnhancedPuzzleMetadata }>({
-    queryKey: [`/api/puzzle/task/${FEATURED_PUZZLE_IDS[0]}`],
-    queryFn: async () => { const res = await fetch(`/api/puzzle/task/${FEATURED_PUZZLE_IDS[0]}`); if (!res.ok) throw new Error('Failed'); return res.json(); }
-  });
-  const featured1 = useQuery<{ success: boolean; data: EnhancedPuzzleMetadata }>({
-    queryKey: [`/api/puzzle/task/${FEATURED_PUZZLE_IDS[1]}`],
-    queryFn: async () => { const res = await fetch(`/api/puzzle/task/${FEATURED_PUZZLE_IDS[1]}`); if (!res.ok) throw new Error('Failed'); return res.json(); }
-  });
-  const featured2 = useQuery<{ success: boolean; data: EnhancedPuzzleMetadata }>({
-    queryKey: [`/api/puzzle/task/${FEATURED_PUZZLE_IDS[2]}`],
-    queryFn: async () => { const res = await fetch(`/api/puzzle/task/${FEATURED_PUZZLE_IDS[2]}`); if (!res.ok) throw new Error('Failed'); return res.json(); }
-  });
-  const featured3 = useQuery<{ success: boolean; data: EnhancedPuzzleMetadata }>({
-    queryKey: [`/api/puzzle/task/${FEATURED_PUZZLE_IDS[3]}`],
-    queryFn: async () => { const res = await fetch(`/api/puzzle/task/${FEATURED_PUZZLE_IDS[3]}`); if (!res.ok) throw new Error('Failed'); return res.json(); }
-  });
-  const featured4 = useQuery<{ success: boolean; data: EnhancedPuzzleMetadata }>({
-    queryKey: [`/api/puzzle/task/${FEATURED_PUZZLE_IDS[4]}`],
-    queryFn: async () => { const res = await fetch(`/api/puzzle/task/${FEATURED_PUZZLE_IDS[4]}`); if (!res.ok) throw new Error('Failed'); return res.json(); }
-  });
-  const featured5 = useQuery<{ success: boolean; data: EnhancedPuzzleMetadata }>({
-    queryKey: [`/api/puzzle/task/${FEATURED_PUZZLE_IDS[5]}`],
-    queryFn: async () => { const res = await fetch(`/api/puzzle/task/${FEATURED_PUZZLE_IDS[5]}`); if (!res.ok) throw new Error('Failed'); return res.json(); }
-  });
-  const featured6 = useQuery<{ success: boolean; data: EnhancedPuzzleMetadata }>({
-    queryKey: [`/api/puzzle/task/${FEATURED_PUZZLE_IDS[6]}`],
-    queryFn: async () => { const res = await fetch(`/api/puzzle/task/${FEATURED_PUZZLE_IDS[6]}`); if (!res.ok) throw new Error('Failed'); return res.json(); }
-  });
-  const featured7 = useQuery<{ success: boolean; data: EnhancedPuzzleMetadata }>({
-    queryKey: [`/api/puzzle/task/${FEATURED_PUZZLE_IDS[7]}`],
-    queryFn: async () => { const res = await fetch(`/api/puzzle/task/${FEATURED_PUZZLE_IDS[7]}`); if (!res.ok) throw new Error('Failed'); return res.json(); }
-  });
-  const featured8 = useQuery<{ success: boolean; data: EnhancedPuzzleMetadata }>({
-    queryKey: [`/api/puzzle/task/${FEATURED_PUZZLE_IDS[8]}`],
-    queryFn: async () => { const res = await fetch(`/api/puzzle/task/${FEATURED_PUZZLE_IDS[8]}`); if (!res.ok) throw new Error('Failed'); return res.json(); }
-  });
-  const featured9 = useQuery<{ success: boolean; data: EnhancedPuzzleMetadata }>({
-    queryKey: [`/api/puzzle/task/${FEATURED_PUZZLE_IDS[9]}`],
-    queryFn: async () => { const res = await fetch(`/api/puzzle/task/${FEATURED_PUZZLE_IDS[9]}`); if (!res.ok) throw new Error('Failed'); return res.json(); }
-  });
+  // Fetch ALL puzzles with NO filters for featured section
+  const { puzzles: allPuzzles, isLoading: allPuzzlesLoading } = usePuzzleList({});
 
-  const featuredQueries = [featured0, featured1, featured2, featured3, featured4, featured5, featured6, featured7, featured8, featured9];
-
+  // Build curated featured set from unfiltered puzzle list
   const featuredPuzzles = React.useMemo(() => {
-    return featuredQueries.map(q => q.data?.success ? q.data.data : null).filter((p): p is EnhancedPuzzleMetadata => p !== null);
-  }, [featured0.data, featured1.data, featured2.data, featured3.data, featured4.data, featured5.data, featured6.data, featured7.data, featured8.data, featured9.data]);
+    const all = (allPuzzles || []) as unknown as EnhancedPuzzleMetadata[];
+    return FEATURED_PUZZLE_IDS
+      .map(id => all.find(p => p.id === id))
+      .filter((puzzle): puzzle is EnhancedPuzzleMetadata => Boolean(puzzle));
+  }, [allPuzzles]);
 
-  const isFeaturedLoading = featuredQueries.some(q => q.isLoading);
+  const isFeaturedLoading = allPuzzlesLoading;
 
   // Apply explanation filtering and sorting after getting puzzles from the hook (advanced browser only)
   const filteredPuzzles = React.useMemo(() => {


### PR DESCRIPTION
PROBLEM:
- Featured puzzles section was only showing 7 of 10 puzzle IDs
- Previous implementation used 10 individual API queries (insane overcomplexity)
- Main branch filtered featured puzzles from filtered list, excluding 3 multi-test puzzles

SOLUTION:
- Fetch ALL puzzles with NO filters for featured section using usePuzzleList({})
- Extract featured IDs from unfiltered list
- Simplified from 10 individual queries to 1 clean unfiltered fetch

RESULT:
- All 10 featured puzzle IDs now display correctly
- Bypasses multiTestFilter and other filters that were hiding puzzles
- Much cleaner, simpler code

Featured IDs guaranteed to show:
65b59efc, e3721c99, dd6b8c4b, 2ba387bc, 14754a24,
b457fec5, 891232d6, 7b5033c1, 981571dc, 136b0064