### PR TITLE
arc3: re-sync the authored task catalog, and report orphans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@
 # reference the old numbers.
 
 
+### Version 9.15.0  Sep 2, 2026
+
+- **Polished tasks now actually reach the play surface** (Author: Claude Opus 5 / Bubba sub-agent)
+  - **In plain language**: the 50 first-party tasks in `server/data/arc3-games/` are authored and polished in a private repository. Polishing them there changed nothing here — the two are joined by a publish step, and until someone ran it this repo kept serving the build it last imported. Two tasks had been polished upstream and the site was still serving their previous builds. Both are re-imported here: `t643da6ee` and `t715ea045`.
+  - **No id churned, which is the whole point.** A published id is a pure function of its upstream id, so an updated task is rewritten under the id it already had. All 50 rows in `arc3Triage.json` are keyed by those ids, as are the feedback rows and the human-play telemetry — an id change would type-check, sort, render, and address nothing. Verified after the import: the 50 manifest ids and the 50 triage ids are the same set, with an empty difference in both directions, and `manifest.json` came back byte-identical.
+  - **`import_authored_games.py` was already idempotent** — re-running it rewrites each task's bytes under the same id — so this needed no parallel path and no wrapper script. What it lacked was orphan detection: a task withdrawn upstream left a published file the manifest kept enumerating and the play surface kept serving. It now reports those. It does **not** delete them, deliberately: the id keys triage and telemetry rows that do not live in this repository, so retiring one is a decision to make with those in view, not a side effect of a sync.
+  - **New runbook** at `docs/2026-09-02-arc3-authored-resync.md`: the order the steps run in, the two gates that must pass before committing (`--check` on both scripts, plus a grep proving no upstream naming leaked onto an added line), and the reasoning for keeping this a **manual** step rather than a cron — it writes to a public permanent repo behind a judgement call no scheduler can make, it is gated on a human merge in someone else's repo, and polish cycles are bursty rather than periodic. The read-only `--check` half could be scheduled to *report* drift; that is the boss's call and nothing here installs it.
+  - **Checked**: before the import, the drift check named exactly 2 stale published files; after it, both `import_authored_games.py --check` and `build_authored_manifest.py --check` exit 0. `npx tsc --noEmit` shows the same 12 pre-existing errors as the unmodified checkout in the same worktree — no new ones. `npm run build` exits 0. Booted the server against the refreshed directory: `/api/arc3-community/games` returns 50, and the two re-imported tasks serve their new source.
+  - **Files**: added `docs/2026-09-02-arc3-authored-resync.md`. Modified `scripts/arc3/import_authored_games.py`, `server/data/arc3-games/t643da6ee.py`, `server/data/arc3-games/t715ea045.py`.
+
 ### Version 9.14.0  Sep 1, 2026
 
 - **23 tasks nobody could win have left the review queue** (Author: Claude Opus 5 / Bubba sub-agent)

--- a/docs/2026-09-02-arc3-authored-resync.md
+++ b/docs/2026-09-02-arc3-authored-resync.md
@@ -1,0 +1,106 @@
+<!--
+Author: Claude Opus 5 (Bubba sub-agent, label arc3-polish-resync)
+Date: 02-September-2026
+PURPOSE: The runbook for re-publishing our authored ARC-AGI-3 tasks into this repository
+after they are polished upstream. Records the order the steps have to run in, the two
+gates that must pass before anything is committed, and why this is a human-run step rather
+than a cron.
+SRP/DRY check: Pass -- sequencing and rationale only. The steps themselves live in
+scripts/arc3/import_authored_games.py and scripts/arc3/build_authored_manifest.py; this
+file does not reimplement them and no wrapper script duplicates them either.
+-->
+
+# Re-syncing the authored task catalog
+
+## What this is for
+
+`server/data/arc3-games/` is the first-party catalog the play surface serves — 50 task
+modules under opaque ids plus a generated `manifest.json`, read by
+`server/services/arc3Mirror/Arc3MirrorCatalog.ts` as its `local` source.
+
+Those tasks are authored in a private repository and polished there. Polishing that
+repository changes nothing here: the two are connected by a publish step, and until
+someone runs it this repository keeps serving the build it last imported. This document is
+that step.
+
+## The property that must not break
+
+A published id is `"t" + sha256("arena:" + <authoring id>)[:8]` — a pure function of the
+authoring id, with no randomness and no state. That is what makes a re-import safe:
+**an updated task is rewritten under the same id it already had.**
+
+Ids must not churn. All 50 rows in `server/services/arc3Mirror/arc3Triage.json` are keyed
+by them, as are the feedback rows and the human-play telemetry, and none of those live in
+this repository. An id change would not fail a build or a type-check; it would type-check,
+sort, render, and address nothing.
+
+`import_authored_games.py --check` exists to assert exactly this, and is the reason step 5
+below is not optional.
+
+## Order of operations
+
+Steps 1–3 happen in the authoring repository, 4 onward here. Run with `python3.13` or
+newer on both sides — several tasks use structural pattern matching, which the macOS
+system `python3` (3.9) cannot parse, and under it every task reports a bogus `SyntaxError`.
+
+Use `set -euo pipefail`, or run the commands unpiped. Piping a step into `tail` makes `$?`
+report the pipe, so a real failure reads as success.
+
+1. **Find stale builds.** In the authoring repo: `python3.13 check_dist_current.py`.
+   It reports any task whose packaged build no longer matches its source — i.e. a polish
+   cycle that never re-ran the packager. It compares content, not mtime; mtime
+   false-positives on comment-only edits, which packaging strips anyway.
+2. **Re-package each stale task**, one at a time.
+3. **Run the verifier for every task you re-packaged**, against both the source and the
+   packaged lane. **A task whose packaged lane fails does not get published.** Nothing
+   downstream catches it — a broken build still imports and still renders.
+4. **Import.** The source is the authoring repo's packaged directory, and `--map-out`
+   is mandatory and must point outside this repository:
+   ```
+   python3 scripts/arc3/import_authored_games.py \
+       --source /path/to/authoring/dist --map-out ~/somewhere/private/map.json
+   python3 scripts/arc3/build_authored_manifest.py
+   ```
+   Both are idempotent. Re-running with an unchanged source rewrites identical bytes.
+   The import prints a note if the published directory holds files the source no longer
+   produces; it does not delete them, and neither should you without checking what still
+   references the id.
+5. **Prove the round trip.** Both must exit 0:
+   ```
+   python3 scripts/arc3/import_authored_games.py --source <same dir> --map-out /tmp/x.json --check
+   python3 scripts/arc3/build_authored_manifest.py --check
+   ```
+6. **Prove nothing leaked.** The authoring names — filenames, class names, `gNNN` ids —
+   must not appear on any added line. `git diff --cached` and grep for them, driven off
+   the private map rather than from memory. This is the one step with no automated gate
+   behind it and it is the one that matters most: this repository is public and permanent.
+7. **Type-check and build.** Compare `npx tsc --noEmit` against a baseline captured on an
+   unmodified checkout in the same worktree — this tree carries pre-existing errors, so
+   the test is "no new ones", not "zero". `npm run build` must exit 0.
+
+## Import from the authoring repo's merged state, not a branch
+
+Publish from what the authoring repository's default branch actually contains. Importing
+a task from an unmerged branch puts bytes in this public repository that do not exist in
+the source of truth, and `--check` in step 5 then fails against that source and keeps
+failing until the branch merges. A task polished in an open PR waits for the merge and
+lands on the next sync.
+
+## Cron or manual?
+
+**Recommendation: manual. Do not schedule the publishing path.**
+
+- It writes to a public, permanent repository. The leak check in step 6 is a judgement
+  call with no automated gate; an unattended publish is only as trustworthy as that step,
+  and that step is the one a machine cannot make.
+- It is gated on a human merge in a private repository owned by someone else. A scheduler
+  cannot decide whether a PR is ready.
+- Polish cycles are bursty, not periodic. A task set can sit unchanged for a fortnight and
+  then move three times in a day, so a timer is wrong in both directions.
+- Step 3 can legitimately refuse to publish. "Verifier failed, publish nothing" needs a
+  person to read it, not a retry.
+
+**The scheduleable middle ground**, if drift going unnoticed is the actual worry: the
+`--check` invocations in step 5 are read-only and write nothing. Those could run on a
+timer purely to *report* that the catalog has drifted from upstream, leaving the publish
+itself manual. That is a separate decision and nothing here installs it.

--- a/scripts/arc3/import_authored_games.py
+++ b/scripts/arc3/import_authored_games.py
@@ -31,6 +31,19 @@ PURPOSE: Publish OUR hand-authored ARC-AGI-3 candidate tasks INTO this repo, und
          refuses to write inside the repository: a committed slug->id table would undo
          everything above in one file.
 
+         RE-RUNNING IS THE POINT, NOT AN EDGE CASE. A published id is a pure function of
+         the authoring id, so importing an updated batch rewrites each game's bytes UNDER
+         THE SAME id. That is what makes this the resync path as well as the first-import
+         path: ids must not churn, because arc3Triage.json's rows, the human-play
+         telemetry and the feedback rows are all keyed by them. Re-running with an
+         unchanged source is a no-op that rewrites identical bytes.
+
+         ORPHANS ARE REPORTED, NEVER DELETED. A game withdrawn upstream leaves a
+         published file this import no longer produces. Deleting it is NOT this script's
+         call -- the id still keys triage and telemetry rows, so retiring one is a
+         decision with consequences outside this repository. Both modes print orphans and
+         neither removes them; the exit code is unaffected.
+
          Dependencies: stdlib only (ast, argparse, hashlib, json, pathlib, re).
          Usage (source dir is required; no path to a private repo is baked in):
              python3 scripts/arc3/import_authored_games.py \
@@ -208,6 +221,29 @@ def build(source: Path) -> list[dict[str, str]]:
     return published
 
 
+def orphans(out_dir: Path, published: list[dict[str, str]]) -> list[str]:
+    """Published modules in `out_dir` that this import does not produce, sorted.
+
+    A game withdrawn upstream stops appearing in the source manifest but its published
+    file stays on disk, where build_authored_manifest.py keeps enumerating it into the
+    catalog and the play surface keeps serving it. Detected here because this is the only
+    step that knows the full set the source SHOULD produce.
+
+    Reported and not deleted, deliberately: the id keys triage rows, feedback rows and
+    human-play telemetry, none of which live in this repository, so retiring one is a
+    decision that has to be made with those in view rather than as a side effect of a
+    sync. The manifest builder will also refuse a filename that is not a published id, so
+    a stray file cannot masquerade as a game.
+    """
+    if not out_dir.is_dir():
+        return []
+    expected = {item["gameId"] for item in published}
+    return sorted(
+        path.stem for path in out_dir.glob("*.py")
+        if not path.name.startswith("__") and path.stem not in expected
+    )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Publish authored ARC-AGI-3 tasks into this repo under opaque names.")
     parser.add_argument("--source", type=Path, required=True, help="directory of authored task modules")
@@ -226,6 +262,15 @@ def main() -> int:
         return 1
 
     published = build(args.source)
+
+    stray = orphans(args.out, published)
+    if stray:
+        print(
+            f"note: {len(stray)} published file(s) are no longer produced by this source: "
+            f"{stray}. Nothing was deleted -- these ids key triage and telemetry rows; "
+            "retiring one is a deliberate decision, not a side effect of a sync.",
+            file=sys.stderr,
+        )
 
     if args.check:
         stale = []

--- a/server/data/arc3-games/t643da6ee.py
+++ b/server/data/arc3-games/t643da6ee.py
@@ -9,278 +9,235 @@ from arcengine import (
     GameAction,
     InteractionMode,
     Level,
-    RenderableUserDisplay,
     Sprite,
 )
 
-FLOOR = 4
-WALL = 1
-COIN = 11
-FUSE_BG = 5
-FUSE_PIP = 8
-SEALED = 13
-EXIT_LOCKED = 15
-EXIT_OPEN = 14
-PLAYER = 12
-PIP_ON = 11
-PIP_OFF = 3
+VOID_BG = 0
+SPAN_FLOOR = 9
+BEAD_MARK = 0
+FRAY_BG = 13
+FRAY_PIP = 0
+COLLAPSED_TILE = 13
+EXIT_SHUT = 15
+EXIT_OPEN = 10
+PLAYER = 6
 
-N = 16
+SPAN = 13
 CELL = 4
+ORIGIN = (64 - SPAN * CELL) // 2
 
-MAX_FUSE = 12
+LOAN = 10
 
-LEVELS_SPEC = [
-    {"fuse": 10, "greedy_dies": False, "rows": [
-        "################",
-        "#......#.......#",
-        "#.P....#.......#",
-        "#......#.......#",
-        "#......#.......#",
-        "#......#.......#",
-        "#......#.......#",
-        "#......c.......#",
-        "#......#.......#",
-        "#......#.......#",
-        "#......#...X...#",
-        "#......#.......#",
-        "#......#.......#",
-        "#......#.......#",
-        "#......#.......#",
-        "################",
-    ]},
-    {"fuse": 8, "greedy_dies": True, "rows": [
-        "################",
-        "#c......#......#",
-        "#.......#......#",
-        "#.......#..X...#",
-        "#.......#......#",
-        "#.......#......#",
-        "#.......#......#",
-        "#.......#......#",
-        "#.......c......#",
-        "#.......#......#",
-        "#.......#......#",
-        "#.......#......#",
-        "#.......#......#",
-        "#.....P.#......#",
-        "#.......#.....c#",
-        "################",
-    ]},
-    {"fuse": 8, "greedy_dies": True, "rows": [
-        "################",
-        "#....#....#....#",
-        "#....#....#..X.#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#.c..c....c....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#....#..P.#....#",
-        "#....#....#....#",
-        "################",
-    ]},
-    {"fuse": 8, "greedy_dies": True, "rows": [
-        "################",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#.c..c....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#....#...P#....#",
-        "#....##c#.c..X.#",
-        "#....#...#.....#",
-        "#....#.c.#.....#",
-        "################",
-    ]},
-    {"fuse": 7, "greedy_dies": True, "rows": [
-        "################",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#.c..c....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "######..P.c..X.#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#.c..c....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "################",
-    ]},
-    {"fuse": 6, "greedy_dies": True, "rows": [
-        "################",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#..c.c....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "######....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#....#....#....#",
-        "#..c.c...Pc....#",
-        "#....#....#....#",
-        "#....#....#..X.#",
-        "#....#....#....#",
-        "################",
-    ]},
-    {"fuse": 6, "greedy_dies": False, "rows": [
-        "################",
-        "################",
-        "##.....P......##",
-        "##.##.#######.##",
-        "##.##.#######.##",
-        "##c##c#######.##",
-        "##.##########.##",
-        "##.##########.##",
-        "##...X#######c##",
-        "##.##########.##",
-        "##.#######c##.##",
-        "##.#######.##.##",
-        "##.#######.##.##",
-        "##............##",
-        "################",
-        "################",
-    ]},
-    {"fuse": 6, "greedy_dies": True, "rows": [
-        "################",
-        "################",
-        "##............##",
-        "##P##.#######.##",
-        "##.##.#######.##",
-        "##c##c#######.##",
-        "##.##########.##",
-        "##.##########.##",
-        "##.c.X#######c##",
-        "##.##########.##",
-        "##.#######c##.##",
-        "##.#######.##.##",
-        "##.#######.##.##",
-        "##............##",
-        "################",
-        "################",
-    ]},
+BOARDS = [
+    [
+        ".............",
+        ".@-----*----.",
+        "...........-.",
+        "...........-.",
+        "...........-.",
+        "...........-.",
+        "...........-.",
+        "...........-.",
+        "...........-.",
+        "...........-.",
+        "...........-.",
+        "...........O.",
+        ".............",
+    ],
+    [
+        ".............",
+        ".............",
+        ".............",
+        ".O--*----*-..",
+        "......-......",
+        "......-......",
+        "......-......",
+        "......-......",
+        "......-......",
+        "......-----..",
+        "..........-..",
+        "..........@..",
+        ".............",
+    ],
+    [
+        ".............",
+        ".............",
+        ".............",
+        "..O..........",
+        "..-..........",
+        "..-..........",
+        "..--------*..",
+        "......*......",
+        "......-......",
+        "......-......",
+        ".-*---@......",
+        ".............",
+        ".............",
+    ],
+    [
+        ".............",
+        ".............",
+        "......O......",
+        "......-......",
+        "......-......",
+        "......-......",
+        "......*......",
+        ".-*-------*-.",
+        "......-......",
+        "......-......",
+        "......-......",
+        "......@......",
+        ".............",
+    ],
+    [
+        ".............",
+        ".............",
+        ".............",
+        ".............",
+        "......O......",
+        "......-......",
+        "......-......",
+        ".....--......",
+        ".....**......",
+        ".-----@-----.",
+        ".*.........*.",
+        ".............",
+        ".............",
+    ],
+    [
+        ".............",
+        ".............",
+        ".............",
+        ".............",
+        "....--*--....",
+        "....-...-....",
+        "....*...*....",
+        "....-...-....",
+        "....-@*--....",
+        "......-......",
+        "......O......",
+        ".............",
+        ".............",
+    ],
+    [
+        ".............",
+        ".*----------.",
+        ".-....-....-.",
+        ".-....*....-.",
+        ".-....-....-.",
+        ".-...---...-.",
+        ".--*--O--*--.",
+        ".-...---...-.",
+        ".-.........-.",
+        ".-.........-.",
+        ".-.........-.",
+        ".-----@----*.",
+        ".............",
+    ],
 ]
 
+WALKABLE = "-*@O"
+UNLIFTED = -1
+STONE = 0
 
-def find_char(rows, ch):
+
+def cell_of(rows: list[str], mark: str) -> tuple[int, int]:
     for y, row in enumerate(rows):
-        for x, c in enumerate(row):
-            if c == ch:
+        for x, char in enumerate(row):
+            if char == mark:
                 return x, y
-    raise AssertionError(f"level has no {ch!r}")
+    raise AssertionError(f"board has no {mark!r}")
 
 
-def coin_cells(rows):
-    return [(x, y) for y, r in enumerate(rows) for x, c in enumerate(r) if c == "c"]
+def bead_cells(rows: list[str]) -> list[tuple[int, int]]:
+    return [(x, y) for y, row in enumerate(rows)
+            for x, char in enumerate(row) if char == "*"]
 
 
-def _solid(colour: int) -> list[list[int]]:
+def is_span(rows: list[str], cell: tuple[int, int]) -> bool:
+    x, y = cell
+    if not (0 <= x < SPAN and 0 <= y < SPAN):
+        return False
+    return rows[y][x] in WALKABLE
+
+
+def _flat(colour: int) -> list[list[int]]:
     return [[colour] * CELL for _ in range(CELL)]
 
 
-def _coin_pixels() -> list[list[int]]:
+def _bead_face() -> list[list[int]]:
     return [
-        [FLOOR, COIN, COIN, FLOOR],
-        [COIN, COIN, COIN, COIN],
-        [COIN, COIN, COIN, COIN],
-        [FLOOR, COIN, COIN, FLOOR],
+        [SPAN_FLOOR, BEAD_MARK, BEAD_MARK, SPAN_FLOOR],
+        [BEAD_MARK, BEAD_MARK, BEAD_MARK, BEAD_MARK],
+        [BEAD_MARK, BEAD_MARK, BEAD_MARK, BEAD_MARK],
+        [SPAN_FLOOR, BEAD_MARK, BEAD_MARK, SPAN_FLOOR],
     ]
 
 
-def _fuse_pixels(remaining: int) -> list[list[int]]:
-    px = [[FUSE_BG] * CELL for _ in range(CELL)]
-    for i in range(min(remaining, CELL * CELL)):
-        px[i // CELL][i % CELL] = FUSE_PIP
-    return px
+def _fray_face(left: int) -> list[list[int]]:
+    face = [[FRAY_BG] * CELL for _ in range(CELL)]
+    for i in range(min(left, CELL * CELL)):
+        face[CELL - 1 - (i // CELL)][i % CELL] = FRAY_PIP
+    return face
+
+
+def _wearing(face: list[list[int]]) -> list[list[int]]:
+    worn = [row[:] for row in face]
+    for y in (1, 2):
+        for x in (1, 2):
+            worn[y][x] = PLAYER
+    return worn
 
 
 def build_levels() -> list[Level]:
     levels: list[Level] = []
-    for spec in LEVELS_SPEC:
-        sprites: list[Sprite] = []
-        for y, row in enumerate(spec["rows"]):
+    for rows in BOARDS:
+        pieces: list[Sprite] = []
+        for y, row in enumerate(rows):
             for x, char in enumerate(row):
-                px, py = x * CELL, y * CELL
-                if char == "#":
-                    sprites.append(Sprite(
-                        pixels=_solid(WALL), name=f"wall_{x}_{y}",
-                        blocking=BlockingMode.BOUNDING_BOX,
-                        interaction=InteractionMode.TANGIBLE, layer=-1,
-                    ).set_position(px, py))
-                elif char == "c":
-                    sprites.append(Sprite(
-                        pixels=_coin_pixels(), name=f"coin_{x}_{y}",
-                        blocking=BlockingMode.NOT_BLOCKED,
-                        interaction=InteractionMode.TANGIBLE, layer=0,
-                        tags=["coin"],
-                    ).set_position(px, py))
-                elif char == "X":
-                    sprites.append(Sprite(
-                        pixels=_solid(EXIT_LOCKED), name="exit",
-                        blocking=BlockingMode.BOUNDING_BOX,
-                        interaction=InteractionMode.TANGIBLE, layer=0, tags=["exit"],
-                    ).set_position(px, py))
-                elif char == "P":
-                    sprites.append(Sprite(
-                        pixels=_solid(PLAYER), name="player",
-                        blocking=BlockingMode.BOUNDING_BOX,
-                        interaction=InteractionMode.TANGIBLE, layer=1,
-                    ).set_position(px, py))
-        levels.append(Level(sprites=sprites, grid_size=(N * CELL, N * CELL)))
+                if char not in WALKABLE:
+                    continue
+                px, py = ORIGIN + x * CELL, ORIGIN + y * CELL
+                if char == "*":
+                    face, tag, name = _bead_face(), "bead", f"bead_{x}_{y}"
+                elif char == "O":
+                    face, tag, name = _flat(EXIT_SHUT), "mouth", "mouth"
+                else:
+                    face, tag, name = _flat(SPAN_FLOOR), "span", f"span_{x}_{y}"
+                pieces.append(Sprite(
+                    pixels=face, name=name, blocking=BlockingMode.NOT_BLOCKED,
+                    interaction=InteractionMode.TANGIBLE, layer=0, tags=[tag],
+                ).set_position(px, py))
+        start = cell_of(rows, "@")
+        pieces.append(Sprite(
+            pixels=_wearing(_flat(SPAN_FLOOR)), name="wader",
+            blocking=BlockingMode.NOT_BLOCKED,
+            interaction=InteractionMode.TANGIBLE, layer=1,
+        ).set_position(ORIGIN + start[0] * CELL, ORIGIN + start[1] * CELL))
+        levels.append(Level(sprites=pieces, grid_size=(64, 64)))
     return levels
-
-
-class G49fbd3f6(RenderableUserDisplay):
-
-    def __init__(self, game: "G8d6b057c") -> None:
-        super().__init__()
-        self._game = game
-
-    def render_interface(self, frame: np.ndarray) -> np.ndarray:
-        cells = self._game.coin_order
-        for i, cell in enumerate(cells):
-            x = 1 + i * 3
-            if x + 2 > frame.shape[1]:
-                break
-            lit = self._game.status.get(cell, 0) == -1
-            frame[1:3, x:x + 2] = PIP_ON if lit else PIP_OFF
-        return frame
 
 
 class G8d6b057c(ARCBaseGame):
 
     def __init__(self) -> None:
-        self.status: dict[tuple[int, int], int] = {}
-        self.coin_order: list[tuple[int, int]] = []
-        camera = Camera(
-            width=N * CELL, height=N * CELL,
-            background=FLOOR, letter_box=5,
-            interfaces=[G49fbd3f6(self)],
+        self.ledger: dict[tuple[int, int], int] = {}
+        self.here: tuple[int, int] = (0, 0)
+        super().__init__(
+            game_id="t643da6ee", levels=build_levels(),
+            camera=Camera(width=64, height=64,
+                          background=VOID_BG, letter_box=VOID_BG),
         )
-        super().__init__(game_id="t643da6ee", levels=build_levels(), camera=camera)
         self.on_set_level(self.current_level)
 
+    @property
+    def rows(self) -> list[str]:
+        return BOARDS[self.level_index]
+
     def on_set_level(self, level: Level) -> None:
-        rows = LEVELS_SPEC[self.level_index]["rows"]
-        self.coin_order = coin_cells(rows)
-        self.status = {cell: -1 for cell in self.coin_order}
-        self._sync_sprites()
+        self.ledger = {cell: UNLIFTED for cell in bead_cells(self.rows)}
+        self.here = cell_of(self.rows, "@")
+        self._repaint()
 
     def level_reset(self) -> None:
         super().level_reset()
@@ -290,80 +247,76 @@ class G8d6b057c(ARCBaseGame):
         super().full_reset()
         self.on_set_level(self.current_level)
 
-    def _sprite(self, name: str) -> Sprite | None:
+    def _piece(self, name: str) -> Sprite | None:
         found = self.current_level.get_sprites_by_name(name)
         return found[0] if found else None
 
-    def _paint(self, sprite: Sprite, pixels: list[list[int]]) -> None:
-        sprite.pixels[:, :] = np.array(pixels, dtype=np.int8)
+    def _face_of(self, cell: tuple[int, int]) -> list[list[int]]:
+        state = self.ledger.get(cell)
+        if state == UNLIFTED:
+            return _bead_face()
+        if state is not None and state > STONE:
+            return _fray_face(state)
+        if state == STONE:
+            return _flat(COLLAPSED_TILE)
+        if self.rows[cell[1]][cell[0]] == "O":
+            return _flat(EXIT_OPEN if self.all_lifted() else EXIT_SHUT)
+        return _flat(SPAN_FLOOR)
 
-    def _sync_sprites(self) -> None:
-        for cell, st in self.status.items():
-            sprite = self._sprite(f"coin_{cell[0]}_{cell[1]}")
-            if sprite is None:
-                continue
-            if st == -1:
-                self._paint(sprite, _coin_pixels())
-                sprite.set_blocking(BlockingMode.NOT_BLOCKED)
-            elif st > 0:
-                self._paint(sprite, _fuse_pixels(st))
-                sprite.set_blocking(BlockingMode.NOT_BLOCKED)
-            else:
-                self._paint(sprite, _solid(SEALED))
-                sprite.set_blocking(BlockingMode.BOUNDING_BOX)
-        exit_sprite = self._sprite("exit")
-        if exit_sprite is not None:
-            if self.all_collected():
-                self._paint(exit_sprite, _solid(EXIT_OPEN))
-                exit_sprite.set_blocking(BlockingMode.NOT_BLOCKED)
-            else:
-                self._paint(exit_sprite, _solid(EXIT_LOCKED))
-                exit_sprite.set_blocking(BlockingMode.BOUNDING_BOX)
+    def _dress(self, piece: Sprite | None, face: list[list[int]]) -> None:
+        if piece is not None:
+            piece.pixels[:, :] = np.array(face, dtype=np.int8)
 
-    def all_collected(self) -> bool:
-        return all(st != -1 for st in self.status.values())
+    def _repaint(self) -> None:
+        for cell in self.ledger:
+            self._dress(self._piece(f"bead_{cell[0]}_{cell[1]}"), self._face_of(cell))
+        mouth = self._piece("mouth")
+        if mouth is not None:
+            self._dress(mouth, _flat(EXIT_OPEN if self.all_lifted() else EXIT_SHUT))
+        wader = self._piece("wader")
+        if wader is not None:
+            self._dress(wader, _wearing(self._face_of(self.here)))
+            wader.set_position(ORIGIN + self.here[0] * CELL, ORIGIN + self.here[1] * CELL)
 
-    def player_cell(self) -> tuple[int, int]:
-        player = self._sprite("player")
-        if player is None:
-            return -1, -1
-        return player.x // CELL, player.y // CELL
+    def all_lifted(self) -> bool:
+        return all(state != UNLIFTED for state in self.ledger.values())
+
+    def underfoot(self) -> tuple[int, int]:
+        return self.here
+
+    def passable(self, cell: tuple[int, int]) -> bool:
+        if not is_span(self.rows, cell):
+            return False
+        if self.ledger.get(cell) == STONE:
+            return False
+        if self.rows[cell[1]][cell[0]] == "O" and not self.all_lifted():
+            return False
+        return True
 
     def step(self) -> None:
-        dx = dy = 0
-        if self.action.id == GameAction.ACTION1:
-            dy = -1
-        elif self.action.id == GameAction.ACTION2:
-            dy = 1
-        elif self.action.id == GameAction.ACTION3:
-            dx = -1
-        elif self.action.id == GameAction.ACTION4:
-            dx = 1
+        moves = {GameAction.ACTION1: (0, -1), GameAction.ACTION2: (0, 1),
+                 GameAction.ACTION3: (-1, 0), GameAction.ACTION4: (1, 0)}
+        step = moves.get(self.action.id)
+        if step is not None:
+            ahead = (self.here[0] + step[0], self.here[1] + step[1])
+            if self.passable(ahead):
+                self.here = ahead
 
-        if dx or dy:
-            self.try_move("player", dx * CELL, dy * CELL)
+        if self.ledger.get(self.here) == UNLIFTED:
+            self.ledger[self.here] = LOAN + 1
+        for cell, state in list(self.ledger.items()):
+            if state > STONE:
+                self.ledger[cell] = state - 1
 
-        cell = self.player_cell()
-        fuse = LEVELS_SPEC[self.level_index]["fuse"]
-
-        if self.status.get(cell, 0) == -1:
-            self.status[cell] = min(fuse, MAX_FUSE) + 1
-
-        for burning, st in list(self.status.items()):
-            if st > 0:
-                self.status[burning] = st - 1
-
-        if self.status.get(cell, -1) == 0:
-            self._sync_sprites()
+        if self.ledger.get(self.here, UNLIFTED) == STONE:
+            self._repaint()
             self.level_reset()
             self.complete_action()
             return
 
-        self._sync_sprites()
+        self._repaint()
 
-        exit_sprite = self._sprite("exit")
-        if exit_sprite is not None and self.all_collected():
-            if (exit_sprite.x // CELL, exit_sprite.y // CELL) == cell:
-                self.next_level()
+        if self.all_lifted() and self.here == cell_of(self.rows, "O"):
+            self.next_level()
 
         self.complete_action()

--- a/server/data/arc3-games/t715ea045.py
+++ b/server/data/arc3-games/t715ea045.py
@@ -15,23 +15,29 @@ from arcengine import (
     Sprite,
 )
 
-FLOOR = 4
-WALL = 1
-PIT = 15
-EXIT = 14
-PLAYER = 12
-UNKNOWN = 5
-PIP_ON = 11
-PIP_OFF = 3
+SMOKE = 2
+TILE = 5
+BLOCK = 0
+FIRE = 8
+GATE = 10
+AVATAR = 6
+BORDER = 13
+BAR = 15
+BAR_SPENT = 5
 
-CELL = 4
-PULSE_RADIUS = 6
+FRAME = 64
+N = 20
+CELL = 3
+OX = 1
+OY = 2
+GUTTER = OX + N * CELL
+FLASH_REACH = 5
 
 OPEN_CHARS = ".PX"
 DIRS = ((0, -1), (0, 1), (-1, 0), (1, 0))
 
 
-def pulse_reveal(rows, sx, sy, radius=PULSE_RADIUS):
+def pulse_reveal(rows, sx, sy, reach=FLASH_REACH):
     learned = {(sx, sy)}
     seen = {(sx, sy)}
     queue = deque([(sx, sy, 0)])
@@ -42,7 +48,7 @@ def pulse_reveal(rows, sx, sy, radius=PULSE_RADIUS):
             if not (0 <= nx < len(rows[0]) and 0 <= ny < len(rows)):
                 continue
             if rows[ny][nx] in OPEN_CHARS:
-                if dist + 1 <= radius and (nx, ny) not in seen:
+                if dist + 1 <= reach and (nx, ny) not in seen:
                     seen.add((nx, ny))
                     learned.add((nx, ny))
                     queue.append((nx, ny, dist + 1))
@@ -51,136 +57,160 @@ def pulse_reveal(rows, sx, sy, radius=PULSE_RADIUS):
     return learned
 
 
+def walkable_from(rows, known, start):
+    if start not in known:
+        return set()
+    reached = {start}
+    queue = deque([start])
+    while queue:
+        x, y = queue.popleft()
+        for dx, dy in DIRS:
+            n = (x + dx, y + dy)
+            if n in reached or n not in known:
+                continue
+            if not (0 <= n[0] < len(rows[0]) and 0 <= n[1] < len(rows)):
+                continue
+            if rows[n[1]][n[0]] not in OPEN_CHARS:
+                continue
+            reached.add(n)
+            queue.append(n)
+    return reached
+
+
 LEVELS_SPEC = [
-    {"pulses": 2, "rows": [
-        "################",
-        "#..............#",
-        "#..............#",
-        "#..P...........#",
-        "#..............#",
-        "#......X.......#",
-        "#..............#",
-        "#..............#",
-        "#..............#",
-        "#..............#",
-        "#..............#",
-        "#..............#",
-        "#..............#",
-        "#..............#",
-        "#..............#",
-        "################",
+    {"charges": 2, "rows": [
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "#######......#######",
+        "#######......#######",
+        "#######..P...#######",
+        "#######......#######",
+        "#######.....X#######",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
     ]},
-    {"pulses": 3, "rows": [
-        "################",
-        "#..............#",
-        "#..P...........#",
-        "#..............#",
-        "#####.##########",
-        "#..............#",
-        "#..............#",
-        "#..............#",
-        "#..............#",
-        "#..............#",
-        "#.........X....#",
-        "#..............#",
-        "#..............#",
-        "#..............#",
-        "#..............#",
-        "################",
+    {"charges": 3, "rows": [
+        "####################",
+        "####################",
+        "##.....#.........###",
+        "##.....#.........###",
+        "##..P............###",
+        "##.....#.........###",
+        "##.....#....X....###",
+        "########.........###",
+        "########.........###",
+        "########.........###",
+        "########.........###",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
     ]},
-    {"pulses": 4, "rows": [
-        "################",
-        "#..............#",
-        "#..P...........#",
-        "#......o.......#",
-        "#####.##########",
-        "#..............#",
-        "#...o.....o....#",
-        "#..............#",
-        "#.....o........#",
-        "#..............#",
-        "#.........X....#",
-        "#..o......o....#",
-        "#..............#",
-        "#..............#",
-        "#..............#",
-        "################",
+    {"charges": 4, "rows": [
+        "####################",
+        "####################",
+        "##.......#........##",
+        "##.P.....#........##",
+        "##.......#........##",
+        "##.......#....f...##",
+        "##.......f........##",
+        "##................##",
+        "##.......f........##",
+        "##.......#..X.....##",
+        "##.......#.f......##",
+        "##.......#........##",
+        "##.......#........##",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
     ]},
-    {"pulses": 3, "rows": [
-        "################",
-        "#.####.........#",
-        "#.#P#..........#",
-        "#.#.#..........#",
-        "#.#.#..........#",
-        "#.#.#..........#",
-        "#.#.#####.######",
-        "#.#............#",
-        "#.#....o.......#",
-        "#.#............#",
-        "#.#........X...#",
-        "#.#....o.......#",
-        "#.#............#",
-        "#..............#",
-        "#..............#",
-        "################",
+    {"charges": 3, "rows": [
+        "####################",
+        "####################",
+        "##P#################",
+        "##.#################",
+        "##.#################",
+        "##.#################",
+        "##.#################",
+        "##.f..............##",
+        "##...........f....##",
+        "##...f....X.......##",
+        "##................##",
+        "##......f.........##",
+        "##................##",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
+        "####################",
     ]},
-    {"pulses": 3, "rows": [
-        "################",
-        "#..P...#.......#",
-        "#......#.......#",
-        "#......#.......#",
-        "#..###.#.......#",
-        "#....#.#...o...#",
-        "####.#.#.......#",
-        "#....#...#######",
-        "#.####.........#",
-        "#......o.......#",
-        "#.####.........#",
-        "#....#.....X...#",
-        "#.o..#.........#",
-        "#....#.........#",
-        "#..............#",
-        "################",
+    {"charges": 4, "rows": [
+        "####################",
+        "####################",
+        "##.......#........##",
+        "##.......#........##",
+        "##..P.............##",
+        "##.......#........##",
+        "##.......#........##",
+        "###f.f####........##",
+        "##.......#........##",
+        "##.......###########",
+        "##.......#........##",
+        "##................##",
+        "##.......#..f.....##",
+        "##.......#........##",
+        "##########....X...##",
+        "##########........##",
+        "##########.....f..##",
+        "##########........##",
+        "####################",
+        "####################",
     ]},
-    {"pulses": 3, "rows": [
-        "################",
-        "#..P..#........#",
-        "#.....#........#",
-        "#.....#....o...#",
-        "#.###.#........#",
-        "#...#.#........#",
-        "##..#.####.#####",
-        "#...#..........#",
-        "#.###....o.....#",
-        "#........#.....#",
-        "#..o.....#..X..#",
-        "#........#.....#",
-        "#..#######.....#",
-        "#..............#",
-        "#..............#",
-        "################",
-    ]},
-    {"pulses": 5, "rows": [
-        "################",
-        "#....#.........#",
-        "#..P.#.........#",
-        "#....#....o....#",
-        "#....#.........#",
-        "#.##.#.........#",
-        "#..#.#####.#####",
-        "#..#.....#.....#",
-        "#..#..o..#.....#",
-        "#..#.....#..X..#",
-        "#..#.....#.....#",
-        "#..#####.#.....#",
-        "#......o.#.....#",
-        "#........#.....#",
-        "#..............#",
-        "################",
+    {"charges": 5, "rows": [
+        "####################",
+        "####################",
+        "##.....#.....#....##",
+        "##.P..f#.....#....##",
+        "##................##",
+        "##.....#f....#....##",
+        "##.....#...f.#....##",
+        "####.#####.#########",
+        "##.....#...f.#....##",
+        "##.....#.....#....##",
+        "##..f..#..........##",
+        "##.....#....f#....##",
+        "##.....#.....#..f.##",
+        "####.##########.####",
+        "##.....#.....#....##",
+        "##.....#......X...##",
+        "##........f..#....##",
+        "##.....#.....#....##",
+        "####################",
+        "####################",
     ]},
 ]
-
-N = len(LEVELS_SPEC[0]["rows"])
 
 
 def _cell_block(colour: int) -> list[list[int]]:
@@ -193,101 +223,105 @@ def build_levels() -> list[Level]:
         sprites: list[Sprite] = []
         for y, row in enumerate(spec["rows"]):
             for x, char in enumerate(row):
-                px, py = x * CELL, y * CELL
+                px, py = OX + x * CELL, OY + y * CELL
                 if char == "#":
                     sprites.append(Sprite(
-                        pixels=_cell_block(WALL), name=f"wall_{x}_{y}",
+                        pixels=_cell_block(BLOCK), name=f"masonry_{x}_{y}",
                         blocking=BlockingMode.BOUNDING_BOX,
                         interaction=InteractionMode.TANGIBLE, layer=-1,
                     ).set_position(px, py))
-                elif char == "o":
+                elif char == "f":
                     sprites.append(Sprite(
-                        pixels=_cell_block(PIT), name=f"pit_{x}_{y}",
+                        pixels=_cell_block(FIRE), name=f"fire_{x}_{y}",
                         blocking=BlockingMode.BOUNDING_BOX,
-                        interaction=InteractionMode.TANGIBLE, layer=0, tags=["pit"],
+                        interaction=InteractionMode.TANGIBLE, layer=0, tags=["fire"],
                     ).set_position(px, py))
                 elif char == "X":
                     sprites.append(Sprite(
-                        pixels=_cell_block(EXIT), name="exit",
+                        pixels=_cell_block(GATE), name="gate",
                         blocking=BlockingMode.BOUNDING_BOX,
-                        interaction=InteractionMode.TANGIBLE, layer=0, tags=["exit"],
+                        interaction=InteractionMode.TANGIBLE, layer=0, tags=["gate"],
                     ).set_position(px, py))
                 elif char == "P":
                     sprites.append(Sprite(
-                        pixels=_cell_block(PLAYER), name="player",
+                        pixels=_cell_block(AVATAR), name="avatar",
                         blocking=BlockingMode.BOUNDING_BOX,
                         interaction=InteractionMode.TANGIBLE, layer=1,
                     ).set_position(px, py))
-        levels.append(Level(sprites=sprites, grid_size=(N * CELL, N * CELL)))
+        levels.append(Level(sprites=sprites, grid_size=(FRAME, FRAME)))
     return levels
 
 
-class Ge31d9375(RenderableUserDisplay):
+class G87b4c1e0(RenderableUserDisplay):
 
     def __init__(self, game: "Ge05b1417") -> None:
         super().__init__()
         self._game = game
 
     def render_interface(self, frame: np.ndarray) -> np.ndarray:
-        out = np.full_like(frame, UNKNOWN)
+        out = np.full_like(frame, BORDER)
+        out[OY:OY + N * CELL, OX:OX + N * CELL] = SMOKE
         for x, y in self._game.known:
             if 0 <= x < N and 0 <= y < N:
-                out[y * CELL:(y + 1) * CELL, x * CELL:(x + 1) * CELL] = \
-                    frame[y * CELL:(y + 1) * CELL, x * CELL:(x + 1) * CELL]
-        px, py = self._game.player_cell()
-        out[py * CELL:(py + 1) * CELL, px * CELL:(px + 1) * CELL] = PLAYER
+                out[OY + y * CELL:OY + (y + 1) * CELL,
+                    OX + x * CELL:OX + (x + 1) * CELL] = \
+                    frame[OY + y * CELL:OY + (y + 1) * CELL,
+                          OX + x * CELL:OX + (x + 1) * CELL]
+        px, py = self._game.avatar_cell()
+        out[OY + py * CELL:OY + (py + 1) * CELL,
+            OX + px * CELL:OX + (px + 1) * CELL] = AVATAR
         return out
 
 
-class G31e5fe32(RenderableUserDisplay):
+class Gd5b9d306(RenderableUserDisplay):
 
     def __init__(self, game: "Ge05b1417") -> None:
         super().__init__()
         self._game = game
 
     def render_interface(self, frame: np.ndarray) -> np.ndarray:
-        total = self._game.level_pulses
-        left = self._game.pulses
+        total = self._game.level_charges
+        left = self._game.charges
         for i in range(total):
-            x = 1 + i * 3
-            if x + 2 > frame.shape[1]:
+            top = OY + i * (CELL + 1)
+            if top + CELL > FRAME or GUTTER + CELL > FRAME:
                 break
-            frame[1:3, x:x + 2] = PIP_ON if i < left else PIP_OFF
+            frame[top:top + CELL, GUTTER:GUTTER + CELL] = BAR if i < left else BAR_SPENT
         return frame
 
 
 class Ge05b1417(ARCBaseGame):
 
     def __init__(self) -> None:
-        self.pulses = LEVELS_SPEC[0]["pulses"]
-        self.level_pulses = LEVELS_SPEC[0]["pulses"]
+        self.charges = LEVELS_SPEC[0]["charges"]
+        self.level_charges = LEVELS_SPEC[0]["charges"]
         self.known: set[tuple[int, int]] = set()
         camera = Camera(
-            width=N * CELL, height=N * CELL,
-            background=FLOOR, letter_box=UNKNOWN,
-            interfaces=[Ge31d9375(self), G31e5fe32(self)],
+            width=FRAME, height=FRAME,
+            background=TILE, letter_box=BORDER,
+            interfaces=[G87b4c1e0(self), Gd5b9d306(self)],
         )
         super().__init__(game_id="t715ea045", levels=build_levels(), camera=camera,
                          available_actions=[1, 2, 3, 4, 5])
 
-    def player_cell(self) -> tuple[int, int]:
-        player = self.current_level.get_sprites_by_name("player")
-        if not player:
+    def avatar_cell(self) -> tuple[int, int]:
+        avatar = self.current_level.get_sprites_by_name("avatar")
+        if not avatar:
             return 0, 0
-        return player[0].x // CELL, player[0].y // CELL
+        return (avatar[0].x - OX) // CELL, (avatar[0].y - OY) // CELL
 
-    def exit_cell(self) -> tuple[int, int]:
+    def gate_cell(self) -> tuple[int, int]:
         rows = LEVELS_SPEC[self.level_index]["rows"]
         for y, row in enumerate(rows):
             x = row.find("X")
             if x >= 0:
                 return x, y
-        raise AssertionError("level has no exit")
+        raise AssertionError("board has no gate")
 
     def on_set_level(self, level: Level) -> None:
         spec = LEVELS_SPEC[self.level_index]
-        self.pulses = spec["pulses"]
-        self.level_pulses = spec["pulses"]
+        self.charges = spec["charges"]
+        self.level_charges = spec["charges"]
         self.known = set()
 
     def level_reset(self) -> None:
@@ -298,18 +332,25 @@ class Ge05b1417(ARCBaseGame):
         super().full_reset()
         self.on_set_level(self.current_level)
 
-    def _emit(self) -> None:
-        if self.pulses <= 0:
+    def _flash(self) -> None:
+        if self.charges <= 0:
             return
-        self.pulses -= 1
+        self.charges -= 1
         rows = LEVELS_SPEC[self.level_index]["rows"]
-        self.known |= pulse_reveal(rows, *self.player_cell())
-        if self.pulses == 0 and self.exit_cell() not in self.known:
+        self.known |= pulse_reveal(rows, *self.avatar_cell())
+        if self.charges == 0 and not self._gate_still_winnable():
             self.level_reset()
+
+    def _gate_still_winnable(self) -> bool:
+        rows = LEVELS_SPEC[self.level_index]["rows"]
+        gate = self.gate_cell()
+        if gate not in self.known:
+            return False
+        return gate in walkable_from(rows, self.known, self.avatar_cell())
 
     def step(self) -> None:
         if self.action.id == GameAction.ACTION5:
-            self._emit()
+            self._flash()
             self.complete_action()
             return
 
@@ -326,9 +367,9 @@ class Ge05b1417(ARCBaseGame):
             self.complete_action()
             return
 
-        hits = self.try_move("player", dx * CELL, dy * CELL)
-        if any("pit" in s.tags for s in hits):
+        hits = self.try_move("avatar", dx * CELL, dy * CELL)
+        if any("fire" in s.tags for s in hits):
             self.level_reset()
-        elif any("exit" in s.tags for s in hits):
+        elif any("gate" in s.tags for s in hits):
             self.next_level()
         self.complete_action()


### PR DESCRIPTION
## The gap this closes

The 50 first-party tasks in `server/data/arc3-games/` are authored and polished in a private repository. Polishing them there changes nothing here — the two are joined by a publish step, and until someone runs it this repo keeps serving the build it last imported.

Two tasks had been polished upstream while this repo served their previous builds. Both are re-imported: **`t643da6ee`** and **`t715ea045`**.

## No id churned, which is the whole point

A published id is a pure function of its upstream id, so an updated task is rewritten **under the id it already had**. All 50 rows in `arc3Triage.json` are keyed by those ids, as are the feedback rows and the human-play telemetry. An id change wouldn't fail a build or a type-check — it would type-check, sort, render, and address nothing.

Checked after the import: the 50 manifest ids and the 50 triage ids are the same set, empty difference in both directions, and `manifest.json` regenerated **byte-identical**.

## Why there's no new sync script

`import_authored_games.py` was already idempotent — re-running it rewrites each task's bytes under the same id — so re-import needed no parallel path, and a wrapper whose only job is calling two scripts in order would be a runbook wearing a `.py` extension. It's extended, not duplicated.

The one thing it genuinely lacked was **orphan detection**: a task withdrawn upstream left a published file that `build_authored_manifest.py` kept enumerating and the play surface kept serving. It now reports those. It does **not** delete them — the id keys triage and telemetry rows that don't live in this repository, so retiring one is a decision to make with those in view, not a side effect of a sync.

## Verified, with numbers

| check | result |
|---|---|
| drift before import | exactly 2 published files stale |
| `import_authored_games.py --check` after | exit 0, `is current (50 tasks)` |
| `build_authored_manifest.py --check` after | exit 0, `is current` |
| id churn vs the pre-existing private map | **NONE** (50/50 ids and class names identical) |
| manifest ids vs triage ids | 50 ∩ 50, empty difference both ways |
| `npx tsc --noEmit` | 12 errors — **byte-identical list** to the baseline captured on unmodified `main` in the same worktree. No new errors. |
| `npm run build` | exit 0 |
| `GET /api/arc3-mirror/games` | 927 total, **50 in category `arena`**, all 50 manifest ids present |
| all 50 served sources | non-empty, byte-identical to disk, manifest `class_name` present in every module (6382–18213 bytes) |
| `t643da6ee` served | **== new build**, `!= old build` (9134B vs old 11109B); all 15 new-only defs present |
| `t715ea045` served | **== new build**, `!= old build` (11753B vs old 9962B); all 5 new-only defs present |

**No naming leaked.** 200 distinct upstream terms (ids, class names, filename stems and mechanic slugs, read mechanically from the private map rather than from memory) checked against all 635 added lines in the staged diff: zero hits, and zero bare `gNNN` tokens.

## Runbook + the cron question

`docs/2026-09-02-arc3-authored-resync.md` records the step order, the gates, and the recommendation: **manual, not a cron.** It writes to a public permanent repo behind a leak check that is a judgement call with no automated gate; it's gated on a human merge in a private repo owned by someone else; polish cycles are bursty rather than periodic; and the publish can legitimately refuse. The read-only `--check` half could be scheduled purely to *report* drift — that's a separate call and **nothing here installs it**.

## Scope note

A third task is also stale upstream, but its fix is in an unmerged PR on the authoring repo. It is deliberately **not** published here: importing from an unmerged branch would put bytes in this public repo that don't exist in the source of truth and would break `--check` until that PR merges. It lands on the next sync run afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)