### PR TITLE
feat(arc3): add 44 verified glow-up community games

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # New entries at the top, use proper SemVer!
 
+### Version 7.6.0  Sep 05, 2026
+
+- **FEAT: Import 44 verified ARC-3 glow-up community games** (Author: OpenAI Codex GPT-5)
+  - **What**: Added the 44 active synthetic games that have completed at least one glow-up pass. Each contribution is stored as an independently loadable `ARCBaseGame` source file under `data/community-games/sonpham/`; the six remaining v1 seeds are intentionally excluded.
+  - **Why**: Make the polished portion of the 50-game research pool playable and reviewable in arc-explainer while keeping unreviewed seed versions out of the community catalog.
+  - **How**: Exported from the canonical Cycle 27 ledger, preserved each qualified source body byte-for-byte, and added only the repository-required Author/Date/PURPOSE/SRP-DRY header. The export rejects stale source hashes, forbidden imports or calls, oversized files, non-`ARCBaseGame` implementations, and v1 entries.
+  - **Verified**: All 44 files compile, import, instantiate, and return a 64x64 palette-valid RESET frame. Every exported body hash matches its qualified canonical source. Static checks found no forbidden imports or calls; `q121-v2` has one validator-safe `hashlib` import used only by its direct-run self-check.
+  - **Scope**: No client, server, route, storage, or runtime behavior changed.
+  - **Files**: `data/community-games/sonpham/q*_v*_q*.py` (44 new), `docs/plans/2026-09-05-glowed-community-games-import-plan.md` (new)
+
 ### Version 7.5.0  Jul 30, 2026
 
 - **DOCS: /arc3 rebuilt around the official ARC-AGI-3 technical report** (Author: Claude Opus 5)

--- a/data/community-games/sonpham/q001_v2_q001.py
+++ b/data/community-games/sonpham/q001_v2_q001.py
@@ -1,0 +1,768 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q001-v2 Velvet Eclipse Theatre -- observation actuates shadow puppets.
+
+An almond lantern-eye glides between ten balcony perches.  Crescent-moth
+puppets travel only while occluded; many-rayed sun puppets travel only while
+observed.  Fixed reed veils and large directly tapped fabric shutters alter
+real lines of sight.  Every pulse previews its complete affected set, and a
+single rewind restores the previous cue.  This module exposes one immutable
+pure transition for search, qualification, and the animated runtime.
+
+Glow-up mechanic candidates mx003, mx004, and mx005 are deliberately rejected:
+uncertainty would change the complete-information visibility model, a matchup
+counter would dilute the observer-dependent core, and a broad pulse already
+has few-actions/large-consequence semantics rather than adding a new mechanic.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PEARL, MIST, SLATE, SMOKE, CHARCOAL, VELVET = 0, 1, 2, 3, 4, 5
+MAGENTA, PINK, RED, BLUE, ICE, AMBER = 6, 7, 8, 9, 10, 11
+GOLD, OXBLOOD, MOSS, VIOLET = 12, 13, 14, 15
+
+SHY, BOLD = 0, 1
+ACTIVE, WIN, LOSS = 0, 2, 3
+TERMINAL_INDEX = 9
+MAX_SHUTTERS = 2
+SHUTTER_MASK = (1 << MAX_SHUTTERS) - 1
+
+EYE_POSITIONS = (
+    (9, 9), (20, 7), (32, 6), (44, 7), (55, 9),
+    (9, 18), (20, 16), (32, 15), (44, 16), (55, 18),
+)
+
+LEFT_LOOP = ((13, 29), (20, 27), (24, 33), (22, 41),
+             (16, 46), (9, 41), (8, 34))
+CENTER_LOOP = ((32, 27), (39, 31), (42, 38), (38, 45),
+               (31, 49), (24, 44), (22, 35))
+RIGHT_LOOP = ((50, 29), (56, 34), (55, 42), (49, 47),
+              (43, 43), (42, 35))
+
+
+def puppet(kind, path, start, target, *, flips=()):
+    return {
+        "kind": int(kind),
+        "path": tuple(tuple(point) for point in path),
+        "start": int(start),
+        "target": int(target),
+        "flips": frozenset(int(index) for index in flips),
+    }
+
+
+def theatre(name, orbs, *, eye=2, target_eye=2, veils=(), shutters=(),
+            start_shutters=0, target_shutters=0, required_toggles=0,
+            required_flips=0, required_rewind=False, history_start=(),
+            budget=12, witness=()):
+    return {
+        "name": name,
+        "orbs": tuple(orbs),
+        "eye": int(eye),
+        "target_eye": int(target_eye),
+        "veils": tuple(tuple(veil) for veil in veils),
+        "shutters": tuple(tuple(shutter) for shutter in shutters),
+        "start_shutters": int(start_shutters),
+        "target_shutters": int(target_shutters),
+        "required_toggles": int(required_toggles),
+        "required_flips": int(required_flips),
+        "required_rewind": bool(required_rewind),
+        "history_start": tuple(history_start),
+        "budget": int(budget),
+        "witness": tuple(witness),
+    }
+
+
+# A veil is (x, y0, y1, width).  A shutter is (x, y0, y1, width); bit 1 means
+# closed. Targets and shortest witnesses are authored immutable evidence and
+# are independently replayed by the cycle qualifier.
+LEVELS = [
+    theatre(
+        "Moth in the Wing",
+        (puppet(SHY, LEFT_LOOP, 0, 2),),
+        eye=4, target_eye=4, veils=((30, 19, 51, 3),), budget=5,
+        witness=(5, 5),
+    ),
+    theatre(
+        "Lantern Crossing",
+        (puppet(BOLD, RIGHT_LOOP, 0, 5),),
+        eye=0, target_eye=0, veils=((31, 18, 52, 2),), budget=10,
+        witness=(2, 2, 5, 5, 5, 5, 5, 1, 1),
+    ),
+    theatre(
+        "Opposite Cues",
+        (puppet(SHY, LEFT_LOOP, 0, 5),
+         puppet(BOLD, RIGHT_LOOP, 0, 5)),
+        eye=2, target_eye=2, veils=((31, 18, 52, 3),), budget=10,
+        witness=(2, 2, 5, 1, 5, 5, 5, 5, 1),
+    ),
+    theatre(
+        "Velvet Turn",
+        (puppet(SHY, CENTER_LOOP, 0, 5),
+         puppet(BOLD, RIGHT_LOOP, 0, 5)),
+        eye=1, target_eye=1, veils=((17, 21, 50, 2),),
+        shutters=((36, 21, 52, 5),), start_shutters=1,
+        target_shutters=0, required_toggles=1, budget=14,
+        witness=(1, 3, 5, 5, 5, (6, 0), 5, 3, 5, 2, 5, 5, 5),
+    ),
+    theatre(
+        "Twin Curtains",
+        (puppet(SHY, LEFT_LOOP, 0, 5),
+         puppet(BOLD, CENTER_LOOP, 0, 6)),
+        eye=3, target_eye=3,
+        shutters=((25, 20, 51, 5), (42, 20, 51, 5)),
+        start_shutters=3, target_shutters=0, required_toggles=3,
+        budget=9,
+        witness=(5, (6, 1), 5, 5, 5, 5, (6, 0), 5),
+    ),
+    theatre(
+        "Changed Temperament",
+        (puppet(SHY, CENTER_LOOP, 1, 5, flips=(2,)),),
+        eye=4, target_eye=4, veils=((36, 18, 51, 3),),
+        required_flips=1, required_rewind=True,
+        history_start=(((0,), (SHY,), 0),), budget=15,
+        witness=(4, 1, 3, 5, 5, 2, 5, 5, 1, 1, 3, 5, 2, 2),
+    ),
+    theatre(
+        "Three-Puppet Matinee",
+        (puppet(SHY, LEFT_LOOP[:4], 0, 3),
+         puppet(BOLD, CENTER_LOOP[:4], 0, 3),
+         puppet(SHY, RIGHT_LOOP[:4], 0, 3, flips=(2,))),
+        eye=2, target_eye=2, veils=((31, 20, 53, 2),),
+        shutters=((19, 21, 50, 5),), start_shutters=1,
+        target_shutters=0, required_toggles=1, required_flips=4,
+        budget=13,
+        witness=(2, 3, 5, 1, 5, 1, 5, (6, 0), 5, 2, 3, 5),
+    ),
+    theatre(
+        "Velvet Eclipse Theatre",
+        (puppet(BOLD, LEFT_LOOP[:4], 1, 3, flips=(1,)),
+         puppet(BOLD, CENTER_LOOP[:4], 1, 3),
+         puppet(SHY, RIGHT_LOOP[:4], 1, 3, flips=(2,))),
+        eye=0, target_eye=0,
+        shutters=((25, 20, 52, 5), (42, 20, 52, 5)),
+        start_shutters=3, target_shutters=1, required_toggles=3,
+        required_flips=5, required_rewind=True,
+        history_start=(((0, 0, 0), (SHY, BOLD, SHY), 0),),
+        budget=14,
+        witness=(4, 2, 2, 3, 5, 1, 1, 3, (6, 0), 5, (6, 1), 5,
+                 (6, 0)),
+    ),
+]
+
+
+def _bresenham(a, b):
+    x0, y0 = a; x1, y1 = b
+    dx = abs(x1 - x0); sx = 1 if x0 < x1 else -1
+    dy = -abs(y1 - y0); sy = 1 if y0 < y1 else -1
+    error = dx + dy
+    while True:
+        yield x0, y0
+        if x0 == x1 and y0 == y1:
+            return
+        double = 2 * error
+        if double >= dy:
+            error += dy; x0 += sx
+        if double <= dx:
+            error += dx; y0 += sy
+
+
+def _veil_cells(veil):
+    x, y0, y1, width = veil
+    cells = set()
+    for y in range(y0, y1 + 1):
+        sway = round(math.sin((y - y0) * math.pi / max(1, y1 - y0)) * 2)
+        for dx in range(-(width // 2), width - width // 2):
+            cells.add((x + sway + dx, y))
+    return cells
+
+
+def opaque_cells(level, shutters):
+    cells = set()
+    for veil in level["veils"]:
+        cells.update(_veil_cells(veil))
+    for index, shutter in enumerate(level["shutters"]):
+        if shutters & (1 << index):
+            cells.update(_veil_cells(shutter))
+    return cells
+
+
+def visible(level, state, orb_index):
+    point = level["orbs"][orb_index]["path"][state[0][orb_index]]
+    eye = EYE_POSITIONS[state[2]]
+    opaque = opaque_cells(level, state[3])
+    return not any(cell in opaque for cell in list(_bresenham(eye, point))[1:-1])
+
+
+def affected_indices(level, state):
+    affected = []
+    for index, kind in enumerate(state[1]):
+        is_visible = visible(level, state, index)
+        if (kind == BOLD and is_visible) or (kind == SHY and not is_visible):
+            affected.append(index)
+    return tuple(affected)
+
+
+def toggle_evidence(value):
+    """Return completed, pending, and pre-toggle shutter masks."""
+    return (value & SHUTTER_MASK,
+            (value >> MAX_SHUTTERS) & SHUTTER_MASK,
+            (value >> (2 * MAX_SHUTTERS)) & SHUTTER_MASK)
+
+
+def pack_toggle_evidence(completed, pending, baseline):
+    return (completed | (pending << MAX_SHUTTERS)
+            | (baseline << (2 * MAX_SHUTTERS)))
+
+
+def target_kind(orb):
+    """Temperament shown by the destination puppet on its direct route."""
+    kind = orb["kind"]
+    position = orb["start"]
+    while position != orb["target"]:
+        position = (position + 1) % len(orb["path"])
+        if position in orb["flips"]:
+            kind = BOLD if kind == SHY else SHY
+    return kind
+
+
+def start_state(level):
+    positions = tuple(orb["start"] for orb in level["orbs"])
+    kinds = tuple(orb["kind"] for orb in level["orbs"])
+    history = level["history_start"]
+    # positions, kinds, eye, shutter mask, toggled mask, flipped mask,
+    # one pulse snapshot, ever rewound, remaining cue seals, terminal
+    return (positions, kinds, level["eye"], level["start_shutters"],
+            0, 0, history, 0, 2, ACTIVE)
+
+
+def ready(level, state):
+    # Low bits are completed shutter evidence. The remaining packed masks are
+    # pending shutters and their exact pre-toggle baseline positions.
+    completed_toggles, _pending, _baseline = toggle_evidence(state[4])
+    return (
+        state[0] == tuple(orb["target"] for orb in level["orbs"])
+        and state[2] == level["target_eye"]
+        and state[3] == level["target_shutters"]
+        and completed_toggles & level["required_toggles"] == level["required_toggles"]
+        and state[5] & level["required_flips"] == level["required_flips"]
+        and (not level["required_rewind"] or state[7])
+    )
+
+
+def _finish(level, state):
+    if ready(level, state):
+        return state[:TERMINAL_INDEX] + (WIN,)
+    return state
+
+
+def parse_action(action):
+    if isinstance(action, (tuple, list)):
+        return int(action[0]), int(action[1]) if len(action) > 1 else None
+    return int(action), None
+
+
+def transition(level, state, action):
+    if state[TERMINAL_INDEX]:
+        return state
+    aid, target = parse_action(action)
+    if aid not in (1, 2, 3, 4, 5, 6):
+        return state
+    positions, kinds, eye, shutters, toggled, flipped, history, rewound, seals, _ = state
+    column = eye % 5; balcony = eye // 5
+
+    # The two rewind lessons open on an intentionally over-cued tableau. Until
+    # that single recovery is performed, every other control is visibly blocked.
+    # This makes recovery causal and collapses a large family of fake detours.
+    if level["required_rewind"] and not rewound and aid != 4:
+        return state
+
+    if aid == 1:
+        if column == 0:
+            return state
+        return _finish(level, (positions, kinds, eye - 1, shutters, toggled,
+                               flipped, history, rewound, seals, ACTIVE))
+    if aid == 2:
+        if column == 4:
+            return state
+        return _finish(level, (positions, kinds, eye + 1, shutters, toggled,
+                               flipped, history, rewound, seals, ACTIVE))
+    if aid == 3:
+        return _finish(level, (positions, kinds, column + (1 - balcony) * 5,
+                               shutters, toggled, flipped, history, rewound,
+                               seals, ACTIVE))
+    if aid == 4:
+        if not history:
+            seals -= 1
+            return (positions, kinds, eye, shutters, toggled, flipped, history,
+                    rewound, seals, LOSS if seals <= 0 else ACTIVE)
+        old_positions, old_kinds, old_flipped = history[0]
+        return _finish(level, (tuple(old_positions), tuple(old_kinds), eye,
+                               shutters, toggled, old_flipped, (), 1, seals,
+                               ACTIVE))
+    if aid == 5:
+        next_positions = list(positions); next_kinds = list(kinds)
+        next_flipped = flipped
+        for index in affected_indices(level, state):
+            orb = level["orbs"][index]
+            next_positions[index] = (positions[index] + 1) % len(orb["path"])
+            if next_positions[index] in orb["flips"]:
+                next_kinds[index] = BOLD if kinds[index] == SHY else SHY
+                next_flipped |= 1 << index
+        # Rewind lessons grant exactly one recovery: after it has been used,
+        # pulses no longer manufacture an unlimited chain of undo states.
+        snapshot = () if level["required_rewind"] and rewound else (
+            (positions, kinds, flipped),)
+        completed, pending, baseline = toggle_evidence(toggled)
+        # Each pending curtain is compared with its own exact pre-toggle mask
+        # at pulse time. Credit is earned only if the still-changed curtain
+        # materially changes which puppets this pulse advances. A pending but
+        # currently irrelevant curtain stays pending for a later sightline.
+        credited = 0
+        for index in range(len(level["shutters"])):
+            bit = 1 << index
+            if not pending & bit:
+                continue
+            counterfactual_shutters = ((shutters & ~bit) | (baseline & bit))
+            counterfactual = (positions, kinds, eye, counterfactual_shutters,
+                              toggled, flipped, history, rewound, seals, ACTIVE)
+            if affected_indices(level, state) != affected_indices(
+                    level, counterfactual):
+                credited |= bit
+        completed |= credited
+        pending &= ~credited
+        baseline &= ~credited
+        next_toggled = pack_toggle_evidence(completed, pending, baseline)
+        return _finish(level, (tuple(next_positions), tuple(next_kinds), eye,
+                               shutters, next_toggled, next_flipped, snapshot,
+                               rewound, seals, ACTIVE))
+    if target is None or not 0 <= target < len(level["shutters"]):
+        return state
+    bit = 1 << target
+    completed, pending, baseline = toggle_evidence(toggled)
+    next_shutters = shutters ^ bit
+    if not completed & bit:
+        if pending & bit:
+            # Binary curtains return to their exact pre-toggle state on the
+            # second tap. Clearing pending here defeats out-and-back credit.
+            returned = bool(next_shutters & bit) == bool(baseline & bit)
+            if returned:
+                pending &= ~bit
+                baseline &= ~bit
+        else:
+            pending |= bit
+            baseline = (baseline | bit) if shutters & bit else (baseline & ~bit)
+    next_toggled = pack_toggle_evidence(completed, pending, baseline)
+    return _finish(level, (positions, kinds, eye, shutters ^ bit,
+                           next_toggled, flipped,
+                           history, rewound, seals, ACTIVE))
+
+
+def action_cost(state, after):
+    if after == state:
+        return 0
+    # A rejected empty rewind cracks one cue seal instead of spending time.
+    if after[8] < state[8]:
+        return 0
+    return 1
+
+
+def solved(level, state):
+    return state[TERMINAL_INDEX] == WIN and ready(level, state)
+
+
+def action_tokens(level):
+    return (1, 2, 3, 4, 5) + tuple((6, index)
+                                    for index in range(len(level["shutters"])))
+
+
+def encoded_witness(level):
+    encoded = []
+    for action in level["witness"]:
+        aid, target = parse_action(action)
+        if aid == 6 and target is not None:
+            x, y0, y1, _width = level["shutters"][target]
+            encoded.append((6, x, (y0 + y1) // 2))
+        else:
+            encoded.append((aid,))
+    return tuple(encoded)
+
+
+class TheatreDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def line(frame, start, end, color, dotted=False, width=1):
+        points = list(_bresenham(start, end))
+        for index, (x, y) in enumerate(points):
+            if dotted and index % 4 in (1, 2):
+                continue
+            for dy in range(-(width // 2), width - width // 2):
+                for dx in range(-(width // 2), width - width // 2):
+                    if 0 <= x + dx < 64 and 0 <= y + dy < 64:
+                        frame[y + dy, x + dx] = color
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center; inner = max(0, radius - 1) ** 2
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius ** 2 and (not hollow or distance >= inner):
+                    frame[y, x] = color
+
+    @classmethod
+    def diamond(cls, frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for dy in range(-radius, radius + 1):
+            reach = radius - abs(dy)
+            if hollow:
+                frame[cy + dy, cx - reach] = color
+                frame[cy + dy, cx + reach] = color
+            else:
+                frame[cy + dy, cx - reach:cx + reach + 1] = color
+
+    @classmethod
+    def crescent(cls, frame, center, radius, color, cut=VELVET, reverse=False):
+        cls.disc(frame, center, radius, color)
+        shift = -2 if reverse else 2
+        cls.disc(frame, (center[0] + shift, center[1] - 1),
+                 max(1, radius - 1), cut)
+
+    @classmethod
+    def almond(cls, frame, center, radius, color, pupil=CHARCOAL):
+        x, y = center
+        for dy in range(-radius // 2, radius // 2 + 1):
+            reach = radius - abs(dy) * 2
+            if reach >= 0:
+                frame[y + dy, x - reach:x + reach + 1] = color
+        cls.disc(frame, center, 2, pupil)
+        frame[y, x] = PEARL
+
+    @classmethod
+    def sun(cls, frame, center, radius, color, hollow=False):
+        cls.disc(frame, center, radius - 1, color, hollow=hollow)
+        x, y = center
+        for angle in range(0, 360, 45):
+            rad = math.radians(angle)
+            start = (x + round((radius - 1) * math.cos(rad)),
+                     y + round((radius - 1) * math.sin(rad)))
+            end = (x + round((radius + 2) * math.cos(rad)),
+                   y + round((radius + 2) * math.sin(rad)))
+            cls.line(frame, start, end, color)
+
+    @classmethod
+    def puppet(cls, frame, center, kind, color=None, hollow=False):
+        color = color if color is not None else (MAGENTA if kind == SHY else AMBER)
+        if kind == SHY:
+            cls.crescent(frame, center, 5, color, VELVET, reverse=True)
+            cls.diamond(frame, (center[0] + 2, center[1] + 3), 2, PINK,
+                        hollow=hollow)
+            cls.line(frame, (center[0] - 4, center[1] - 1),
+                     (center[0] - 7, center[1] - 3), color)
+        else:
+            cls.sun(frame, center, 4, color, hollow=hollow)
+            cls.disc(frame, center, 1, OXBLOOD if not hollow else CHARCOAL)
+
+    def background(self, frame):
+        frame[:, :] = VELVET
+        # Deep vertical nap and stitched proscenium folds carry no state.
+        for x in range(0, 64, 5):
+            color = CHARCOAL if (x // 5) % 2 else SMOKE
+            self.line(frame, (x, 0), (x + 2, 63), color, dotted=True)
+        self.line(frame, (2, 22), (8, 8), OXBLOOD, width=2)
+        self.line(frame, (8, 8), (32, 2), OXBLOOD, width=2)
+        self.line(frame, (32, 2), (56, 8), OXBLOOD, width=2)
+        self.line(frame, (56, 8), (62, 22), OXBLOOD, width=2)
+        for x in range(8, 57, 8):
+            self.disc(frame, (x, 8 - abs(32 - x) // 8), 1, GOLD)
+        self.line(frame, (4, 56), (60, 56), SLATE, dotted=True)
+        for x in range(6, 61, 9):
+            self.crescent(frame, (x, 60), 2, CHARCOAL, VELVET,
+                          reverse=(x // 9) % 2 == 0)
+
+    def curve(self, frame, points, color):
+        for index, (start, end) in enumerate(zip(points, points[1:] + points[:1])):
+            self.line(frame, start, end, color, dotted=True)
+            midpoint = ((start[0] + end[0]) // 2, (start[1] + end[1]) // 2)
+            self.disc(frame, midpoint, 1, SLATE, hollow=index % 2 == 0)
+
+    def veil(self, frame, spec, closed=True, selected=False):
+        x, y0, y1, width = spec
+        color = OXBLOOD if closed else SLATE
+        if not closed:
+            self.line(frame, (x - 5, y0), (x + 5, y0 + 5), color, width=2)
+            self.line(frame, (x + 5, y0 + 5), (x - 4, y0 + 9), color,
+                      dotted=True)
+            return
+        cells = _veil_cells(spec)
+        for px, py in cells:
+            if 0 <= px < 64 and 0 <= py < 64:
+                frame[py, px] = color
+        for y in range(y0 + 2, y1, 5):
+            sway = round(math.sin((y - y0) * math.pi / max(1, y1 - y0)) * 2)
+            self.line(frame, (x - width // 2 + sway, y),
+                      (x + width // 2 + sway, y + 2),
+                      GOLD if selected else SMOKE, dotted=True)
+        self.crescent(frame, (x, y0), max(2, width // 2), color, VELVET)
+
+    def shutter_mark(self, frame, state, index, spec):
+        """Persistent non-color state: hollow ring=pending, cut diamond=used."""
+        completed, pending, _baseline = toggle_evidence(state[4])
+        bit = 1 << index
+        x, y0, _y1, _width = spec
+        center = (x, y0 - 4)
+        if completed & bit:
+            self.diamond(frame, center, 3, PEARL, hollow=True)
+            self.line(frame, (x - 2, y0 - 4), (x + 2, y0 - 4), PEARL)
+            self.line(frame, (x, y0 - 6), (x, y0 - 2), PEARL)
+        elif pending & bit:
+            self.disc(frame, center, 3, PEARL, hollow=True)
+            self.line(frame, (x - 2, y0 - 1), (x + 2, y0 - 1), MIST,
+                      dotted=True)
+
+    def sight_and_preview(self, frame, state):
+        g = self.game; eye = EYE_POSITIONS[state[2]]
+        affected = set(affected_indices(g.level, state))
+        for index, orb in enumerate(g.level["orbs"]):
+            point = orb["path"][state[0][index]]
+            if visible(g.level, state, index):
+                self.line(frame, eye, point, MIST, dotted=True)
+            if index in affected:
+                self.disc(frame, point, 7, PINK if state[1][index] == SHY else GOLD,
+                          hollow=True)
+                self.line(frame, (point[0] - 5, point[1] + 7),
+                          (point[0] + 5, point[1] + 7), PEARL, dotted=True)
+
+    def stable_stage(self, frame, state):
+        g = self.game
+        for orb in g.level["orbs"]:
+            self.curve(frame, orb["path"], SLATE)
+            target = orb["path"][orb["target"]]
+            self.puppet(frame, target, target_kind(orb), color=SMOKE,
+                        hollow=True)
+        for veil in g.level["veils"]:
+            self.veil(frame, veil, True)
+        for index, shutter in enumerate(g.level["shutters"]):
+            self.veil(frame, shutter, bool(state[3] & (1 << index)))
+            self.shutter_mark(frame, state, index, shutter)
+        self.sight_and_preview(frame, state)
+        for index, orb in enumerate(g.level["orbs"]):
+            point = orb["path"][state[0][index]]
+            self.puppet(frame, point, state[1][index])
+        self.almond(frame, EYE_POSITIONS[state[2]], 5, PEARL, VIOLET)
+
+    def hud(self, frame, state):
+        # Exact individually countable beads grouped by stitched five-bead knots.
+        for index in range(self.game.budget_max):
+            group = index // 5; offset = index % 5
+            x = 4 + group * 11 + offset * 2
+            y = 58
+            live = index < self.game.budget_left
+            self.disc(frame, (x, y), 1, AMBER if live else SLATE,
+                      hollow=not live)
+            if offset == 4:
+                self.line(frame, (x + 1, y - 2), (x + 1, y + 2), OXBLOOD)
+        for index, x in enumerate((55, 61)):
+            live = index < state[8]
+            self.crescent(frame, (x, 24), 2, MAGENTA if live else SLATE,
+                          VELVET, reverse=index == 1)
+        if self.game.level["required_rewind"] and not state[7] and state[6]:
+            old_positions, old_kinds, _old_flipped = state[6][0]
+            for index, orb in enumerate(self.game.level["orbs"]):
+                self.puppet(frame, orb["path"][old_positions[index]],
+                            old_kinds[index], color=MIST, hollow=True)
+            self.crescent(frame, (54, 29), 4, PINK, VELVET, reverse=True)
+            self.line(frame, (58, 28), (60, 31), MIST, dotted=True)
+            # Four separate notches map the demanded return cue to action 4
+            # without text or digit glyphs.
+            for index in range(4):
+                self.diamond(frame, (49 + index * 3, 35), 1, PEARL,
+                             hollow=bool(index % 2))
+        if state[7]:
+            self.line(frame, (51, 29), (57, 27), MIST, dotted=True)
+            self.line(frame, (51, 27), (57, 31), PINK, dotted=True)
+
+    def animated_state(self):
+        g = self.game
+        if g.anim_kind != "pulse" or not g.anim_trace:
+            return g.state
+        span = max(1, g.anim_total - 1)
+        completed = len(g.anim_trace) * g.anim_progress // max(1, span + 1)
+        if not completed:
+            return g.state
+        positions = list(g.state[0]); kinds = list(g.state[1])
+        for index in g.anim_trace[:completed]:
+            positions[index] = g.pending_state[0][index]
+            kinds[index] = g.pending_state[1][index]
+        return (tuple(positions), tuple(kinds)) + g.state[2:]
+
+    def animation(self, frame, render_state):
+        g = self.game
+        if not g.anim_kind:
+            if g.terminal_hold == "loss":
+                self.line(frame, (8, 24), (56, 53), RED, width=2)
+                self.line(frame, (56, 24), (8, 53), RED, width=2)
+            return
+        before, after = g.state, g.pending_state
+        p = g.anim_progress; span = max(1, g.anim_total - 1)
+        wave = min(p, span - p)
+        if g.anim_kind == "eye":
+            start = EYE_POSITIONS[before[2]]; end = EYE_POSITIONS[after[2]]
+            x = start[0] + (end[0] - start[0]) * p // span
+            y = start[1] + (end[1] - start[1]) * p // span
+            self.almond(frame, (x, y + wave // 2), 5, PEARL, VIOLET)
+            for index, orb in enumerate(g.level["orbs"]):
+                point = orb["path"][before[0][index]]
+                self.line(frame, (x, y), point, MIST, dotted=True)
+        elif g.anim_kind == "shutter":
+            changed = before[3] ^ after[3]
+            index = max(0, changed.bit_length() - 1)
+            x, y0, y1, width = g.level["shutters"][index]
+            bow = 5 * wave // max(1, span // 2)
+            self.line(frame, (x - bow, y0), (x + bow, y1), GOLD, width=2)
+            self.line(frame, (x + bow, y0), (x - bow, y1), OXBLOOD,
+                      dotted=True)
+        elif g.anim_kind == "pulse":
+            for index in g.anim_trace:
+                orb = g.level["orbs"][index]
+                old = orb["path"][before[0][index]]
+                new = orb["path"][after[0][index]]
+                x = old[0] + (new[0] - old[0]) * p // span
+                y = old[1] + (new[1] - old[1]) * p // span - wave
+                kind = before[1][index] if p < span // 2 else after[1][index]
+                self.puppet(frame, (x, y), kind)
+                self.line(frame, old, (x, y), MIST, dotted=True)
+                if before[1][index] != after[1][index]:
+                    self.disc(frame, (x, y), 7 + wave, GOLD, hollow=True)
+            self.disc(frame, EYE_POSITIONS[before[2]], 7 + p * 3,
+                      PINK, hollow=True)
+        elif g.anim_kind == "rewind":
+            for index, orb in enumerate(g.level["orbs"]):
+                old = orb["path"][before[0][index]]
+                new = orb["path"][after[0][index]]
+                x = old[0] + (new[0] - old[0]) * p // span
+                y = old[1] + (new[1] - old[1]) * p // span + wave
+                self.puppet(frame, (x, y), after[1][index], color=MIST)
+                self.crescent(frame, (x - 4, y), 3, PINK, VELVET, reverse=True)
+        elif g.anim_kind == "reject":
+            self.crescent(frame, (55, 24), 3 + wave, RED, VELVET)
+            self.line(frame, (24 + wave, 19), (40 - wave, 24), OXBLOOD,
+                      width=2)
+        elif g.anim_kind == "success":
+            self.line(frame, (5, 54), (5 + 54 * p // span, 54), GOLD, width=2)
+            for index, orb in enumerate(g.level["orbs"]):
+                point = orb["path"][after[0][index]]
+                self.disc(frame, point, 6 + wave, MOSS, hollow=True)
+        elif g.anim_kind == "loss":
+            inset = 26 * p // span
+            self.line(frame, (5 + inset, 21), (5 + inset, 54), RED, width=2)
+            self.line(frame, (59 - inset, 21), (59 - inset, 54), RED, width=2)
+        else:  # blocked miss or edge move: localized nonflashing recoil
+            eye = EYE_POSITIONS[before[2]]
+            offset = (-2, 2, -1, 1, 0)[min(p, 4)]
+            self.almond(frame, (eye[0] + offset, eye[1]), 5, PINK, VIOLET)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self.background(frame)
+        render_state = self.animated_state()
+        self.stable_stage(frame, render_state)
+        self.hud(frame, render_state)
+        self.animation(frame, render_state)
+        return frame
+
+
+class Q001(ARCBaseGame):
+    def __init__(self):
+        self.display = TheatreDisplay(self)
+        self.level = LEVELS[0]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_trace = (); self.pending_state = self.pending_budget = None
+        self.pending_terminal = None; self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(level),
+                        name=level["name"]) for level in LEVELS]
+        super().__init__("q001", levels,
+                         Camera(0, 0, 64, 64, VELVET, VELVET, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_trace = (); self.pending_state = self.pending_budget = None
+        self.pending_terminal = None; self.terminal_hold = None
+
+    def snap_shutter(self, x, y):
+        for index, (sx, y0, y1, width) in enumerate(self.level["shutters"]):
+            # Twelve-plus display cells wide and the full hanging fabric height.
+            if sx - width - 4 <= x <= sx + width + 4 and y0 - 4 <= y <= y1 + 4:
+                return index
+        return None
+
+    def begin(self, kind, frames, after, budget, trace=(), terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames
+        self.anim_progress = 0; self.pending_state = after
+        self.pending_budget = budget; self.anim_trace = tuple(trace)
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state; self.budget_left = self.pending_budget
+        self.anim_kind = None; self.anim_trace = ()
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.terminal_hold = "win"; self.next_level()
+        elif terminal == "loss":
+            self.terminal_hold = "loss"; self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        aid = self.action.id.value
+        if aid == 0:
+            self.complete_action(); return
+        token = aid
+        if aid == 6:
+            target = self.snap_shutter(int(self.action.data.get("x", -99)),
+                                       int(self.action.data.get("y", -99)))
+            token = aid if target is None else (aid, target)
+        before = self.state; after = transition(self.level, before, token)
+        if after == before:
+            self.begin("blocked", 5, before, self.budget_left); return
+        cost = action_cost(before, after); budget = self.budget_left - cost
+        won = after[TERMINAL_INDEX] == WIN
+        lost = after[TERMINAL_INDEX] == LOSS or (budget <= 0 and not won)
+        if lost and after[TERMINAL_INDEX] != LOSS:
+            after = after[:TERMINAL_INDEX] + (LOSS,)
+        if won:
+            kind, frames, terminal = "success", 7, "win"
+        elif lost:
+            kind, frames, terminal = "loss", 7, "loss"
+        elif after[8] < before[8]:
+            kind, frames, terminal = "reject", 6, None
+        elif aid in (1, 2, 3):
+            kind, frames, terminal = "eye", 6, None
+        elif aid == 4:
+            kind, frames, terminal = "rewind", 7, None
+        elif aid == 5:
+            kind, frames, terminal = "pulse", 7, None
+        else:
+            kind, frames, terminal = "shutter", 6, None
+        trace = affected_indices(self.level, before) if aid == 5 else ()
+        self.begin(kind, frames, after, budget, trace=trace, terminal=terminal)

--- a/data/community-games/sonpham/q002_v2_q002.py
+++ b/data/community-games/sonpham/q002_v2_q002.py
@@ -1,0 +1,601 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q002-v2 Soot-and-Brass Afterimage Foundry.
+
+Observation writes a vane program only into open turbine irises. Closing an
+iris hides and arms that remembered program; a single pressure pulse then
+advances every armed capsule whose etched phase gate agrees. Finished routes
+latch, allowing later pulses to continue without overrunning completed work.
+
+The accepted mx005 few-actions-large-consequence mechanic is the global pulse:
+late solutions require one input to move several differently programmed
+devices at once. Hex topology and real-time strategy were rejected because
+neither belongs to this radial, deterministic programming puzzle.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+SOOT, ASH, IRON, OXIDE, BRONZE, INK = 5, 4, 3, 13, 12, 2
+MAGENTA, ROSE, RED, COBALT, GLASS, AMBER = 6, 7, 8, 9, 10, 11
+BRASS, BURGUNDY, VERDIGRIS, VIOLET = 12, 13, 14, 15
+
+ACTIVE, WIN, LOSS = 0, 2, 3
+TERMINAL_INDEX = 7
+
+
+def turbine(center, route, steps, memory=4):
+    """Author one radial device.
+
+    Each step is ``(program, phase)``; phase -1 accepts every phase. Routes
+    carry visible capsule coordinates and therefore contain one more point
+    than steps.
+    """
+    route = tuple(tuple(point) for point in route)
+    steps = tuple((int(program), int(phase)) for program, phase in steps)
+    assert len(route) == len(steps) + 1
+    return {
+        "center": tuple(center),
+        "route": route,
+        "steps": steps,
+        "memory": int(memory),
+    }
+
+
+def foundry(name, turbines, phase_mod, budget, witness):
+    return {
+        "name": name,
+        "turbines": tuple(deepcopy(turbines)),
+        "phase_mod": int(phase_mod),
+        "budget": int(budget),
+        "witness": tuple(witness),
+    }
+
+
+LEVELS = (
+    foundry(
+        "Spark Register",
+        (turbine((15, 18), ((21, 23), (29, 27), (38, 23)),
+                 ((1, -1), (1, -1))),),
+        1, 4, (1, (6, 0), 5, 5),
+    ),
+    foundry(
+        "Glass Return",
+        (turbine((49, 18),
+                 ((43, 23), (36, 27), (29, 24), (22, 29), (16, 24)),
+                 ((1, -1), (2, -1), (3, -1), (4, -1))),),
+        1, 15,
+        (1, (6, 0), 5,
+         (6, 0), 2, (6, 0), 5,
+         (6, 0), 3, (6, 0), 5,
+         (6, 0), 4, (6, 0), 5),
+    ),
+    foundry(
+        "Phase Escapement",
+        (
+            turbine((16, 17), ((20, 23), (27, 27), (34, 24)),
+                    ((1, 0), (3, 0))),
+            turbine((48, 18), ((44, 24), (37, 30)), ((2, 1),)),
+        ),
+        2, 10,
+        (1, (6, 0), 2, (6, 1), 5, 5, (6, 0), 3, (6, 0), 5),
+    ),
+    foundry(
+        "Split Vanes",
+        (
+            turbine((14, 20), ((20, 24), (27, 27), (34, 25), (40, 29)),
+                    ((1, -1), (2, -1), (3, -1))),
+            turbine((50, 20), ((44, 24), (37, 27), (30, 25), (24, 29)),
+                    ((4, -1), (3, -1), (2, -1))),
+        ),
+        1, 19,
+        (1, (6, 0), 4, (6, 1), 5,
+         (6, 0), 2, (6, 0), (6, 1), 3, (6, 1), 5,
+         (6, 0), 3, (6, 0), (6, 1), 2, (6, 1), 5),
+    ),
+    foundry(
+        "Three-Bell Route",
+        (
+            turbine((15, 17), ((20, 23), (28, 25), (34, 30)),
+                    ((1, 0), (3, 2))),
+            turbine((49, 18), ((44, 24), (37, 28), (31, 34)),
+                    ((2, 1), (4, 0))),
+        ),
+        3, 14,
+        (1, (6, 0), 2, (6, 1), 5, 5,
+         (6, 0), 3, (6, 0), 5,
+         (6, 1), 4, (6, 1), 5),
+    ),
+    foundry(
+        "Cooling Latches",
+        (
+            turbine((32, 12), ((32, 19), (28, 25)), ((1, 0),)),
+            turbine((50, 34), ((43, 33), (37, 29), (31, 33)),
+                    ((2, 0), (2, 1))),
+            turbine((15, 40), ((21, 38), (27, 34), (34, 39), (40, 43)),
+                    ((3, 1), (4, 0), (4, 1))),
+        ),
+        2, 13,
+        (1, (6, 0), 2, (6, 1), 3, (6, 2), 5, 5,
+         (6, 2), 4, (6, 2), 5, 5),
+    ),
+    foundry(
+        "Sextant Choir",
+        (
+            turbine((32, 11), ((32, 18), (27, 23), (23, 29)),
+                    ((1, 0), (4, 0))),
+            turbine((51, 36), ((44, 34), (38, 29), (32, 33)),
+                    ((2, 1), (1, 1))),
+            turbine((13, 38), ((20, 36), (26, 32), (32, 38)),
+                    ((3, 2), (2, 2))),
+        ),
+        3, 21,
+        (1, (6, 0), 2, (6, 1), 3, (6, 2), 5, 5, 5,
+         (6, 0), 4, (6, 0),
+         (6, 1), 1, (6, 1),
+         (6, 2), 2, (6, 2), 5, 5, 5),
+    ),
+    foundry(
+        "Afterimage Foundry",
+        (
+            turbine((32, 10), ((32, 17), (27, 22), (23, 28)),
+                    ((1, 0), (4, 0))),
+            turbine((53, 29), ((46, 29), (40, 24), (34, 28)),
+                    ((2, 0), (1, 0))),
+            turbine((35, 52), ((34, 45), (40, 39), (36, 33)),
+                    ((3, 1), (2, 2))),
+            turbine((11, 34), ((18, 34), (24, 39), (29, 34)),
+                    ((4, 1), (3, 2))),
+        ),
+        3, 24,
+        (1, (6, 0), 2, (6, 1), 3, (6, 2), 4, (6, 3), 5, 5,
+         (6, 2), 2, (6, 2),
+         (6, 3), 3, (6, 3), 5,
+         (6, 0), 4, (6, 0),
+         (6, 1), 1, (6, 1), 5),
+    ),
+)
+
+
+def parse_action(action):
+    if isinstance(action, (tuple, list)):
+        return int(action[0]), int(action[1]) if len(action) > 1 else None
+    return int(action), None
+
+
+def action_tokens(level):
+    return (1, 2, 3, 4, 5) + tuple(
+        (6, index) for index in range(len(level["turbines"])))
+
+
+def encode_action(level, action):
+    """Translate a semantic iris target to the public pointer action."""
+    aid, target = parse_action(action)
+    if aid == 6 and target is not None:
+        x, y = level["turbines"][target]["center"]
+        return (6, x, y)
+    return (aid,)
+
+
+def start_state(level):
+    memories = tuple(item["memory"] for item in level["turbines"])
+    # progress, memories, closed irises, phase, latched routes, pressure
+    # strikes, last moved mask, terminal.
+    return (tuple(0 for _ in level["turbines"]), memories,
+            0, 0, 0, 0, 0, ACTIVE)
+
+
+def solved(level, state):
+    complete = (1 << len(level["turbines"])) - 1
+    return state[TERMINAL_INDEX] == WIN and state[4] == complete
+
+
+def transition(level, state, action):
+    if state[TERMINAL_INDEX]:
+        return state
+    aid, target = parse_action(action)
+    if aid not in (1, 2, 3, 4, 5, 6):
+        return state
+    progress, memories, closed, phase, latched, strikes, _moved, _terminal = state
+    complete_mask = (1 << len(level["turbines"])) - 1
+
+    if aid in (1, 2, 3, 4):
+        updated = list(memories)
+        for index in range(len(updated)):
+            bit = 1 << index
+            if not closed & bit and not latched & bit:
+                updated[index] = aid
+        updated = tuple(updated)
+        if updated == memories:
+            return state
+        return progress, updated, closed, phase, latched, strikes, 0, ACTIVE
+
+    if aid == 6:
+        if target is None or not 0 <= target < len(level["turbines"]):
+            return state
+        bit = 1 << target
+        if latched & bit:
+            return state
+        return (progress, memories, closed ^ bit, phase, latched,
+                strikes, 0, ACTIVE)
+
+    next_progress = list(progress)
+    moved = 0
+    next_latched = latched
+    for index, item in enumerate(level["turbines"]):
+        bit = 1 << index
+        if not closed & bit or latched & bit:
+            continue
+        position = progress[index]
+        if position >= len(item["steps"]):
+            continue
+        required_program, required_phase = item["steps"][position]
+        phase_ready = required_phase < 0 or required_phase == phase
+        if memories[index] == required_program and phase_ready:
+            next_progress[index] += 1
+            moved |= bit
+            if next_progress[index] == len(item["steps"]):
+                next_latched |= bit
+
+    if not moved:
+        next_strikes = strikes + 1
+        return (progress, memories, closed, phase, latched, next_strikes, 0,
+                LOSS if next_strikes >= 2 else ACTIVE)
+
+    next_phase = (phase + 1) % level["phase_mod"]
+    terminal = WIN if next_latched == complete_mask else ACTIVE
+    return (tuple(next_progress), memories, closed, next_phase,
+            next_latched, strikes, moved, terminal)
+
+
+def action_cost(before, after):
+    if after == before:
+        return 0
+    if after[5] > before[5]:
+        return 0
+    return 1
+
+
+def execute(level, actions):
+    state = start_state(level)
+    budget = level["budget"]
+    for action in actions:
+        after = transition(level, state, action)
+        budget -= action_cost(state, after)
+        state = after
+    return state, budget
+
+
+for _level in LEVELS:
+    _state, _left = execute(_level, _level["witness"])
+    assert solved(_level, _state) and _left >= 0, (_level["name"], _state, _left)
+assert {parse_action(action)[0] for level in LEVELS
+        for action in level["witness"]} == {1, 2, 3, 4, 5, 6}
+
+
+class FoundryDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def line(frame, start, end, color, dotted=False, width=1):
+        x0, y0 = start; x1, y1 = end
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 4 in (1, 2):
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            for offset in range(width):
+                if 0 <= x < 64 and 0 <= y + offset < 64:
+                    frame[y + offset, x] = color
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center; inner = max(0, radius - 1) ** 2
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius ** 2 and (not hollow or distance >= inner):
+                    frame[y, x] = color
+
+    @classmethod
+    def diamond(cls, frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for dy in range(-radius, radius + 1):
+            reach = radius - abs(dy)
+            if 0 <= cy + dy < 64:
+                if hollow:
+                    if 0 <= cx - reach < 64: frame[cy + dy, cx - reach] = color
+                    if 0 <= cx + reach < 64: frame[cy + dy, cx + reach] = color
+                else:
+                    frame[cy + dy, max(0, cx - reach):min(64, cx + reach + 1)] = color
+
+    def background(self, frame):
+        frame[:, :] = SOOT
+        # Dense soot grain, oxidized pipes, and etched moon-glass rings.
+        for y in range(2, 62, 4):
+            for x in range(2 + (y % 7), 63, 7):
+                frame[y, x] = ASH if (x + y) % 3 else IRON
+        for radius, color in ((27, OXIDE), (22, IRON), (15, VERDIGRIS)):
+            self.disc(frame, (32, 31), radius, color, hollow=True)
+        for spoke in range(12):
+            angle = 2 * math.pi * spoke / 12
+            a = (32 + round(12 * math.cos(angle)), 31 + round(12 * math.sin(angle)))
+            b = (32 + round(27 * math.cos(angle)), 31 + round(27 * math.sin(angle)))
+            self.line(frame, a, b, BRONZE, dotted=True)
+        self.disc(frame, (32, 31), 7, INK)
+        self.disc(frame, (32, 31), 6, GLASS, hollow=True)
+        self.diamond(frame, (32, 31), 3, AMBER, hollow=True)
+
+    def route(self, frame, item, progress, latched):
+        points = item["route"]
+        for index, (a, b) in enumerate(zip(points, points[1:])):
+            color = VERDIGRIS if index < progress else IRON
+            self.line(frame, a, b, color, dotted=index >= progress, width=2)
+            midpoint = ((a[0] + b[0]) // 2, (a[1] + b[1]) // 2)
+            # Every rail segment openly previews its required program and
+            # phase.  The direction silhouette is redundant with hue; phase
+            # is a count of one-to-three violet notches, while an all-phase
+            # gate is a single hollow glass ring.  Closed irises still hide
+            # the *stored* program, but the route law is never hidden.
+            program, required_phase = item["steps"][index]
+            self.disc(frame, midpoint, 4, SOOT)
+            self.disc(frame, midpoint, 4,
+                      VERDIGRIS if index < progress else BRASS, hollow=True)
+            self.program_glyph(
+                frame, midpoint, program,
+                VERDIGRIS if index < progress else AMBER)
+            phase_center = (midpoint[0], midpoint[1] + 5)
+            if required_phase < 0:
+                self.disc(frame, phase_center, 1, GLASS, hollow=True)
+            else:
+                count = required_phase + 1
+                for mark in range(count):
+                    x = phase_center[0] + mark * 2 - (count - 1)
+                    self.diamond(frame, (x, phase_center[1]), 1, VIOLET)
+        self.diamond(frame, points[-1], 4, VERDIGRIS if latched else GLASS,
+                     hollow=True)
+
+    def program_glyph(self, frame, center, program, color):
+        x, y = center
+        if program == 1:
+            self.line(frame, (x, y + 3), (x, y - 3), color, width=2)
+            self.line(frame, (x - 2, y - 1), (x, y - 3), color)
+            self.line(frame, (x + 2, y - 1), (x, y - 3), color)
+        elif program == 2:
+            self.line(frame, (x, y - 3), (x, y + 3), color, width=2)
+            self.line(frame, (x - 2, y + 1), (x, y + 3), color)
+            self.line(frame, (x + 2, y + 1), (x, y + 3), color)
+        elif program == 3:
+            self.line(frame, (x + 3, y), (x - 3, y), color, width=2)
+            self.line(frame, (x - 1, y - 2), (x - 3, y), color)
+            self.line(frame, (x - 1, y + 2), (x - 3, y), color)
+        else:
+            self.line(frame, (x - 3, y), (x + 3, y), color, width=2)
+            self.line(frame, (x + 1, y - 2), (x + 3, y), color)
+            self.line(frame, (x + 1, y + 2), (x + 3, y), color)
+
+    def turbine(self, frame, item, index, state, center=None):
+        center = center or item["center"]
+        bit = 1 << index
+        closed = bool(state[2] & bit); latched = bool(state[4] & bit)
+        self.disc(frame, center, 7, OXIDE)
+        self.disc(frame, center, 6, BRASS if not closed else BRONZE, hollow=True)
+        if latched:
+            self.disc(frame, center, 5, VERDIGRIS, hollow=True)
+            self.diamond(frame, center, 3, GLASS, hollow=True)
+        elif closed:
+            # Closed irises hide the remembered direction behind crossed vanes.
+            self.disc(frame, center, 5, INK)
+            self.line(frame, (center[0] - 4, center[1] - 4),
+                      (center[0] + 4, center[1] + 4), BRONZE, width=2)
+            self.line(frame, (center[0] + 4, center[1] - 4),
+                      (center[0] - 4, center[1] + 4), BRONZE, width=2)
+        else:
+            self.disc(frame, center, 4, GLASS, hollow=True)
+            self.program_glyph(frame, center, state[1][index], AMBER)
+
+    def capsule(self, frame, item, progress, color=GLASS, center=None):
+        center = center or item["route"][progress]
+        self.diamond(frame, center, 3, color)
+        self.disc(frame, center, 1, SOOT)
+
+    def instruments(self, frame, state):
+        # Exact one-bead-per-action budget, grouped by four with hanging knots.
+        for index in range(self.game.budget_max):
+            x = 7 + (index % 12) * 4
+            y = 58 + 3 * (index // 12)
+            live = index < self.game.budget_left
+            self.disc(frame, (x, y), 1, BRASS if live else IRON,
+                      hollow=not live)
+            if index % 4 == 3:
+                self.line(frame, (x + 2, y - 2), (x + 2, y + 2), OXIDE)
+        # Phase moons are count/position encoded, not a text or hue code.
+        for phase in range(self.game.level["phase_mod"]):
+            angle = 2 * math.pi * phase / self.game.level["phase_mod"] - math.pi / 2
+            center = (32 + round(10 * math.cos(angle)),
+                      31 + round(10 * math.sin(angle)))
+            self.disc(frame, center, 2, VIOLET if phase == state[3] else ASH,
+                      hollow=phase != state[3])
+        for index in range(2):
+            center = (57, 8 + index * 7)
+            self.disc(frame, center, 3, RED if index < state[5] else VERDIGRIS,
+                      hollow=index >= state[5])
+            if index < state[5]:
+                self.line(frame, (center[0] - 2, center[1]),
+                          (center[0] + 2, center[1]), BRASS)
+
+    def animation(self, frame, state):
+        g = self.game
+        if not g.anim_kind:
+            if state[TERMINAL_INDEX] == LOSS:
+                self.line(frame, (5, 8), (59, 54), RED, width=2)
+            return
+        before, after = g.state, g.pending_state
+        p = g.anim_progress; span = max(1, g.anim_total - 1)
+        wave = min(p, span - p)
+        if g.anim_kind == "program":
+            for index, item in enumerate(g.level["turbines"]):
+                if before[1][index] != after[1][index]:
+                    self.disc(frame, item["center"], 8 + wave, AMBER, hollow=True)
+                    shown = before[1][index] if p < span // 2 else after[1][index]
+                    self.program_glyph(frame, item["center"], shown, GLASS)
+        elif g.anim_kind == "toggle":
+            changed = before[2] ^ after[2]
+            index = max(0, changed.bit_length() - 1)
+            center = g.level["turbines"][index]["center"]
+            self.disc(frame, center, 8 + wave, BRASS, hollow=True)
+            for spoke in range(4):
+                angle = 2 * math.pi * spoke / 4 + p * math.pi / 8
+                end = (center[0] + round((3 + wave) * math.cos(angle)),
+                       center[1] + round((3 + wave) * math.sin(angle)))
+                self.line(frame, center, end, OXIDE, width=2)
+        elif g.anim_kind == "pulse":
+            self.disc(frame, (32, 31), 8 + p * 4, VIOLET, hollow=True)
+            for index, item in enumerate(g.level["turbines"]):
+                if not after[6] & (1 << index):
+                    continue
+                a = item["route"][before[0][index]]
+                b = item["route"][after[0][index]]
+                center = (a[0] + (b[0] - a[0]) * p // span,
+                          a[1] + (b[1] - a[1]) * p // span - wave // 2)
+                self.capsule(frame, item, before[0][index], BRASS, center)
+        elif g.anim_kind == "reject":
+            offset = (-2, 2, -1, 1, 0, 1, 0)[min(p, 6)]
+            self.disc(frame, (32 + offset, 31), 8 + wave, RED, hollow=True)
+        elif g.anim_kind == "success":
+            self.disc(frame, (32, 31), 8 + p * 4, VERDIGRIS, hollow=True)
+            for index in range(8):
+                angle = 2 * math.pi * index / 8
+                center = (32 + round((8 + p) * math.cos(angle)),
+                          31 + round((8 + p) * math.sin(angle)))
+                self.diamond(frame, center, 1, BRASS)
+        elif g.anim_kind == "loss":
+            inset = p * 3
+            self.line(frame, (4 + inset, 5), (60 - inset, 57), RED, width=2)
+            self.line(frame, (60 - inset, 5), (4 + inset, 57), BURGUNDY,
+                      width=2)
+        else:
+            self.disc(frame, (32, 31), 7 + wave, ASH, hollow=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        state = self.game.state
+        self.background(frame)
+        for index, item in enumerate(self.game.level["turbines"]):
+            self.route(frame, item, state[0][index], bool(state[4] & (1 << index)))
+        for index, item in enumerate(self.game.level["turbines"]):
+            self.turbine(frame, item, index, state)
+            self.capsule(frame, item, state[0][index],
+                         VERDIGRIS if state[4] & (1 << index) else GLASS)
+        self.instruments(frame, state)
+        self.animation(frame, state)
+        return frame
+
+
+class Q002(ARCBaseGame):
+    def __init__(self):
+        self.display = FoundryDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        levels = [
+            Level(sprites=[], grid_size=(64, 64), data=deepcopy(item),
+                  name=item["name"])
+            for item in LEVELS
+        ]
+        super().__init__("q002", levels,
+                         Camera(0, 0, 64, 64, SOOT, SOOT, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+
+    def snap_turbine(self, x, y):
+        distances = [
+            ((x - item["center"][0]) ** 2 + (y - item["center"][1]) ** 2,
+             index)
+            for index, item in enumerate(self.level["turbines"])
+        ]
+        distance, index = min(distances)
+        return index if distance <= 10 ** 2 else None
+
+    def begin(self, kind, frames, after, budget, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.pending_state = after
+        self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state
+        self.budget_left = self.pending_budget
+        self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        aid = self.action.id.value
+        if aid == 0:
+            self.complete_action()
+            return
+        token = aid
+        if aid == 6:
+            target = self.snap_turbine(
+                int(self.action.data.get("x", -99)),
+                int(self.action.data.get("y", -99)),
+            )
+            token = aid if target is None else (aid, target)
+        before = self.state
+        after = transition(self.level, before, token)
+        if after == before:
+            self.begin("blocked", 6, before, self.budget_left)
+            return
+        cost = action_cost(before, after)
+        budget = self.budget_left - cost
+        won = after[TERMINAL_INDEX] == WIN
+        lost = after[TERMINAL_INDEX] == LOSS or (budget <= 0 and not won)
+        if lost and after[TERMINAL_INDEX] != LOSS:
+            after = after[:TERMINAL_INDEX] + (LOSS,)
+        if won:
+            kind, frames, terminal = "success", 7, "win"
+        elif lost:
+            kind, frames, terminal = "loss", 7, "loss"
+        elif after[5] > before[5]:
+            kind, frames, terminal = "reject", 6, None
+        elif aid in (1, 2, 3, 4):
+            kind, frames, terminal = "program", 6, None
+        elif aid == 5:
+            kind, frames, terminal = "pulse", 8, None
+        else:
+            kind, frames, terminal = "toggle", 7, None
+        self.begin(kind, frames, after, budget, terminal)

--- a/data/community-games/sonpham/q009_v2_q009.py
+++ b/data/community-games/sonpham/q009_v2_q009.py
@@ -1,0 +1,627 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q009-v2 Abyssal Current Observatory.
+
+Freeze local lenses while exact current quanta advance around a closed ring.
+The targets below are authored constants, never derived from an answer plan.
+Their known solutions and counterfactual mechanic-necessity bounds are checked
+by the Cycle 22 qualifier against the same pure transition used at runtime.
+
+Glow-up mechanic draw:
+* accepted mx002 deterministic physics: exact modular quanta, typed currents,
+  alternating gills, and a dual influence boundary;
+* rejected mx001: multiple strategic fronts would replace the intimate focus
+  boundary with an unrelated command layer;
+* rejected mx007: direct mouse navigation would add a second control language
+  without making any current decision clearer.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+INK, MIST, SLATE, DEEP, ABYSS = 0, 1, 2, 4, 5
+FUCHSIA, PEARL, RED, BLUE, CYAN, LIME, CORAL, EARTH, GREEN, VIOLET = range(6, 16)
+
+TERMINAL_INDEX = 6
+ACTIVE, WIN, LOSS = 0, 2, 3
+NORMAL = 1
+COUNTER = -1
+UNGATED = -1
+
+
+def level(
+    name,
+    start,
+    target,
+    solution,
+    *,
+    radius_max=0,
+    types=None,
+    gates=None,
+    reversible=False,
+    dual_offset=None,
+    budget,
+):
+    count = len(start)
+    return {
+        "name": name,
+        "start": tuple(start),
+        "target": tuple(target),
+        "mod": 4,
+        "radius_max": radius_max,
+        "types": tuple(types or (NORMAL,) * count),
+        "gates": tuple(gates or (UNGATED,) * count),
+        "reversible": reversible,
+        "dual_offset": dual_offset,
+        "dock": 0,
+        "budget": budget,
+        "known_solution": tuple(solution),
+    }
+
+
+# Each solution ends in ACTION6 audit. Budgets include that audit. Levels 2+
+# need at least five physical decisions before audit, resisting accidental play.
+LEVELS = [
+    level(
+        "Still Lens", (0, 1, 2), (0, 2, 3), (5, 6), budget=4,
+    ),
+    level(
+        "Swimming Focus", (0, 0, 1, 2), (2, 0, 1, 3),
+        (1, 1, 5, 1, 5, 1, 5, 5, 5, 6), budget=10,
+    ),
+    level(
+        "Breathing Boundary", (0, 1, 2, 0, 1), (2, 1, 3, 1, 3),
+        (2, 5, 2, 3, 5, 1, 1, 6), radius_max=1, budget=8,
+    ),
+    level(
+        "Closing the Ring", (0, 1, 2, 3, 0, 1), (1, 3, 0, 0, 0, 1),
+        (1, 1, 3, 5, 2, 5, 2, 6), radius_max=1, budget=8,
+    ),
+    level(
+        "Countercurrent Jellies", (0, 1, 2, 3, 0, 1), (1, 1, 2, 2, 2, 3),
+        (2, 2, 3, 5, 1, 5, 1, 6), radius_max=1,
+        types=(NORMAL, COUNTER, NORMAL, COUNTER, NORMAL, COUNTER), budget=8,
+    ),
+    level(
+        "Alternating Gills", (0, 1, 2, 3, 0, 1), (0, 1, 1, 1, 3, 0),
+        (4, 5, 2, 3, 5, 5, 1, 6), radius_max=1,
+        types=(NORMAL, COUNTER, NORMAL, COUNTER, NORMAL, COUNTER),
+        gates=(0, 1, UNGATED, 0, 1, UNGATED), reversible=True, budget=8,
+    ),
+    level(
+        "Twin Lenses", (0, 1, 2, 3, 0, 1), (0, 0, 2, 2, 1, 2),
+        (5, 5, 2, 3, 5, 1, 6), radius_max=1,
+        types=(NORMAL, COUNTER, NORMAL, COUNTER, NORMAL, COUNTER),
+        gates=(0, 1, UNGATED, 0, 1, UNGATED), reversible=True,
+        dual_offset=2, budget=7,
+    ),
+    level(
+        "Abyssal Current", (2, 0, 3, 1, 2, 0), (3, 0, 3, 0, 2, 0),
+        (1, 5, 1, 3, 4, 5, 2, 2, 6), radius_max=1,
+        types=(NORMAL, COUNTER, NORMAL, COUNTER, NORMAL, COUNTER),
+        gates=(0, 1, UNGATED, 0, 1, UNGATED), reversible=True,
+        dual_offset=2, budget=9,
+    ),
+]
+
+
+def start_state(level_data):
+    """values, focus, radius, direction, phase, audit strikes, terminal."""
+    return tuple(level_data["start"]), 0, 0, 0, 0, 0, ACTIVE
+
+
+def cyclic_distance(a, b, count):
+    return min((a - b) % count, (b - a) % count)
+
+
+def lens_centers(level_data, state):
+    focus = state[1]
+    centers = [focus]
+    if level_data["dual_offset"] is not None:
+        centers.append((focus + level_data["dual_offset"]) % len(state[0]))
+    return tuple(centers)
+
+
+def frozen_indices(level_data, state):
+    count = len(state[0])
+    centers = lens_centers(level_data, state)
+    radius = state[2]
+    return tuple(
+        index for index in range(count)
+        if any(cyclic_distance(index, center, count) <= radius for center in centers)
+    )
+
+
+def affected_indices(level_data, state):
+    """Previewable pulse footprint in visible clockwise propagation order."""
+    count = len(state[0])
+    frozen = set(frozen_indices(level_data, state))
+    phase = state[4]
+    return tuple(
+        index
+        for step in range(1, count + 1)
+        for index in ((state[1] + step) % count,)
+        if index not in frozen
+        and (level_data["gates"][index] == UNGATED
+             or level_data["gates"][index] == phase)
+    )
+
+
+def pulse_values(level_data, state):
+    values = list(state[0])
+    direction = -1 if state[3] else 1
+    for index in affected_indices(level_data, state):
+        quantum = level_data["types"][index] * direction
+        values[index] = (values[index] + quantum) % level_data["mod"]
+    return tuple(values)
+
+
+def transition(level_data, state, action):
+    """Pure deterministic transition shared by runtime and exact search."""
+    values, focus, radius, direction, phase, strikes, terminal = state
+    if terminal or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    count = len(values)
+    if action == 1:
+        return values, (focus - 1) % count, radius, direction, phase, strikes, terminal
+    if action == 2:
+        return values, (focus + 1) % count, radius, direction, phase, strikes, terminal
+    if action == 3:
+        maximum = level_data["radius_max"]
+        if not maximum:
+            return state
+        return values, focus, (radius + 1) % (maximum + 1), direction, phase, strikes, terminal
+    if action == 4:
+        if not level_data["reversible"]:
+            return state
+        return values, focus, radius, 1 - direction, phase, strikes, terminal
+    if action == 5:
+        return (pulse_values(level_data, state), focus, radius, direction,
+                1 - phase, strikes, terminal)
+
+    # The observation marks a pearl mooring at dock. Returning the lens there
+    # is a visible physical settle condition, not hidden answer-plan state.
+    if values == level_data["target"] and focus == level_data["dock"]:
+        terminal = WIN
+    else:
+        strikes += 1
+        if strikes >= 2:
+            terminal = LOSS
+    return values, focus, radius, direction, phase, strikes, terminal
+
+
+def action_cost(state, after):
+    """Wrong audits are the explicit recoverable error and spend no current."""
+    if state[TERMINAL_INDEX] or after == state:
+        return 0
+    if after[5] > state[5]:
+        return 0
+    return 1
+
+
+def solved(_level_data, state):
+    return state[TERMINAL_INDEX] == WIN
+
+
+RING_POSITIONS = {
+    3: ((32, 13), (49, 43), (15, 43)),
+    4: ((32, 11), (52, 31), (32, 51), (12, 31)),
+    5: ((32, 10), (52, 25), (45, 50), (19, 50), (12, 25)),
+    6: ((32, 10), (50, 20), (50, 42), (32, 52), (14, 42), (14, 20)),
+}
+
+
+class CurrentDisplay(RenderableUserDisplay):
+    INNER = ((0, -3), (3, 0), (0, 3), (-3, 0))
+    OUTER = ((0, -7), (7, 0), (0, 7), (-7, 0))
+
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        inner = max(0, radius - 1) ** 2
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius ** 2 and (not hollow or distance >= inner):
+                    frame[y, x] = color
+
+    @staticmethod
+    def line(frame, start, end, color, dotted=False, thick=False):
+        x0, y0 = start
+        x1, y1 = end
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 4 in (1, 2):
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+                if thick and y + 1 < 64:
+                    frame[y + 1, x] = color
+
+    @classmethod
+    def triangle(cls, frame, center, radius, color, down=False, hollow=False):
+        cx, cy = center
+        top = cy + radius if down else cy - radius
+        base = cy - radius if down else cy + radius
+        for y in range(min(top, base), max(top, base) + 1):
+            width = abs(y - top) * radius // max(1, abs(base - top))
+            if hollow:
+                cls.line(frame, (cx - width, y), (cx + width, y), color,
+                         dotted=width > 1)
+            else:
+                cls.line(frame, (cx - width, y), (cx + width, y), color)
+
+    @classmethod
+    def crescent(cls, frame, center, radius, color, cut_color, reverse=False):
+        cls.disc(frame, center, radius, color)
+        shift = -2 if reverse else 2
+        cls.disc(frame, (center[0] + shift, center[1] - 1), max(1, radius - 1), cut_color)
+
+    @classmethod
+    def droplet(cls, frame, center, radius, color, orientation=0, hollow=False):
+        cls.disc(frame, center, radius, color, hollow=hollow)
+        dx, dy = ((0, -radius - 2), (radius + 2, 0),
+                  (0, radius + 2), (-radius - 2, 0))[orientation % 4]
+        tip = (center[0] + dx, center[1] + dy)
+        cls.line(frame, center, tip, color, thick=not hollow)
+
+    def positions(self):
+        return RING_POSITIONS[len(self.game.state[0])]
+
+    def background(self, frame):
+        frame[:, :] = ABYSS
+        # Fixed plankton and caustic commas add luminous depth without carrying state.
+        for y in range(4, 61, 7):
+            for x in range(3 + (y // 7) % 5, 63, 11):
+                color = DEEP if (x + y) % 3 else SLATE
+                self.disc(frame, (x, y), 1, color)
+                if (x * 3 + y) % 5 == 0:
+                    self.line(frame, (x - 2, y + 1), (x + 1, y - 2), BLUE,
+                              dotted=True)
+        self.disc(frame, (32, 31), 28, DEEP, hollow=True)
+        self.disc(frame, (31, 32), 24, BLUE, hollow=True)
+        self.disc(frame, (33, 30), 18, SLATE, hollow=True)
+        for center in ((5, 14), (59, 17), (7, 49), (57, 48)):
+            self.crescent(frame, center, 3, VIOLET, ABYSS,
+                          reverse=center[0] < 32)
+
+    def topology(self, frame, state):
+        positions = self.positions()
+        count = len(positions)
+        reverse = bool(state[3])
+        for index, start in enumerate(positions):
+            end = positions[(index + 1) % count]
+            node_type = self.game.level["types"][index]
+            color = VIOLET if node_type == COUNTER else CYAN
+            self.line(frame, start, end, color, dotted=True)
+            midpoint = ((start[0] + end[0]) // 2, (start[1] + end[1]) // 2)
+            clockwise = (node_type == NORMAL) != reverse
+            dx = 2 if end[0] > start[0] else -2 if end[0] < start[0] else 0
+            dy = 2 if end[1] > start[1] else -2 if end[1] < start[1] else 0
+            if not clockwise:
+                dx, dy = -dx, -dy
+            self.line(frame, (midpoint[0] - dx, midpoint[1] - dy), midpoint,
+                      PEARL)
+            self.triangle(frame, (midpoint[0] + dx, midpoint[1] + dy), 2,
+                          color, down=dy < 0)
+
+    def gauge(self, frame, center, value, target, modulus):
+        # Current fill and target ghost share the same four-lobed unary grammar.
+        for index in range(modulus):
+            ix, iy = self.INNER[index]
+            ox, oy = self.OUTER[index]
+            if index < value:
+                self.droplet(frame, (center[0] + ix, center[1] + iy), 1,
+                             LIME, orientation=index)
+            else:
+                frame[center[1] + iy, center[0] + ix] = DEEP
+            if index < target:
+                self.disc(frame, (center[0] + ox, center[1] + oy), 1,
+                          FUCHSIA, hollow=True)
+                frame[center[1] + oy, center[0] + ox] = PEARL
+        if value == 0:
+            self.disc(frame, center, 2, SLATE, hollow=True)
+        if target == 0:
+            self.crescent(frame, (center[0], center[1] - 7), 2,
+                          FUCHSIA, DEEP)
+
+    def node(self, frame, index, value, target, state):
+        center = self.positions()[index]
+        node_type = self.game.level["types"][index]
+        # Normal types are asymmetric droplets; counter-current types are crescents.
+        self.disc(frame, center, 7, DEEP)
+        if node_type == NORMAL:
+            self.droplet(frame, center, 5, CYAN, orientation=index)
+            self.disc(frame, center, 4, BLUE)
+        else:
+            self.crescent(frame, center, 6, VIOLET, DEEP,
+                          reverse=index % 2 == 0)
+            self.disc(frame, center, 3, BLUE)
+        self.gauge(frame, center, value, target, self.game.level["mod"])
+
+        gate = self.game.level["gates"][index]
+        if gate != UNGATED:
+            open_now = gate == state[4]
+            marker = (center[0], center[1] + 9)
+            if gate == 0:
+                self.triangle(frame, marker, 2, LIME if open_now else SLATE,
+                              hollow=not open_now)
+            else:
+                self.crescent(frame, marker, 2,
+                              FUCHSIA if open_now else SLATE, ABYSS,
+                              reverse=True)
+
+    def influence(self, frame, state):
+        positions = self.positions()
+        frozen = set(frozen_indices(self.game.level, state))
+        affected = set(affected_indices(self.game.level, state))
+        centers = lens_centers(self.game.level, state)
+        for index in frozen:
+            color = FUCHSIA if len(centers) > 1 and cyclic_distance(
+                index, centers[-1], len(positions)) <= state[2] else CYAN
+            self.disc(frame, positions[index], 9, color, hollow=True)
+            # Offset twin rings form an amoebic, not perfectly circular, membrane.
+            self.disc(frame, (positions[index][0] - 1, positions[index][1] + 1),
+                      8, PEARL, hollow=True)
+        for index in affected:
+            self.disc(frame, positions[index], 9, LIME, hollow=True)
+            x, y = positions[index]
+            self.line(frame, (x - 3, y + 10), (x + 3, y + 10),
+                      CYAN if self.game.level["types"][index] == NORMAL else VIOLET,
+                      dotted=True)
+        # A persistent hollow pearl shows where the lens must settle to audit.
+        dock = positions[self.game.level["dock"]]
+        self.disc(frame, dock, 11, FUCHSIA, hollow=True)
+        self.droplet(frame, (dock[0], dock[1] + 11), 2, PEARL,
+                     orientation=2, hollow=True)
+
+    def hud(self, frame, state):
+        phase, reverse, strikes = state[4], bool(state[3]), state[5]
+        # Phase uses opposed sun/crescent silhouettes, never hue alone.
+        if phase == 0:
+            self.disc(frame, (5, 5), 3, LIME)
+            for dx, dy in ((0, -5), (5, 0), (0, 5), (-5, 0)):
+                self.line(frame, (5, 5), (5 + dx, 5 + dy), PEARL)
+        else:
+            self.crescent(frame, (5, 5), 4, FUCHSIA, ABYSS)
+
+        # Direction is a curling seed whose tip physically reverses.
+        self.disc(frame, (59, 5), 4, VIOLET, hollow=True)
+        if reverse:
+            self.line(frame, (62, 5), (56, 2), PEARL)
+            self.triangle(frame, (56, 2), 2, LIME, down=False)
+        else:
+            self.line(frame, (56, 5), (62, 2), PEARL)
+            self.triangle(frame, (62, 2), 2, LIME, down=False)
+
+        # Two persistent shell scars expose the finite recoverable audit.
+        for index in range(2):
+            center = (59, 26 + index * 12)
+            if index < strikes:
+                self.crescent(frame, center, 4, RED, ABYSS,
+                              reverse=index % 2 == 0)
+                self.line(frame, (56, center[1] + 3), (62, center[1] - 3), PEARL)
+            else:
+                self.disc(frame, center, 4, SLATE, hollow=True)
+
+        # Exact remaining action quanta appear as individually countable orbit beads.
+        for index in range(self.game.budget_max):
+            center = (6 + index * 4, 60)
+            live = index < self.game.budget_left
+            self.disc(frame, center, 1, CYAN if live else SLATE,
+                      hollow=not live)
+            if live and index % 2 == 0:
+                frame[60, center[0]] = PEARL
+
+    def pulse_state(self):
+        g = self.game
+        state = g.state
+        if g.anim_kind != "pulse" or not g.anim_trace:
+            return state
+        completed = len(g.anim_trace) * g.anim_progress // max(1, g.anim_total - 1)
+        if completed <= 0:
+            return state
+        values = list(state[0])
+        for index in g.anim_trace[:completed]:
+            values[index] = g.pending_state[0][index]
+        phase = g.pending_state[4] if completed == len(g.anim_trace) else state[4]
+        return (tuple(values), state[1], state[2], state[3], phase,
+                state[5], state[6])
+
+    def animation(self, frame, render_state):
+        g = self.game
+        if not g.anim_kind:
+            if g.intro_mark:
+                for index in affected_indices(g.level, g.state):
+                    self.disc(frame, self.positions()[index], 11, LIME, hollow=True)
+            if g.terminal_hold == "loss":
+                self.crescent(frame, (32, 31), 27, RED, ABYSS)
+            return
+        progress = g.anim_progress
+        span = max(1, g.anim_total - 1)
+        before, after = g.state, g.pending_state
+        if g.anim_kind == "focus":
+            start = self.positions()[before[1]]
+            end = self.positions()[after[1]]
+            # Wrapping from 0 to the final node follows the closing ring edge.
+            x = start[0] + (end[0] - start[0]) * progress // span
+            y = start[1] + (end[1] - start[1]) * progress // span
+            wobble = min(progress, span - progress)
+            self.disc(frame, (x - wobble % 2, y + wobble % 3 - 1),
+                      8 + wobble // 2, CYAN, hollow=True)
+            self.crescent(frame, (x, y), 4, FUCHSIA, ABYSS,
+                          reverse=after[1] < before[1])
+        elif g.anim_kind == "radius":
+            for index in frozen_indices(g.level, after):
+                radius = 6 + 4 * progress // span
+                self.disc(frame, self.positions()[index], radius, CYAN,
+                          hollow=True)
+                if index % 2:
+                    self.crescent(frame, self.positions()[index],
+                                  max(2, radius - 3), FUCHSIA, ABYSS)
+        elif g.anim_kind == "reverse":
+            for index, center in enumerate(self.positions()):
+                radius = 7 + (progress + index) % 4
+                self.crescent(frame, center, radius,
+                              VIOLET if after[3] else CYAN, ABYSS,
+                              reverse=bool(after[3]))
+        elif g.anim_kind == "pulse":
+            if g.anim_trace:
+                trace_index = min(len(g.anim_trace) - 1,
+                                  len(g.anim_trace) * progress // max(1, span + 1))
+                node_index = g.anim_trace[trace_index]
+                center = self.positions()[node_index]
+                self.disc(frame, center, 8 + progress % 4, LIME, hollow=True)
+                self.droplet(frame, center, 2, PEARL,
+                             orientation=(node_index + progress) % 4)
+            ripple = 5 + 24 * progress // span
+            self.disc(frame, self.positions()[before[1]], ripple, CYAN,
+                      hollow=True)
+        elif g.anim_kind == "audit_fail":
+            center = (59, 26 + min(1, after[5] - 1) * 12)
+            self.crescent(frame, center, 3 + progress // 2, RED, ABYSS)
+            self.disc(frame, (32, 31), 8 + progress * 2, FUCHSIA,
+                      hollow=True)
+        elif g.anim_kind == "success":
+            self.disc(frame, (32, 31), 6 + progress * 4, LIME, hollow=True)
+            for index, center in enumerate(self.positions()):
+                self.droplet(frame, center, 2 + (progress + index) % 3,
+                             PEARL, orientation=index)
+        elif g.anim_kind == "loss":
+            radius = max(3, 27 - progress * 3)
+            self.crescent(frame, (32, 31), radius, RED, ABYSS,
+                          reverse=progress % 2 == 0)
+            self.line(frame, (8 + progress, 8), (56 - progress, 55), RED,
+                      dotted=True, thick=True)
+        else:  # blocked input: one localized elastic recoil, never a flash.
+            center = self.positions()[before[1]]
+            offset = (0, -2, 0, 2, 0)[min(progress, 4)]
+            self.disc(frame, (center[0] + offset, center[1]), 9, RED,
+                      hollow=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        render_state = self.pulse_state()
+        self.background(frame)
+        self.topology(frame, render_state)
+        for index, (value, target) in enumerate(zip(
+                render_state[0], self.game.level["target"])):
+            self.node(frame, index, value, target, render_state)
+        if self.game.anim_kind != "focus":
+            self.influence(frame, render_state)
+        self.hud(frame, render_state)
+        self.animation(frame, render_state)
+        return frame
+
+
+class Q009(ARCBaseGame):
+    def __init__(self):
+        self.display = CurrentDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_trace = ()
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+        levels = [
+            Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+            for item in LEVELS
+        ]
+        super().__init__(
+            "q009", levels,
+            Camera(0, 0, 64, 64, ABYSS, ABYSS, [self.display]),
+            False, len(levels), [1, 2, 3, 4, 5, 6],
+        )
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_trace = ()
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+
+    def begin(self, kind, frames, state, budget, trace=(), terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.anim_trace = tuple(trace)
+        self.pending_state = state
+        self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state
+        self.budget_left = self.pending_budget
+        self.anim_kind = None
+        self.anim_trace = ()
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.terminal_hold = "win"
+            self.next_level()
+        elif terminal == "loss":
+            self.terminal_hold = "loss"
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        self.intro_mark = False
+        before = self.state
+        after = transition(self.level, before, action)
+        if after == before:
+            self.begin("blocked", 5, before, self.budget_left)
+            return
+        budget = self.budget_left - action_cost(before, after)
+        won = after[TERMINAL_INDEX] == WIN
+        lost = after[TERMINAL_INDEX] == LOSS or (budget <= 0 and not won)
+        if lost and after[TERMINAL_INDEX] != LOSS:
+            after = after[:TERMINAL_INDEX] + (LOSS,)
+        if won:
+            # Runtime counts the initiating frame and the level-transition
+            # settle in addition to these authored animation ticks.
+            kind, frames, terminal = "success", 7, "win"
+        elif lost:
+            kind, frames, terminal = "loss", 8, "loss"
+        elif after[5] > before[5]:
+            kind, frames, terminal = "audit_fail", 7, None
+        elif action in (1, 2):
+            kind, frames, terminal = "focus", 6, None
+        elif action == 3:
+            kind, frames, terminal = "radius", 6, None
+        elif action == 4:
+            kind, frames, terminal = "reverse", 6, None
+        elif action == 5:
+            kind, frames, terminal = "pulse", 8, None
+        else:
+            kind, frames, terminal = "blocked", 5, None
+        trace = affected_indices(self.level, before) if action == 5 else ()
+        self.begin(kind, frames, after, budget, trace=trace, terminal=terminal)

--- a/data/community-games/sonpham/q011_v2_q011.py
+++ b/data/community-games/sonpham/q011_v2_q011.py
@@ -1,0 +1,549 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q011-v2 Courtesy Carnival -- infer stable yielding through staged meetings.
+
+The player schedules adjacent walkers beneath a row of street-theatre arches. A
+meeting leaves a permanent, shape-coded courtesy ribbon showing who passed and
+who yielded; the final audit accepts an anonymous locally stable line rather
+than displaying a solution order. Later arches witness evidence, reverse the
+local courtesy rule, rotate the whole roundabout, and close after one meeting.
+Chalk undo restores the physical arrangement while deliberately preserving the
+social evidence, so play stays about learned relations rather than target-copy
+sorting.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+CREAM, CHALK, CERAMIC, MOSS, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, CORAL, RED, SKY, AQUA, SUN = 6, 7, 8, 9, 10, 11
+MARIGOLD, TERRACOTTA, LEAF, LILAC = 12, 13, 14, 15
+ROSE = MAGENTA
+RANK = (2, 0, 4, 1, 5, 3)
+
+
+def pair_bit(a, b):
+    lo, hi = sorted((a, b))
+    return 1 << (lo * 6 + hi)
+
+
+def pairs_mask(pairs):
+    mask = 0
+    for a, b in pairs:
+        mask |= pair_bit(a, b)
+    return mask
+
+
+def carnival(name, order, budget, *, reverse=(), witness=(), closing=(),
+             active_gaps=None, required=(), required_witness=(),
+             required_reverse=(), required_closed=(), rotate=False,
+             require_rotation=False, undo=False, require_undo=False):
+    gaps = len(order) - 1
+    return {
+        "name": name,
+        "order": tuple(order),
+        "budget": budget,
+        "reverse": frozenset(reverse),
+        "witness": frozenset(witness),
+        "closing": frozenset(closing),
+        "active_gaps": frozenset(range(gaps) if active_gaps is None else active_gaps),
+        "required": pairs_mask(required),
+        "required_witness": pairs_mask(required_witness),
+        "required_reverse": pairs_mask(required_reverse),
+        "required_closed": sum(1 << gap for gap in required_closed),
+        "rotate": rotate,
+        "require_rotation": require_rotation,
+        "undo": undo,
+        "require_undo": require_undo,
+    }
+
+
+LEVELS = [
+    carnival("First Bow", (1, 0), 1),
+    carnival("Ribbon Memory", (1, 3, 0, 2), 11,
+             required=((0, 1), (0, 2), (0, 3),
+                       (1, 2), (1, 3), (2, 3))),
+    carnival("Witness Canopy", (3, 0, 1, 2), 7, witness=(1,),
+             required=((0, 3),), required_witness=((2, 3),)),
+    carnival("Contrary Arch", (0, 2, 3, 1), 9, reverse=(1,),
+             required=((0, 1), (0, 2), (1, 3), (2, 3)),
+             required_reverse=((0, 3),)),
+    carnival("Roundabout Matinee", (4, 1, 3, 0, 2), 10,
+             reverse=(2,), active_gaps=(0, 2), rotate=True,
+             required_reverse=((0, 3),), require_rotation=True),
+    carnival("Chalk Encore", (5, 1, 3, 0, 2), 10,
+             witness=(1,), closing=(1,), rotate=True, undo=True,
+             required_witness=((1, 3),), required_closed=(1,),
+             require_rotation=True, require_undo=True),
+    carnival("Twin-Curtain Parade", (1, 5, 3, 0, 2, 4), 9,
+             reverse=(1, 3), witness=(2,), rotate=True,
+             required_witness=((0, 3),), required_reverse=((1, 5),),
+             require_rotation=True),
+    carnival("Courtesy Carnival", (3, 1, 5, 0, 4, 2), 10,
+             reverse=(1, 4), witness=(2,), closing=(3,),
+             rotate=True, undo=True, required=((0, 5),),
+             required_witness=((0, 5),), required_reverse=((1, 3),),
+             required_closed=(3,), require_rotation=True, require_undo=True),
+]
+
+
+def start_state(level):
+    # order, cursor, all evidence, witnessed evidence, reversed evidence,
+    # closed gaps, ever-closed gaps, one physical undo snapshot,
+    # rotated, undone, wax seals, terminal (0/2/3)
+    return level["order"], 0, 0, 0, 0, 0, 0, (), 0, 0, 2, 0
+
+
+def would_swap(level, order, gap):
+    a, b = order[gap], order[gap + 1]
+    result = RANK[a] < RANK[b]
+    return not result if gap in level["reverse"] else result
+
+
+def configuration_ready(level, state):
+    return all(not would_swap(level, state[0], gap)
+               for gap in range(len(state[0]) - 1))
+
+
+def audit_ready(level, state):
+    return (configuration_ready(level, state)
+            and state[2] & level["required"] == level["required"]
+            and state[3] & level["required_witness"] == level["required_witness"]
+            and state[4] & level["required_reverse"] == level["required_reverse"]
+            and state[6] & level["required_closed"] == level["required_closed"]
+            and (not level["require_rotation"] or state[8])
+            and (not level["require_undo"] or state[9]))
+
+
+def transition(level, state, action):
+    (order, cursor, evidence, witnessed, reversed_evidence, closed,
+     closed_seen, history, rotated, undone, seals, terminal) = state
+    if terminal or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    gaps = len(order) - 1
+    if action == 1:
+        return (order, (cursor - 1) % gaps, evidence, witnessed,
+                reversed_evidence, closed, closed_seen, history, rotated,
+                undone, seals, terminal)
+    if action == 2:
+        return (order, (cursor + 1) % gaps, evidence, witnessed,
+                reversed_evidence, closed, closed_seen, history, rotated,
+                undone, seals, terminal)
+    if action == 3:
+        if cursor not in level["active_gaps"] or closed & (1 << cursor):
+            return state
+        a, b = order[cursor], order[cursor + 1]
+        bit = pair_bit(a, b)
+        new_order = list(order)
+        if would_swap(level, order, cursor):
+            new_order[cursor], new_order[cursor + 1] = b, a
+        new_closed = closed | ((1 << cursor) if cursor in level["closing"] else 0)
+        snapshot = (order, cursor, closed)
+        return (tuple(new_order), cursor, evidence | bit,
+                witnessed | (bit if cursor in level["witness"] else 0),
+                reversed_evidence | (bit if cursor in level["reverse"] else 0),
+                new_closed, closed_seen | new_closed, snapshot, rotated,
+                undone, seals, terminal)
+    if action == 4:
+        if not level["undo"] or not history:
+            return state
+        old_order, old_cursor, old_closed = history
+        reopened = int(closed != old_closed)
+        return (old_order, old_cursor, evidence, witnessed, reversed_evidence,
+                old_closed, closed_seen, (), rotated, undone or reopened,
+                seals, terminal)
+    if action == 5:
+        if not level["rotate"]:
+            return state
+        snapshot = (order, cursor, closed)
+        return (order[1:] + order[:1], cursor, evidence, witnessed,
+                reversed_evidence, closed, closed_seen, snapshot, 1, undone,
+                seals, terminal)
+    if audit_ready(level, state):
+        return state[:-1] + (2,)
+    remaining = seals - 1
+    return state[:-2] + (remaining, 3 if remaining <= 0 else 0)
+
+
+def action_cost(state, after):
+    if after == state:
+        return 0
+    # Every valid selection movement, meeting, roundabout turn, and physical
+    # chalk undo consumes one program action. Only audits are free.
+    if after[10] < state[10] or after[11] != state[11]:
+        return 0
+    return 1
+
+
+def solved(_level, state):
+    return state[-1] == 2
+
+
+class CarnivalDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def line(frame, a, b, color, dotted=False, width=1):
+        x0, y0 = a; x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for i in range(steps + 1):
+            if dotted and i % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * i // steps
+            y = y0 + (y1 - y0) * i // steps
+            for dy in range(-(width // 2), width - width // 2):
+                for dx in range(-(width // 2), width - width // 2):
+                    if 0 <= x + dx < 64 and 0 <= y + dy < 64:
+                        frame[y + dy, x + dx] = color
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                d = (x - cx) ** 2 + (y - cy) ** 2
+                if d <= radius ** 2 and (not hollow or d >= max(0, radius - 1) ** 2):
+                    frame[y, x] = color
+
+    @classmethod
+    def diamond(cls, frame, center, radius, color, hollow=False):
+        x, y = center
+        for dy in range(-radius, radius + 1):
+            reach = radius - abs(dy)
+            if hollow:
+                frame[y + dy, x - reach] = color
+                frame[y + dy, x + reach] = color
+            else:
+                frame[y + dy, x - reach:x + reach + 1] = color
+
+    @staticmethod
+    def centers(count):
+        return tuple((7 + i * 50 // max(1, count - 1), 39) for i in range(count))
+
+    def background(self, frame):
+        frame[:, :] = CREAM
+        frame[22:55, :] = SUN
+        frame[25:52, :] = TERRACOTTA
+        frame[29:49, :] = CERAMIC
+        for x in range(0, 64, 6):
+            self.line(frame, (x, 50 + (x // 6) % 2),
+                      (x + 4, 50 + (x // 6) % 2), CHALK)
+        self.line(frame, (1, 22), (62, 22), LEAF, dotted=True)
+        for x in range(4, 63, 8):
+            color = (CORAL, MARIGOLD, LEAF)[(x // 8) % 3]
+            self.line(frame, (x - 3, 22), (x, 26), color)
+            self.line(frame, (x, 26), (x + 3, 22), color)
+        self.disc(frame, (55, 8), 6, MARIGOLD)
+        self.disc(frame, (55, 8), 3, CREAM)
+        for angle in range(0, 360, 45):
+            end = (55 + round(9 * math.cos(math.radians(angle))),
+                   8 + round(9 * math.sin(math.radians(angle))))
+            self.line(frame, (55, 8), end, CORAL, dotted=True)
+        for x in range(3, 62, 9):
+            frame[53, x:x + 3] = MOSS
+            frame[54, x + 1] = LEAF
+
+    def sigil(self, frame, center, identity, color=INK, small=False):
+        x, y = center; r = 1 if small else 2
+        kind = identity % 6
+        if kind == 0:
+            self.disc(frame, center, r + 1, color, hollow=True)
+            frame[y, x] = color
+        elif kind == 1:
+            self.line(frame, (x, y - r - 1), (x + r + 1, y + r), color)
+            self.line(frame, (x + r + 1, y + r), (x - r - 1, y + r), color)
+            self.line(frame, (x - r - 1, y + r), (x, y - r - 1), color)
+        elif kind == 2:
+            self.diamond(frame, center, r + 1, color, hollow=True)
+        elif kind == 3:
+            self.line(frame, (x - r - 1, y), (x + r + 1, y), color)
+            self.line(frame, (x, y - r - 1), (x, y + r + 1), color)
+        elif kind == 4:
+            self.line(frame, (x - r, y - r), (x + r, y + r), color)
+            self.line(frame, (x + r, y - r), (x - r, y + r), color)
+        else:
+            for dx, dy in ((0, -2), (2, 0), (0, 2), (-2, 0)):
+                self.disc(frame, (x + dx, y + dy), 1, color)
+
+    def walker(self, frame, center, identity, bow=0, offset=0):
+        x, y = center; x += offset; y += bow
+        color = (CORAL, LEAF, MARIGOLD, ROSE, AQUA, LILAC)[identity]
+        if identity == 0:
+            self.disc(frame, (x, y - 8), 3, color)
+            for yy in range(y - 5, y + 5):
+                reach = 2 + (yy - (y - 5)) // 3
+                frame[yy, x - reach:x + reach + 1] = color
+        elif identity == 1:
+            self.diamond(frame, (x, y - 7), 3, color)
+            self.line(frame, (x - 1, y - 4), (x - 6, y + 4), color, width=2)
+            self.line(frame, (x - 5, y + 4), (x + 3, y + 4), color, width=2)
+        elif identity == 2:
+            self.line(frame, (x, y - 12), (x - 5, y - 5), color, width=2)
+            self.line(frame, (x, y - 12), (x + 5, y - 5), color, width=2)
+            self.diamond(frame, (x, y), 6, color)
+        elif identity == 3:
+            for dx, dy in ((0, -4), (4, 0), (0, 4), (-4, 0)):
+                self.disc(frame, (x + dx, y - 6 + dy), 3, color)
+            self.disc(frame, (x, y - 6), 3, CERAMIC)
+            self.line(frame, (x, y - 2), (x, y + 5), color, width=2)
+        elif identity == 4:
+            self.diamond(frame, (x, y - 8), 5, color)
+            self.diamond(frame, (x, y + 1), 5, color)
+            self.line(frame, (x - 4, y - 4), (x + 4, y - 4), CERAMIC, dotted=True)
+        else:
+            self.disc(frame, (x, y - 5), 7, color)
+            self.disc(frame, (x + 3, y - 7), 6, CERAMIC)
+            self.line(frame, (x - 3, y), (x + 3, y + 4), color, width=2)
+        self.sigil(frame, (x, y - 5), identity, INK)
+        self.line(frame, (x - 2, y + 5), (x - 3, y + 8), INK)
+        self.line(frame, (x + 2, y + 5), (x + 3, y + 8), INK)
+
+    def gate(self, frame, gap, center, state):
+        level = self.game.level; x, _ = center
+        closed = bool(state[5] & (1 << gap))
+        active = gap in level["active_gaps"]
+        color = TERRACOTTA if active else CHALK
+        if gap in level["reverse"]:
+            self.line(frame, (x - 5, 31), (x, 26), CORAL, width=2)
+            self.line(frame, (x, 26), (x + 5, 31), CORAL, width=2)
+            self.line(frame, (x - 4, 28), (x + 4, 28), INK, dotted=True)
+            self.diamond(frame, (x - 5, 31), 2, CORAL)
+            self.diamond(frame, (x + 5, 31), 2, CORAL)
+        elif gap in level["witness"]:
+            self.line(frame, (x - 5, 31), (x - 5, 25), LEAF)
+            self.line(frame, (x + 5, 31), (x + 5, 25), LEAF)
+            self.line(frame, (x - 5, 25), (x + 5, 25), LEAF, dotted=True)
+            self.disc(frame, (x, 25), 2, MARIGOLD)
+        else:
+            self.line(frame, (x - 4, 30), (x, 26), color)
+            self.line(frame, (x, 26), (x + 4, 30), color)
+        if gap in level["closing"]:
+            self.line(frame, (x - 6, 31), (x - 3, 27), INK, dotted=True)
+            self.line(frame, (x + 6, 31), (x + 3, 27), INK, dotted=True)
+        if closed:
+            self.line(frame, (x - 6, 27), (x + 6, 31), RED, width=2)
+            self.line(frame, (x + 6, 27), (x - 6, 31), RED, width=2)
+
+    @staticmethod
+    def relation_entries(mask):
+        return [(a, b, pair_bit(a, b))
+                for a in range(6) for b in range(a + 1, 6)
+                if mask & pair_bit(a, b)]
+
+    def evidence(self, frame, state):
+        level = self.game.level
+        critical = (level["required"] | level["required_witness"]
+                    | level["required_reverse"])
+        # Six compact slots always reserve room for every audit-critical edge.
+        # Noncritical discoveries fill only the remaining slots, so a required,
+        # witnessed, or contrary ribbon can never scroll out of view.
+        required_entries = self.relation_entries(state[2] & critical)
+        other_entries = self.relation_entries(state[2] & ~critical)
+        entries = (required_entries + other_entries)[:6]
+        for index, (a, b, bit) in enumerate(entries):
+            x = 3 + index * 7
+            stronger, weaker = (a, b) if RANK[a] > RANK[b] else (b, a)
+            self.sigil(frame, (x, 9), stronger, INK, small=True)
+            self.sigil(frame, (x + 4, 13), weaker, INK, small=True)
+            self.line(frame, (x + 1, 10), (x + 3, 12), TERRACOTTA,
+                      dotted=bool(state[3] & bit))
+            if state[4] & bit:
+                self.line(frame, (x, 15), (x + 4, 7), CORAL)
+
+    def hud(self, frame, state):
+        for index, x in enumerate((55, 62)):
+            live = index < state[10]
+            self.disc(frame, (x, 18), 2, ROSE if live else RED, hollow=not live)
+            self.sigil(frame, (x, 18), 3, INK, small=True)
+        shown = self.game.budget_left
+        offsets = ((0, -2), (2, 0), (0, 2), (-2, 0))
+        for group in range((self.game.budget_max + 3) // 4):
+            center = (4 + group * 8, 60)
+            self.disc(frame, center, 1, TERRACOTTA)
+            for petal, (dx, dy) in enumerate(offsets):
+                i = group * 4 + petal
+                if i >= self.game.budget_max:
+                    continue
+                if i < shown:
+                    self.disc(frame, (center[0] + dx, center[1] + dy), 1, MARIGOLD)
+                else:
+                    frame[center[1] + dy, center[0] + dx] = CHALK
+        # This anonymous arch now reflects the complete audit contract, not
+        # merely physical order: missing evidence/undo/rotation stays closed.
+        ready = audit_ready(self.game.level, state)
+        self.line(frame, (48, 13), (51, 8), LEAF if ready else TERRACOTTA)
+        self.line(frame, (51, 8), (54, 13), LEAF if ready else TERRACOTTA)
+        self.disc(frame, (51, 8), 1, CERAMIC)
+        if state[8]:
+            self.disc(frame, (59, 8), 3, CORAL, hollow=True)
+            self.line(frame, (59, 4), (62, 7), INK)
+        if state[9]:
+            self.line(frame, (57, 13), (62, 10), CHALK, dotted=True)
+            self.line(frame, (57, 11), (62, 14), TERRACOTTA, dotted=True)
+
+    def base_queue(self, frame, state, skip=()):
+        centers = self.centers(len(state[0]))
+        for gap in range(len(state[0]) - 1):
+            gx = (centers[gap][0] + centers[gap + 1][0]) // 2
+            self.gate(frame, gap, (gx, 29), state)
+        for index, identity in enumerate(state[0]):
+            if index not in skip:
+                self.walker(frame, centers[index], identity)
+        return centers
+
+    def animation(self, frame, centers):
+        g = self.game
+        if not g.anim_kind:
+            if g.intro_mark:
+                for radius in (3, 6, 9):
+                    self.disc(frame, (55, 8), radius, MARIGOLD, hollow=True)
+            if g.state[-1] == 3:
+                for y in range(27, 50, 5):
+                    self.line(frame, (2, y), (61, y + 2), RED,
+                              dotted=True, width=2)
+            return
+        p = g.anim_progress; span = max(1, g.anim_total - 1)
+        before, after = g.state, g.pending_state
+        if g.anim_kind == "cursor":
+            old = (centers[before[1]][0] + centers[before[1] + 1][0]) // 2
+            new = (centers[after[1]][0] + centers[after[1] + 1][0]) // 2
+            x = old + (new - old) * p // span
+            self.diamond(frame, (x, 52), 2 + min(p, span - p), CORAL, hollow=True)
+        elif g.anim_kind in ("encounter", "undo", "rotate"):
+            for identity in before[0]:
+                old_i = before[0].index(identity); new_i = after[0].index(identity)
+                a, b = centers[old_i], centers[new_i]
+                x = a[0] + (b[0] - a[0]) * p // span
+                arc = -4 * min(p, span - p) // max(1, span // 2)
+                bow = 2 * math.sin(math.pi * p / span) if g.anim_kind == "encounter" else 0
+                self.line(frame, a, (x, a[1] + arc), CHALK, dotted=True)
+                self.walker(frame, (x, a[1] + arc), identity, bow=round(bow))
+            if g.anim_kind == "undo":
+                for x in range(5, 60, 7):
+                    self.disc(frame, (x, 53 - p % 2), 1, TERRACOTTA, hollow=True)
+            if g.anim_kind == "rotate":
+                self.disc(frame, (32, 39), 12 + p, CORAL, hollow=True)
+        elif g.anim_kind in ("audit", "reject"):
+            edge = 4 + 55 * p // span
+            color = LEAF if g.anim_kind == "audit" else RED
+            self.line(frame, (edge, 24), (edge, 51), color,
+                      dotted=True, width=2)
+            self.diamond(frame, (edge, 21), 2, MARIGOLD)
+        elif g.anim_kind == "success":
+            self.line(frame, (8, 49), (8 + 48 * p // span, 27), LEAF, width=2)
+            self.line(frame, (56, 49), (56 - 48 * p // span, 27), LEAF, width=2)
+            for x in range(8, 57, 8):
+                self.diamond(frame, (x, 19 + (x + p) % 3), 2, CORAL)
+        elif g.anim_kind == "loss":
+            inset = 28 * p // span
+            self.line(frame, (2 + inset, 26), (2 + inset, 51), RED, width=2)
+            self.line(frame, (61 - inset, 26), (61 - inset, 51), RED, width=2)
+        else:
+            index = before[1]
+            x, y = centers[index]
+            offset = (-2, 0, 2, 0, -1, 0)[min(p, 5)]
+            self.disc(frame, (x + offset, y - 14), 2, RED, hollow=True)
+            self.line(frame, (x - 4 + offset, y - 14),
+                      (x + 4 + offset, y - 14), INK)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self.background(frame)
+        state = self.game.state
+        skip = tuple(range(len(state[0]))) if self.game.anim_kind in (
+            "encounter", "undo", "rotate") else ()
+        centers = self.base_queue(frame, state, skip)
+        self.evidence(frame, state)
+        self.hud(frame, state)
+        self.animation(frame, centers)
+        if not self.game.anim_kind:
+            gap_x = (centers[state[1]][0] + centers[state[1] + 1][0]) // 2
+            self.diamond(frame, (gap_x, 52), 2, CORAL, hollow=True)
+        return frame
+
+
+class Q011(ARCBaseGame):
+    def __init__(self):
+        self.display = CarnivalDisplay(self)
+        self.level = LEVELS[0]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = None; self.pending_budget = None; self.pending_terminal = None
+        self.intro_mark = True
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(level), name=level["name"])
+                  for level in LEVELS]
+        super().__init__("q011", levels, Camera(0, 0, 64, 64, CREAM, CREAM, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        self.intro_mark = True
+
+    def begin(self, kind, frames, after, budget, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames
+        self.anim_progress = 0; self.pending_state = after
+        self.pending_budget = budget; self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state; self.budget_left = self.pending_budget
+        self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        self.intro_mark = False
+        before = self.state; after = transition(self.level, before, action)
+        if after == before:
+            self.begin("blocked", 5, before, self.budget_left)
+            return
+        cost = action_cost(before, after)
+        if cost > self.budget_left:
+            lost = before[:-1] + (3,)
+            self.begin("loss", 7, lost, self.budget_left, "loss")
+            return
+        budget = self.budget_left - cost
+        won = after[-1] == 2; lost = after[-1] == 3
+        if won:
+            kind, frames, terminal = "success", 7, "win"
+        elif lost:
+            kind, frames, terminal = "loss", 7, "loss"
+        elif after[10] < before[10]:
+            kind, frames, terminal = "reject", 6, None
+        elif action in (1, 2):
+            kind, frames, terminal = "cursor", 5, None
+        elif action == 3:
+            kind, frames, terminal = "encounter", 7, None
+        elif action == 4:
+            kind, frames, terminal = "undo", 7, None
+        elif action == 5:
+            kind, frames, terminal = "rotate", 7, None
+        else:
+            kind, frames, terminal = "audit", 6, None
+        self.begin(kind, frames, after, budget, terminal)

--- a/data/community-games/sonpham/q012_v2_q012.py
+++ b/data/community-games/sonpham/q012_v2_q012.py
@@ -1,0 +1,365 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q012-v2 Cloudberry Commons -- diagnose two-part appetites and share a finite picnic."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+CREAM, LINEN, ASH, CLAY, BARK, INK = 0, 1, 2, 3, 4, 5
+BERRY, PINK, RED, BLUE, SKY, HONEY, APRICOT, PLUM, SAGE, LAVENDER = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+
+# Every dish is a conjunction of an independently shaped food and stamped texture.
+ITEM_FEATURES = ((0, 0), (1, 1), (2, 2), (3, 0), (0, 1), (1, 2))
+
+LEVELS = [
+    {"name": "First Taste", "items": (0,), "prefs": (0,), "dual": False, "probes": 1, "rotate": 0, "order": (), "budget": 4},
+    {"name": "Shared Basket", "items": (0, 1, 2), "prefs": (2, 0, 1), "dual": False, "probes": 3, "rotate": 0, "order": (), "budget": 14},
+    {"name": "Shape and Crumb", "items": (0, 4, 1), "prefs": (4, 1, 0), "dual": True, "probes": 3, "rotate": 0, "order": (), "budget": 14},
+    {"name": "Quiet Placemat", "items": (0, 4, 1, 5), "prefs": (5, 0, 4, 1), "dual": True, "probes": 3, "rotate": 0, "order": (), "budget": 19},
+    {"name": "Turning Picnic", "items": (0, 4, 1, 5), "prefs": (4, 1, 5, 0), "dual": True, "probes": 4, "rotate": 1, "order": (), "budget": 19},
+    {"name": "Courtesy Path", "items": (0, 4, 1, 5), "prefs": (1, 4, 0, 5), "dual": True, "probes": 3, "rotate": 1, "order": (2, 0, 3, 1), "budget": 24},
+    {"name": "Cloudberry Circle", "items": (0, 4, 1, 5, 2), "prefs": (4, 2, 5, 0, 1), "dual": True, "probes": 4, "rotate": 1, "order": (1, 4, 0, 3, 2), "budget": 28},
+    {"name": "Cloudberry Commons", "items": (0, 4, 1, 5, 2), "prefs": (5, 0, 1, 4, 2), "dual": True, "probes": 4, "rotate": 2, "order": (4, 1, 3, 0, 2), "budget": 34},
+]
+
+
+def start_state(level):
+    n = len(level["prefs"])
+    # phase, guest cursor, item-slot cursor, platter order, seen, evidence, probes used,
+    # assigned guests, used item identities, courtesy index, chances, terminal
+    return 0, 0, 0, tuple(level["items"]), 0, (0,) * n, 0, 0, 0, 0, 2, 0
+
+
+def rotate(values, amount):
+    amount %= len(values)
+    return values[-amount:] + values[:-amount] if amount else values
+
+
+def transition(level, state, action):
+    phase, guest, slot, platter, seen, evidence, probes, assigned, used, courtesy, chances, terminal = state
+    if terminal or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    n = len(level["prefs"])
+    if action == 1:
+        return phase, (guest - 1) % n, slot, platter, seen, evidence, probes, assigned, used, courtesy, chances, terminal
+    if action == 2:
+        return phase, (guest + 1) % n, slot, platter, seen, evidence, probes, assigned, used, courtesy, chances, terminal
+    if action == 3:
+        return phase, guest, (slot - 1) % n, platter, seen, evidence, probes, assigned, used, courtesy, chances, terminal
+    if action == 4:
+        return phase, guest, (slot + 1) % n, platter, seen, evidence, probes, assigned, used, courtesy, chances, terminal
+    if phase == 0 and action == 5:
+        if probes >= level["probes"] or seen & (1 << guest):
+            return state
+        item = platter[slot]; values = list(evidence); values[guest] = item + 1
+        return phase, guest, slot, platter, seen | (1 << guest), tuple(values), probes + 1, assigned, used, courtesy, chances, terminal
+    if phase == 0 and action == 6:
+        if probes != level["probes"] or seen.bit_count() != level["probes"]:
+            return state
+        return 1, guest, slot, platter, seen, evidence, probes, assigned, used, courtesy, chances, terminal
+    if phase == 1 and action == 5:
+        if assigned & (1 << guest):
+            return state
+        if level["order"] and guest != level["order"][courtesy]:
+            return state
+        item = platter[slot]
+        if used & (1 << item):
+            return state
+        if item != level["prefs"][guest]:
+            values = list(evidence); values[guest] = item + 1; chances -= 1
+            return phase, guest, slot, platter, seen | (1 << guest), tuple(values), probes, assigned, used, courtesy, chances, 3 if chances <= 0 else 0
+        assigned |= 1 << guest; used |= 1 << item; courtesy += 1
+        if level["rotate"] == 1:
+            platter = rotate(platter, 1)
+        elif level["rotate"] == 2:
+            platter = rotate(platter, 1 + ITEM_FEATURES[item][1] % 2)
+        terminal = 2 if assigned.bit_count() == n else 0
+        return phase, guest, slot, platter, seen, evidence, probes, assigned, used, courtesy, chances, terminal
+    if phase == 1 and action == 6:
+        # Closing the napkin before every guest is served is a recoverable
+        # audit error and supplies an honest loss trace even in the tutorial.
+        chances -= 1
+        return phase, guest, slot, platter, seen, evidence, probes, assigned, used, courtesy, chances, 3 if chances <= 0 else 0
+    return state
+
+
+def action_cost(state, after):
+    # A politely returned wrong dish spends a berry-shaped retry, not picnic time.
+    return 0 if after[10] < state[10] else 1
+
+
+def solved(_level, state):
+    return state[-1] == 2
+
+
+class CommonsDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                d = (x - cx) ** 2 + (y - cy) ** 2
+                if d <= radius ** 2 and (not hollow or d >= max(0, radius - 1) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def line(frame, a, b, color, dotted=False):
+        x0, y0 = a; x1, y1 = b; steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for i in range(steps + 1):
+            if dotted and i % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * i // steps; y = y0 + (y1 - y0) * i // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    @staticmethod
+    def guest_center(index, n):
+        return (32, 18) if n == 1 else (8 + index * (48 // (n - 1)), 17 + (index % 2) * 3)
+
+    @staticmethod
+    def item_center(index, n):
+        return (32, 45) if n == 1 else (9 + index * (46 // (n - 1)), 45 - (index % 2) * 2)
+
+    def background(self, frame):
+        frame[:, :] = CREAM
+        for y in range(3, 62, 6):
+            frame[y, 2 + y % 4:62:10] = LINEN
+        for x in range(4, 62, 9):
+            frame[2 + x % 5:62:11, x] = ASH
+        # Asymmetric woven picnic cloth with a scalloped edge.
+        frame[28:57, 4:60] = LINEN
+        for x in range(5, 60, 6):
+            self.disc(frame, (x, 57), 3, LINEN)
+        self.line(frame, (6, 31), (57, 53), CLAY, dotted=True)
+
+    def guest(self, frame, center, index, assigned=False):
+        x, y = center; colors = (SAGE, APRICOT, SKY, LAVENDER, PINK); color = colors[index % len(colors)]
+        self.disc(frame, (x, y), 6, color)
+        # Irregular ears/crests distinguish every guest without hue.
+        if index % 5 == 0:
+            self.disc(frame, (x - 4, y - 5), 3, color); self.disc(frame, (x + 4, y - 5), 3, color)
+        elif index % 5 == 1:
+            self.line(frame, (x - 5, y - 3), (x - 2, y - 9), color); self.line(frame, (x + 5, y - 3), (x + 2, y - 9), color)
+        elif index % 5 == 2:
+            self.disc(frame, (x, y - 7), 3, color); frame[y - 10:y - 7, x] = color
+        elif index % 5 == 3:
+            frame[y - 9:y - 4, x - 5:x - 2] = color; frame[y - 9:y - 4, x + 3:x + 6] = color
+        else:
+            for dx in (-5, 0, 5): self.disc(frame, (x + dx, y - 5), 2, color)
+        frame[y - 1:y + 1, x - 3:x - 1] = INK; frame[y - 1:y + 1, x + 2:x + 4] = INK
+        if assigned:
+            self.line(frame, (x - 3, y + 3), (x, y + 5), HONEY); self.line(frame, (x, y + 5), (x + 4, y + 2), HONEY)
+            self.disc(frame, (x, y), 8, SAGE, hollow=True)
+
+    def food(self, frame, center, item, used=False, small=False):
+        x, y = center; shape, texture = ITEM_FEATURES[item]; r = 2 if small else 4
+        color = (BERRY, HONEY, APRICOT, SAGE, LAVENDER, SKY)[item]
+        if used:
+            self.disc(frame, center, r + 1, ASH, hollow=True)
+            # Empty plate retains the food's stamped texture as consumed-state memory.
+            if texture == 1: self.line(frame, (x - r, y), (x + r, y), CLAY, dotted=True)
+            elif texture == 2: self.disc(frame, center, 1, CLAY, hollow=True)
+            return
+        if shape == 0:
+            self.disc(frame, center, r, color)
+        elif shape == 1:
+            self.line(frame, (x - r, y + r), (x, y - r), color); self.line(frame, (x, y - r), (x + r, y + r), color); self.line(frame, (x + r, y + r), (x - r, y + r), color)
+        elif shape == 2:
+            self.line(frame, (x - r, y), (x + r, y), color); self.line(frame, (x, y - r), (x, y + r), color); self.line(frame, (x - r + 1, y - r + 1), (x + r - 1, y + r - 1), color)
+        else:
+            self.line(frame, (x, y - r), (x + r, y), color); self.line(frame, (x + r, y), (x, y + r), color); self.line(frame, (x, y + r), (x - r, y), color); self.line(frame, (x - r, y), (x, y - r), color)
+        if texture == 1:
+            self.line(frame, (x - r + 1, y), (x + r - 1, y), INK, dotted=True)
+        elif texture == 2:
+            self.disc(frame, center, 1, INK, hollow=True)
+
+    def cue(self, frame, center, offered, preferred, dual):
+        ox, oy = ITEM_FEATURES[offered]; px, py = ITEM_FEATURES[preferred]
+        for row, (source, target) in enumerate(((ox, px), (oy, py))):
+            if row and not dual:
+                continue
+            x, y = center[0], center[1] + row * 5
+            delta = (target - source) % 4 if row == 0 else (target - source) % 3
+            if delta == 0:
+                self.disc(frame, (x, y), 2, SAGE, hollow=True); frame[y, x] = SAGE
+            elif row == 0 and delta == 2:
+                # Opposite shapes get a double chevron, distinct from either
+                # one-step direction on the four-shape wheel.
+                for offset in (-2, 2):
+                    self.line(frame, (x + offset - 1, y - 2), (x + offset + 1, y), APRICOT)
+                    self.line(frame, (x + offset + 1, y), (x + offset - 1, y + 2), APRICOT)
+            elif delta == 1:
+                self.line(frame, (x - 2, y - 2), (x + 2, y), APRICOT); self.line(frame, (x + 2, y), (x - 2, y + 2), APRICOT)
+            else:
+                self.line(frame, (x + 2, y - 2), (x - 2, y), PLUM); self.line(frame, (x - 2, y), (x + 2, y + 2), PLUM)
+
+    def commons(self, frame):
+        g = self.game; s = g.state; n = len(g.level["prefs"])
+        for i in range(n):
+            center = self.guest_center(i, n); self.guest(frame, center, i, bool(s[7] & (1 << i)))
+            if s[5][i]:
+                offered = s[5][i] - 1
+                self.food(frame, (center[0] - 4, 29), offered, small=True)
+                self.cue(frame, (center[0] + 3, 27), offered, g.level["prefs"][i], g.level["dual"])
+            elif s[0] == 1:
+                # The unprobed elimination seat is an open woven medallion.
+                self.disc(frame, (center[0], 29), 3, ASH, hollow=True)
+        if g.anim_kind == "serve_turn" and g.pending_state:
+            served = s[3][s[2]]; p = g.anim_progress
+            for old_slot, item in enumerate(s[3]):
+                if item == served:
+                    continue
+                new_slot = g.pending_state[3].index(item)
+                before = self.item_center(old_slot, n); after = self.item_center(new_slot, n)
+                center = (before[0] + (after[0] - before[0]) * p // g.anim_total,
+                          before[1] + (after[1] - before[1]) * p // g.anim_total)
+                self.food(frame, center, item, bool(s[8] & (1 << item)))
+        else:
+            traveling = s[3][s[2]] if g.anim_kind in ("serve", "return") else -1
+            for slot, item in enumerate(s[3]):
+                if item == traveling:
+                    continue
+                self.food(frame, self.item_center(slot, n), item, bool(s[8] & (1 << item)))
+        # Guest and dish focus use unrelated geometry.
+        gc = self.guest_center(s[1], n); ic = self.item_center(s[2], n)
+        self.disc(frame, gc, 9, BERRY, hollow=True)
+        self.line(frame, (ic[0] - 6, ic[1] + 7), (ic[0], ic[1] + 4), HONEY)
+        self.line(frame, (ic[0], ic[1] + 4), (ic[0] + 6, ic[1] + 7), HONEY)
+        if g.level["order"] and s[0] == 1 and s[9] < n:
+            expected = g.level["order"][s[9]]; ex, ey = self.guest_center(expected, n)
+            self.disc(frame, (ex, ey), 11, SAGE, hollow=True)
+        if g.level["rotate"] and s[0] == 1:
+            selected_item = s[3][s[2]]
+            shift = 1 if g.level["rotate"] == 1 else 1 + ITEM_FEATURES[selected_item][1] % 2
+            # One or two curved-arrow buds preview the exact post-serve turn;
+            # the final texture-indexed consequence is not animation-only.
+            for i in range(shift):
+                cx = 28 + i * 8
+                self.disc(frame, (cx, 36), 3, SKY, hollow=True)
+                frame[33:36, cx + 2:cx + 5] = SKY
+
+    def hud(self, frame):
+        g = self.game; s = g.state
+        # Probe beads drain from filled berries into hollow napkin rings.
+        for i in range(g.level["probes"]):
+            x = 6 + i * 6; self.disc(frame, (x, 5), 2, ASH if i < s[6] else BERRY, hollow=i < s[6])
+        for i in range(s[10]):
+            self.disc(frame, (55 + i * 5, 5), 2, BERRY); frame[3:5, 55 + i * 5] = SAGE
+        # Phase: magnifying leaf for diagnosis, tied napkin for serving.
+        if s[0] == 0:
+            self.disc(frame, (32, 5), 3, SKY, hollow=True); self.line(frame, (34, 7), (38, 10), SKY)
+        else:
+            self.line(frame, (29, 3), (35, 8), APRICOT); self.line(frame, (35, 3), (29, 8), APRICOT); self.disc(frame, (32, 6), 2, HONEY)
+        # Exact action budget: remaining beads are filled and two pixels tall;
+        # spent entries are hollow one-pixel knots.
+        for i in range(g.budget_max):
+            x = 4 + i
+            if i < g.budget_left:
+                frame[61:63, x] = SAGE
+            else:
+                frame[62, x] = ASH
+
+    def animation(self, frame):
+        g = self.game
+        if not g.anim_kind:
+            if g.intro_mark:
+                self.disc(frame, self.guest_center(0, len(g.level["prefs"])), 11, SKY, hollow=True)
+            if g.terminal_hold == "loss":
+                for x in range(4, 61, 7): self.line(frame, (x, 2), (x - 3, 58), BLUE, dotted=True)
+            return
+        p = g.anim_progress; n = len(g.level["prefs"]); s = g.state
+        if g.anim_kind in ("guest_cursor", "item_cursor"):
+            center = self.guest_center(g.pending_state[1], n) if g.anim_kind == "guest_cursor" else self.item_center(g.pending_state[2], n)
+            self.disc(frame, center, 7 + p, BERRY if g.anim_kind == "guest_cursor" else HONEY, hollow=True)
+        elif g.anim_kind == "probe":
+            source = self.item_center(s[2], n); destination = self.guest_center(s[1], n)
+            mid = (source[0] + (destination[0] - source[0]) * p // g.anim_total,
+                   source[1] + (destination[1] - source[1]) * p // g.anim_total - p * (g.anim_total - p) // 2)
+            self.food(frame, mid, s[3][s[2]], small=True)
+            self.disc(frame, destination, 7 + p, SKY, hollow=True)
+        elif g.anim_kind in ("serve", "serve_turn", "return"):
+            source = self.item_center(s[2], n); destination = self.guest_center(s[1], n)
+            if g.anim_kind == "return":
+                half = max(1, g.anim_total // 2)
+                if p <= half:
+                    start, end, phase, span = source, destination, p, half
+                else:
+                    start, end, phase, span = destination, source, p - half, g.anim_total - half
+                mid = (start[0] + (end[0] - start[0]) * phase // max(1, span),
+                       start[1] + (end[1] - start[1]) * phase // max(1, span) - 4)
+            else:
+                mid = (source[0] + (destination[0] - source[0]) * p // g.anim_total,
+                       source[1] + (destination[1] - source[1]) * p // g.anim_total - 4)
+            self.food(frame, mid, s[3][s[2]], small=True)
+            if g.anim_kind == "return": self.disc(frame, destination, 7 + p, RED, hollow=True)
+            elif g.anim_kind == "serve_turn":
+                self.disc(frame, (32, 45), 7 + p * 3, SKY, hollow=True)
+        elif g.anim_kind == "phase":
+            self.disc(frame, (32, 33), 6 + p * 4, APRICOT, hollow=True)
+        elif g.anim_kind == "success":
+            for x in range(7, 60, 8):
+                self.disc(frame, (x, 32), 2 + p, (BERRY, APRICOT, SAGE)[(x // 8) % 3], hollow=True)
+        elif g.anim_kind == "loss":
+            for x in range(4 + p, 61, 8): self.line(frame, (x, 2), (x - 4, 58), BLUE, dotted=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self.background(frame); self.commons(frame); self.hud(frame); self.animation(frame); return frame
+
+
+class Q012(ARCBaseGame):
+    def __init__(self):
+        self.display = CommonsDisplay(self); self.level = LEVELS[0]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0; self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None; self.intro_mark = True; self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"]) for item in LEVELS]
+        super().__init__("q012", levels, Camera(0, 0, 64, 64, CREAM, CREAM, [self.display]), False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]; self.state = start_state(self.level); self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None; self.intro_mark = True; self.terminal_hold = None
+
+    def begin(self, kind, frames, state, budget, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames; self.anim_progress = 0
+        self.pending_state = state; self.pending_budget = budget; self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal; self.state = self.pending_state; self.budget_left = self.pending_budget
+        self.anim_kind = None; self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win": self.terminal_hold = "win"; self.next_level()
+        elif terminal == "loss": self.terminal_hold = "loss"; self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1; self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0: self.finish()
+            return
+        action = self.action.id.value
+        if action == 0: self.complete_action(); return
+        self.intro_mark = False; before = self.state; after = transition(self.level, before, action)
+        if after == before:
+            self.begin("return", 4, before, self.budget_left); return
+        budget = self.budget_left - action_cost(before, after); won = after[-1] == 2; lost = after[-1] == 3 or (budget <= 0 and not won)
+        if won: kind = "success"
+        elif lost: kind = "loss"
+        elif after[10] < before[10]: kind = "return"
+        elif before[0] != after[0]: kind = "phase"
+        elif action in (1, 2): kind = "guest_cursor"
+        elif action in (3, 4): kind = "item_cursor"
+        elif before[0] == 0: kind = "probe"
+        elif before[3] != after[3]: kind = "serve_turn"
+        else: kind = "serve"
+        frames = 7 if kind in ("success", "loss", "phase", "serve_turn") else 5
+        self.begin(kind, frames, after, budget, "win" if won else "loss" if lost else None)

--- a/data/community-games/sonpham/q015_v2_q015.py
+++ b/data/community-games/sonpham/q015_v2_q015.py
@@ -1,0 +1,633 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q015-v2 Reciprocity Garden -- visible short-memory social causality.
+
+Every partner carries a three-knot memory garland and a shape-coded response
+policy.  Open-hand and closed-knot gestures rewrite that partner's memory;
+their visible reply then changes blooms or persistent obligations.  Later
+gardens add seeds, shelters, delayed replies, and neighbor cascades.  The
+target is a second, outer garland rather than a hidden answer string.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+WHITE, PEARL, ASH, SLATE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, AQUA, GOLD, CORAL, EARTH, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+
+ECHO, MAJORITY, FORGIVING, GUARDED = 0, 1, 2, 3
+HAND, KNOT, SEED, SHELTER = 0, 1, 2, 3
+
+
+RAW_LEVELS = [
+    {
+        "name": "First Welcome", "n": 2, "policies": (ECHO, ECHO),
+        "memories": (2, 5), "gestures": 2, "delay": False,
+        "cascade": False, "relay": False, "budget": 1,
+        "solution": (5,),
+    },
+    {
+        "name": "Many Garlands", "n": 3, "policies": (ECHO, ECHO, ECHO),
+        "memories": (0, 7, 2), "gestures": 2, "delay": False,
+        "cascade": False, "relay": False, "budget": 6,
+        "solution": (5, 2, 4, 5, 2, 3, 5),
+    },
+    {
+        "name": "Three-Petal Council", "n": 3,
+        "policies": (MAJORITY, ECHO, MAJORITY), "memories": (7, 0, 3),
+        "gestures": 2, "delay": False, "cascade": False, "relay": False,
+        "budget": 7, "solution": (4, 5, 2, 3, 5, 2, 4, 5),
+    },
+    {
+        "name": "Seed and Shelter", "n": 3,
+        "policies": (GUARDED, FORGIVING, ECHO), "memories": (0, 0, 5),
+        "gestures": 4, "delay": False, "cascade": False, "relay": False,
+        "budget": 6, "solution": (5, 3, 5, 2, 3, 5, 3, 3, 5),
+    },
+    {
+        "name": "Patient Ribbon", "n": 3,
+        "policies": (ECHO, MAJORITY, FORGIVING), "memories": (2, 7, 0),
+        "gestures": 4, "delay": True, "cascade": False, "relay": False,
+        "budget": 11, "solution": (5, 3, 3, 5, 2, 4, 4, 5, 3, 3, 5),
+    },
+    {
+        "name": "Neighbor Garland", "n": 4,
+        "policies": (ECHO, MAJORITY, FORGIVING, ECHO),
+        "memories": (0, 7, 0, 2), "gestures": 4, "delay": False,
+        "cascade": True, "relay": False, "budget": 7,
+        "solution": (5, 2, 4, 5, 2, 3, 5),
+    },
+    {
+        "name": "Remembered Circle", "n": 4,
+        "policies": (MAJORITY, GUARDED, ECHO, FORGIVING),
+        "memories": (7, 0, 2, 0), "gestures": 4, "delay": True,
+        "cascade": True, "relay": False, "budget": 12,
+        "solution": (4, 5, 4, 5, 2, 4, 5, 3, 3, 5, 4, 5),
+    },
+    {
+        "name": "Reciprocity Garden", "n": 5,
+        "policies": (GUARDED, MAJORITY, FORGIVING, ECHO, MAJORITY),
+        "memories": (0, 7, 1, 2, 3), "gestures": 4, "delay": True,
+        "cascade": True, "relay": True, "budget": 15,
+        "solution": (3, 5, 4, 5, 4, 4, 5, 2, 2, 4, 4, 5, 4, 4, 5),
+    },
+]
+
+
+def start_state(level):
+    # partner, gesture, three-knot memories, blooms, seeds, shelters,
+    # obligations, queued reply, two repair patches, terminal
+    return (0, 0, tuple(level["memories"]), 0, 0, 0, 0, 0, 2, 0)
+
+
+def _reply(level, memories, shelters, partner):
+    memory = memories[partner]
+    policy = level["policies"][partner]
+    if policy == ECHO:
+        return memory & 1
+    if policy == MAJORITY:
+        return int(memory.bit_count() >= 2)
+    if policy == FORGIVING:
+        return int(bool(memory & 3))
+    return int(bool(shelters & (1 << partner)))
+
+
+def _apply_reply(level, memories, blooms, seeds, obligations, recipient, reply):
+    memories = list(memories)
+
+    def apply_one(index, bit, rewrite):
+        nonlocal blooms, seeds, obligations
+        marker = 1 << index
+        if rewrite:
+            memories[index] = ((memories[index] << 1) | bit) & 7
+        if bit:
+            if seeds & marker:
+                seeds &= ~marker
+                blooms |= marker
+            else:
+                blooms ^= marker
+        else:
+            obligations ^= marker
+
+    apply_one(recipient, reply, level["relay"])
+    if level["cascade"]:
+        neighbor = (recipient + 1) % level["n"]
+        apply_one(neighbor, reply, True)
+    return tuple(memories), blooms, seeds, obligations
+
+
+def configuration_solved(level, state):
+    if state[9]:
+        return False
+    target = level["target"]
+    return (state[2] == target["memories"] and state[3] == target["blooms"]
+            and state[4] == target["seeds"] and state[5] == target["shelters"]
+            and state[6] == target["obligations"] and state[7] == target["pending"])
+
+
+def _mistake(state):
+    values = list(state)
+    if values[8] > 0:
+        values[8] -= 1
+    else:
+        values[9] = 3
+    return tuple(values)
+
+
+def transition(level, state, action):
+    partner, gesture, memories, blooms, seeds, shelters, obligations, pending, repairs, terminal = state
+    if terminal or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    if action == 1:
+        return ((partner - 1) % level["n"], gesture, memories, blooms, seeds,
+                shelters, obligations, pending, repairs, 0)
+    if action == 2:
+        return ((partner + 1) % level["n"], gesture, memories, blooms, seeds,
+                shelters, obligations, pending, repairs, 0)
+    if action == 3:
+        return (partner, (gesture - 1) % level["gestures"], memories, blooms,
+                seeds, shelters, obligations, pending, repairs, 0)
+    if action == 4:
+        return (partner, (gesture + 1) % level["gestures"], memories, blooms,
+                seeds, shelters, obligations, pending, repairs, 0)
+    if action == 6:
+        if configuration_solved(level, state):
+            return state[:-1] + (2,)
+        return _mistake(state)
+
+    marker = 1 << partner
+    if gesture in (HAND, KNOT):
+        if pending:
+            return state
+        memories = list(memories)
+        memories[partner] = ((memories[partner] << 1) | int(gesture == HAND)) & 7
+        memories = tuple(memories)
+        reply = _reply(level, memories, shelters, partner)
+        recipient = (partner + 1) % level["n"] if level["relay"] else partner
+        if level["delay"]:
+            pending = recipient * 2 + reply + 1
+        else:
+            memories, blooms, seeds, obligations = _apply_reply(
+                level, memories, blooms, seeds, obligations, recipient, reply)
+    elif gesture == SEED:
+        if pending:
+            coded = pending - 1
+            recipient, reply = coded // 2, coded % 2
+            memories, blooms, seeds, obligations = _apply_reply(
+                level, memories, blooms, seeds, obligations, recipient, reply)
+            pending = 0
+        else:
+            seeds ^= marker
+    else:
+        shelters ^= marker
+        if shelters & marker:
+            obligations &= ~marker
+    return (partner, gesture, memories, blooms, seeds, shelters, obligations,
+            pending, repairs, 0)
+
+
+def action_cost(before, after):
+    if after == before or after[8] != before[8] or after[9] in (2, 3):
+        return 0
+    return 1
+
+
+def solved(_level, state):
+    return state[9] == 2
+
+
+def _finalize_levels():
+    levels = []
+    for raw in RAW_LEVELS:
+        level = {key: deepcopy(value) for key, value in raw.items() if key != "solution"}
+        state = start_state(level)
+        for action in raw["solution"]:
+            state = transition(level, state, action)
+            assert not state[9]
+        assert not state[7]
+        level["target"] = {
+            "memories": state[2], "blooms": state[3], "seeds": state[4],
+            "shelters": state[5], "obligations": state[6], "pending": state[7],
+        }
+        levels.append(level)
+    return levels
+
+
+LEVELS = _finalize_levels()
+
+
+class GardenDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def line(frame, a, b, color, dotted=False, limit=None):
+        x0, y0 = a; x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        last = steps if limit is None else min(steps, max(0, limit * steps // 100))
+        for step in range(last + 1):
+            if dotted and step % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius * radius and (not hollow or distance >= max(0, radius - 2) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def diamond(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for dy in range(-radius, radius + 1):
+            y = cy + dy
+            if not 0 <= y < 64:
+                continue
+            width = radius - abs(dy)
+            if hollow:
+                for x in (cx - width, cx + width):
+                    if 0 <= x < 64:
+                        frame[y, x] = color
+            else:
+                frame[y, max(0, cx - width):min(64, cx + width + 1)] = color
+
+    @staticmethod
+    def positions(n):
+        return tuple((32 + round(15 * math.cos(-math.pi / 2 + 2 * math.pi * i / n)),
+                      31 + round(15 * math.sin(-math.pi / 2 + 2 * math.pi * i / n)))
+                     for i in range(n))
+
+    @staticmethod
+    def gesture_positions():
+        return ((32, 24), (39, 31), (32, 38), (25, 31))
+
+    @staticmethod
+    def badge_position(center, slot, target=False):
+        """Place seven paired state channels in one outward partner fan."""
+        x, y = center; radial_x, radial_y = x - 32, y - 31
+        length = max(1.0, math.hypot(radial_x, radial_y))
+        normal_x, normal_y = radial_x / length, radial_y / length
+        tangent_x, tangent_y = -normal_y, normal_x
+        radial = 11 if target else 7
+        tangent = (slot - 3) * 4
+        return (round(x + normal_x * radial + tangent_x * tangent),
+                round(y + normal_y * radial + tangent_y * tangent))
+
+    def background(self, frame):
+        frame[:, :] = PEARL
+        for index in range(16):
+            angle = 2 * math.pi * index / 16
+            center = (32 + round(25 * math.cos(angle)), 31 + round(24 * math.sin(angle)))
+            self.disc(frame, center, 5, ROSE)
+        self.disc(frame, (32, 31), 24, WHITE)
+        self.disc(frame, (32, 31), 22, PEARL)
+        self.disc(frame, (32, 31), 18, ROSE, hollow=True)
+        for y in range(9, 56, 7):
+            for x in range(5 + (y % 3), 60, 11):
+                self.line(frame, (x, y), (x + 2, y - 1), ASH)
+        for index in range(24):
+            angle = 2 * math.pi * index / 24
+            x = 32 + round(28 * math.cos(angle)); y = 31 + round(27 * math.sin(angle))
+            self.diamond(frame, (x, y), 1, CORAL if index % 2 else GOLD)
+
+    def policy_body(self, frame, center, policy, identity):
+        x, y = center
+        if policy == ECHO:
+            self.diamond(frame, center, 4, GREEN)
+            self.line(frame, (x, y - 3), (x, y + 4), EARTH)
+            self.line(frame, (x, y), (x + 3, y - 2), WHITE)
+        elif policy == MAJORITY:
+            for dx, dy in ((0, -3), (-3, 2), (3, 2)):
+                self.disc(frame, (x + dx, y + dy), 3, GOLD)
+            self.diamond(frame, center, 2, EARTH)
+        elif policy == FORGIVING:
+            self.disc(frame, center, 5, AQUA)
+            self.disc(frame, (x + 3, y - 1), 5, PEARL)
+            self.diamond(frame, (x - 2, y + 1), 2, GREEN)
+        else:
+            self.line(frame, (x - 5, y + 3), (x, y - 5), VIOLET)
+            self.line(frame, (x, y - 5), (x + 5, y + 3), VIOLET)
+            self.line(frame, (x - 5, y + 3), (x + 5, y + 3), EARTH)
+            self.diamond(frame, (x, y), 3, ROSE)
+        # One-to-three inset notches distinguish partners that share a policy
+        # without occupying the outward state fan.
+        count = identity % 3 + 1
+        radial_x, radial_y = x - 32, y - 31
+        length = max(1.0, math.hypot(radial_x, radial_y))
+        normal_x, normal_y = radial_x / length, radial_y / length
+        tangent_x, tangent_y = -normal_y, normal_x
+        for mark in range(count):
+            tangent = (mark - (count - 1) / 2) * 2
+            notch = (round(x - normal_x * 4 + tangent_x * tangent),
+                     round(y - normal_y * 4 + tangent_y * tangent))
+            self.diamond(frame, notch, 0, WHITE)
+
+    def memory_mark(self, frame, center, bit, target=False):
+        color = VIOLET if target else GREEN
+        if bit:
+            self.diamond(frame, center, 1, color, hollow=target)
+        else:
+            x, y = center
+            self.line(frame, (x - 1, y - 1), (x + 1, y + 1), color)
+            self.line(frame, (x + 1, y - 1), (x - 1, y + 1), color)
+
+    def memories(self, frame, center, index, state):
+        level = self.game.level
+        current = state[2][index]; target = level["target"]["memories"][index]
+        for order in range(3):
+            current_center = self.badge_position(center, order)
+            target_center = self.badge_position(center, order, target=True)
+            self.memory_mark(frame, current_center, (current >> (2 - order)) & 1)
+            self.memory_mark(frame, target_center, (target >> (2 - order)) & 1, target=True)
+
+    def badge_connectors(self, frame, center):
+        for slot in range(7):
+            current_center = self.badge_position(center, slot)
+            target_center = self.badge_position(center, slot, target=True)
+            self.line(frame, current_center, target_center, ASH, dotted=True)
+
+    def small_status(self, frame, center, kind, active, target=False):
+        x, y = center; color = VIOLET if target else EARTH
+        if not active:
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = SLATE
+            return
+        if kind == 0:  # bloom
+            for dx, dy in ((0, 0), (0, -1), (1, 0), (0, 1), (-1, 0)):
+                if 0 <= x + dx < 64 and 0 <= y + dy < 64:
+                    frame[y + dy, x + dx] = color
+        elif kind == 1:  # seed
+            self.line(frame, (x, y - 1), (x - 1, y + 1), color)
+            self.line(frame, (x - 1, y + 1), (x + 1, y + 1), color)
+            self.line(frame, (x + 1, y + 1), (x, y - 1), color)
+        elif kind == 2:  # shelter
+            self.line(frame, (x - 1, y), (x, y - 1), color)
+            self.line(frame, (x, y - 1), (x + 1, y), color)
+            self.line(frame, (x - 1, y), (x - 1, y + 1), color)
+            self.line(frame, (x + 1, y), (x + 1, y + 1), color)
+        else:  # obligation knot
+            self.line(frame, (x - 1, y - 1), (x + 1, y + 1), color)
+            self.line(frame, (x + 1, y - 1), (x - 1, y + 1), color)
+
+    def statuses(self, frame, center, index, state):
+        current_masks = state[3:7]
+        target = self.game.level["target"]
+        target_masks = (target["blooms"], target["seeds"], target["shelters"], target["obligations"])
+        for kind in range(4):
+            current_center = self.badge_position(center, 3 + kind)
+            target_center = self.badge_position(center, 3 + kind, target=True)
+            self.small_status(frame, current_center, kind,
+                              bool(current_masks[kind] & (1 << index)))
+            self.small_status(frame, target_center, kind,
+                              bool(target_masks[kind] & (1 << index)), target=True)
+
+    def gesture_icon(self, frame, center, gesture, selected=False):
+        x, y = center
+        if gesture == HAND:
+            self.diamond(frame, (x, y + 1), 2, GREEN)
+            for dx in (-2, 0, 2):
+                self.line(frame, (x + dx, y), (x + dx, y - 3), GREEN)
+        elif gesture == KNOT:
+            self.disc(frame, center, 3, EARTH, hollow=True)
+            self.line(frame, (x - 3, y - 3), (x + 3, y + 3), EARTH)
+            self.line(frame, (x + 3, y - 3), (x - 3, y + 3), EARTH)
+        elif gesture == SEED:
+            self.line(frame, (x, y - 3), (x - 3, y + 3), GOLD)
+            self.line(frame, (x - 3, y + 3), (x + 3, y + 3), GOLD)
+            self.line(frame, (x + 3, y + 3), (x, y - 3), GOLD)
+            self.diamond(frame, center, 1, GREEN)
+        else:
+            self.line(frame, (x - 4, y + 3), (x, y - 4), VIOLET)
+            self.line(frame, (x, y - 4), (x + 4, y + 3), VIOLET)
+            self.line(frame, (x - 4, y + 3), (x + 4, y + 3), EARTH)
+        if selected:
+            for dx, dy in ((0, -5), (5, 0), (0, 5), (-5, 0)):
+                self.diamond(frame, (x + dx, y + dy), 1, WHITE)
+
+    def apparatus(self, frame):
+        game = self.game; state = game.state; positions = self.positions(game.level["n"])
+        moving_partner = game.anim_kind == "partner" and game.anim_progress < max(1, game.anim_total - 1)
+        moving_gesture = game.anim_kind == "gesture" and game.anim_progress < max(1, game.anim_total - 1)
+        for index, center in enumerate(positions):
+            self.policy_body(frame, center, game.level["policies"][index], index)
+        for center in positions:
+            self.badge_connectors(frame, center)
+        for index, center in enumerate(positions):
+            self.memories(frame, center, index, state)
+            self.statuses(frame, center, index, state)
+            if index == state[0] and not moving_partner:
+                radial_x, radial_y = center[0] - 32, center[1] - 31
+                length = max(1.0, math.hypot(radial_x, radial_y))
+                tangent_x, tangent_y = -radial_y / length, radial_x / length
+                for side in (-1, 1):
+                    marker = (round(center[0] + tangent_x * 7 * side),
+                              round(center[1] + tangent_y * 7 * side))
+                    self.diamond(frame, marker, 1, WHITE)
+        for gesture in range(game.level["gestures"]):
+            self.gesture_icon(frame, self.gesture_positions()[gesture], gesture,
+                              selected=gesture == state[1] and not moving_gesture)
+        # A delayed reply remains as a physical bead and tether.
+        if state[7]:
+            coded = state[7] - 1; recipient, reply = coded // 2, coded % 2
+            target = positions[recipient]
+            self.line(frame, (32, 31), target, VIOLET, dotted=True)
+            midpoint = ((32 + target[0]) // 2, (31 + target[1]) // 2)
+            if reply:
+                self.diamond(frame, midpoint, 3, GREEN, hollow=True)
+            else:
+                self.disc(frame, midpoint, 3, EARTH, hollow=True)
+                self.line(frame, (midpoint[0] - 2, midpoint[1] - 2),
+                          (midpoint[0] + 2, midpoint[1] + 2), EARTH)
+
+    def hud(self, frame):
+        game = self.game
+        shown = game.budget_left
+        if (game.anim_kind and game.pending_budget is not None
+                and game.anim_progress >= max(1, game.anim_total - 1)
+                and game.anim_kind != "success"):
+            shown = game.pending_budget
+        for group in range((game.budget_max + 4) // 5):
+            cx, cy = 8 + group * 12, 3
+            self.disc(frame, (cx, cy), 1, EARTH)
+            offsets = ((0, -2), (2, -1), (2, 1), (-2, 1), (-2, -1))
+            for leaf, (dx, dy) in enumerate(offsets):
+                unit = group * 5 + leaf
+                if unit >= game.budget_max:
+                    continue
+                x, y = cx + dx, cy + dy
+                if unit < shown:
+                    self.diamond(frame, (x, y), 1, GREEN)
+                else:
+                    self.line(frame, (x - 1, y - 1), (x + 1, y + 1), SLATE)
+                    self.line(frame, (x + 1, y - 1), (x - 1, y + 1), SLATE)
+        for index, x in enumerate((56, 61)):
+            active = index < game.state[8]
+            self.disc(frame, (x, 60), 2, VIOLET if active else SLATE, hollow=True)
+            if active:
+                self.line(frame, (x - 1, 60), (x + 1, 60), WHITE)
+            else:
+                self.line(frame, (x - 2, 58), (x + 2, 62), RED)
+                self.line(frame, (x + 2, 58), (x - 2, 62), RED)
+
+    def terminal(self, frame):
+        terminal = self.game.state[9]
+        if terminal == 3:
+            for radius in (8, 14, 20):
+                self.disc(frame, (32, 31), radius, EARTH, hollow=True)
+            self.line(frame, (14, 13), (50, 49), SLATE)
+            self.line(frame, (50, 13), (14, 49), SLATE)
+
+    def animation(self, frame):
+        game = self.game
+        if game.intro_mark:
+            for radius in (3, 7, 11):
+                self.disc(frame, (32, 31), radius, GOLD, hollow=True)
+        if not game.anim_kind:
+            return
+        p = game.anim_progress; span = max(1, game.anim_total - 1)
+        before, after = game.anim_before, game.pending_state
+        positions = self.positions(game.level["n"])
+        if game.anim_kind == "partner" and p < span:
+            start, finish = positions[before[0]], positions[after[0]]
+            point = (start[0] + (finish[0] - start[0]) * p // span,
+                     start[1] + (finish[1] - start[1]) * p // span)
+            self.disc(frame, point, 7, WHITE, hollow=True)
+        elif game.anim_kind == "gesture" and p < span:
+            icons = self.gesture_positions(); start, finish = icons[before[1]], icons[after[1]]
+            point = (start[0] + (finish[0] - start[0]) * p // span,
+                     start[1] + (finish[1] - start[1]) * p // span)
+            self.diamond(frame, point, 4, WHITE, hollow=True)
+        elif game.anim_kind == "interact" and p < span:
+            source = (32, 31); actor = positions[before[0]]
+            if p * 2 <= span:
+                self.line(frame, source, actor, CORAL, dotted=True, limit=200 * p // span)
+                reach = (source[0] + (actor[0] - source[0]) * (2 * p) // span,
+                         source[1] + (actor[1] - source[1]) * (2 * p) // span)
+                self.disc(frame, reach, 2, GOLD, hollow=True)
+            else:
+                self.line(frame, source, actor, CORAL, dotted=True)
+                changed = ((before[3] ^ after[3]) | (before[4] ^ after[4])
+                           | (before[5] ^ after[5]) | (before[6] ^ after[6]))
+                for index, target in enumerate(positions):
+                    if changed & (1 << index):
+                        amount = (2 * p - span) * 100 // span
+                        self.line(frame, actor, target, VIOLET, dotted=True, limit=amount)
+                        point = (actor[0] + (target[0] - actor[0]) * amount // 100,
+                                 actor[1] + (target[1] - actor[1]) * amount // 100)
+                        self.diamond(frame, point, 2, GREEN, hollow=True)
+                if before[7] != after[7]:
+                    radius = 1 + (2 * p - span) * 4 // span
+                    self.disc(frame, (32, 31), radius, VIOLET, hollow=True)
+        elif game.anim_kind == "audit" and p < span:
+            x = (56, 61)[max(0, before[8] - 1)] if before[8] else 61
+            radius = 1 + 2 * p // span
+            self.line(frame, (x - radius, 60 - radius), (x + radius, 60 + radius), RED)
+            self.line(frame, (x + radius, 60 - radius), (x - radius, 60 + radius), RED)
+        elif game.anim_kind == "blocked" and p < span:
+            folded = min(p, span - p); radius = 3 + 3 * folded // max(1, span // 2)
+            self.disc(frame, positions[before[0]], radius, EARTH, hollow=True)
+        elif game.anim_kind == "success":
+            for radius in range(4, min(29, 4 + p * 4), 5):
+                self.disc(frame, (32, 31), radius, GREEN, hollow=True)
+            for index, center in enumerate(positions):
+                if index <= p:
+                    self.diamond(frame, center, 5, GOLD, hollow=True)
+        elif game.anim_kind == "loss" and p < span:
+            inset = 6 * p // span
+            self.line(frame, (8 + inset, 7 + inset), (56 - inset, 55 - inset), EARTH)
+            self.line(frame, (56 - inset, 7 + inset), (8 + inset, 55 - inset), SLATE)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        game = self.game
+        preview = (game.anim_kind in ("partner", "gesture", "interact", "audit", "blocked", "loss")
+                   and game.pending_state is not None
+                   and game.anim_progress >= max(1, game.anim_total - 1))
+        current = game.state
+        if preview:
+            game.state = game.pending_state
+        self.background(frame); self.apparatus(frame); self.hud(frame); self.terminal(frame)
+        if preview:
+            game.state = current
+        self.animation(frame)
+        return frame
+
+
+class Q015(ARCBaseGame):
+    def __init__(self):
+        self.display = GardenDisplay(self); self.level = LEVELS[0]
+        self.state = start_state(self.level); self.budget_left = self.budget_max = 0
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = None; self.pending_budget = None
+        self.pending_terminal = None; self.intro_mark = True
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(level), name=level["name"])
+                  for level in LEVELS]
+        super().__init__("q015", levels, Camera(0, 0, 64, 64, PEARL, PEARL, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = self.pending_budget = None
+        self.pending_terminal = None; self.intro_mark = True
+
+    def begin(self, kind, frames, before, after, budget, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames; self.anim_progress = 0
+        self.anim_before = before; self.pending_state = after; self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal; self.state = self.pending_state
+        self.budget_left = self.pending_budget; self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1; self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action(); return
+        self.intro_mark = False; before = self.state; after = transition(self.level, before, action)
+        if after == before:
+            self.begin("blocked", 5, before, before, self.budget_left); return
+        cost = action_cost(before, after)
+        if cost > self.budget_left:
+            lost = before[:-1] + (3,)
+            self.begin("loss", 7, before, lost, self.budget_left, "loss"); return
+        budget = self.budget_left - cost
+        if after[9] == 2:
+            kind, frames, terminal = "success", 7, "win"
+        elif after[9] == 3:
+            kind, frames, terminal = "loss", 7, "loss"
+        elif action in (1, 2):
+            kind, frames, terminal = "partner", 5, None
+        elif action in (3, 4):
+            kind, frames, terminal = "gesture", 5, None
+        elif action == 5:
+            kind, frames, terminal = "interact", 7, None
+        else:
+            kind, frames, terminal = "audit", 6, None
+        self.begin(kind, frames, before, after, budget, terminal)

--- a/data/community-games/sonpham/q021_v3_q021.py
+++ b/data/community-games/sonpham/q021_v3_q021.py
@@ -1,0 +1,538 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q021-v3 Glass Relay -- learn only enough hidden optics to schedule a clean relay."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from functools import lru_cache
+from itertools import permutations
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, PEARL, ASH, SLATE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, AQUA, GOLD, CORAL, EARTH, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+
+
+# Evidence is sufficient only when the observed operators contain an exact,
+# distinct-operator proof of evidence_steps (or solution_steps by default).
+# Early grounded-reference levels therefore require observing a zero ray as
+# well as the useful pair.  required_modes prevents the
+# violet lens from becoming ceremonial after it is introduced.  In delayed
+# levels the plate rotates one aperture clockwise before each parked pulse
+# lands, so A->B and B->A can produce different answers.
+LEVELS = [
+    {"name": "First Ray", "masks": ((0b1,),), "initial": 0, "target": 0b1, "outputs": 1, "probes": 2, "isolate": False, "delayed": False, "solution_steps": 1, "required_modes": 1, "budget": 8},
+    {"name": "Two Channels", "masks": ((0b01, 0b10, 0b00, 0b00, 0b00),), "initial": 0, "target": 0b11, "outputs": 2, "probes": 3, "isolate": True, "delayed": False, "solution_steps": 2, "evidence_steps": 3, "required_modes": 1, "budget": 13},
+    {"name": "Shared Glass", "masks": ((0b011, 0b110, 0b111, 0b000, 0b000),), "initial": 0, "target": 0b101, "outputs": 3, "probes": 4, "isolate": True, "delayed": False, "solution_steps": 2, "evidence_steps": 3, "required_modes": 1, "budget": 13},
+    {"name": "Violet Lens", "masks": ((0b001, 0b110, 0b101), (0b100, 0b011, 0b110)), "initial": 0, "target": 0b111, "outputs": 3, "probes": 5, "isolate": True, "delayed": False, "solution_steps": 2, "required_modes": 2, "budget": 12},
+    {"name": "Charged Baseline", "masks": ((0b0011, 0b0110, 0b1100), (0b1001, 0b0101, 0b1010)), "initial": 0b1111, "target": 0b0101, "outputs": 4, "probes": 6, "isolate": True, "delayed": False, "solution_steps": 3, "required_modes": 2, "budget": 14},
+    {"name": "Echo Socket", "masks": ((0b0011, 0b0110, 0b1100),), "initial": 0, "target": 0b1111, "outputs": 4, "probes": 5, "isolate": True, "delayed": True, "solution_steps": 2, "required_modes": 1, "budget": 10},
+    {"name": "Double Refraction", "masks": ((0b00011, 0b01100, 0b10101, 0b11010), (0b10001, 0b00110, 0b01011, 0b11100)), "initial": 0b00101, "target": 0b10011, "outputs": 5, "probes": 7, "isolate": True, "delayed": True, "solution_steps": 3, "required_modes": 2, "budget": 14},
+    {"name": "Glass Relay", "masks": ((0b00101, 0b01011, 0b10110, 0b11100), (0b10010, 0b01101, 0b11001, 0b00111)), "initial": 0b10001, "target": 0b01110, "outputs": 5, "probes": 8, "isolate": True, "delayed": True, "solution_steps": 3, "required_modes": 2, "budget": 14},
+]
+
+
+def lever_count(level):
+    return len(level["masks"][0])
+
+
+def start_state(level):
+    # stage, cursor, test lamps, live lamps, probes, mode, parked code,
+    # seen mode0, seen mode1, judgment crescents, terminal
+    return 0, 0, level["initial"], level["initial"], level["probes"], 0, 0, 0, 0, 2, 0
+
+
+def decode_pending(level, code):
+    value = code - 1
+    return value // lever_count(level), value % lever_count(level)
+
+
+def rotate_apertures(value, outputs):
+    mask = (1 << outputs) - 1
+    return ((value << 1) & mask) | ((value >> (outputs - 1)) & 1)
+
+
+def delayed_apply(level, value, operator):
+    return rotate_apertures(value, level["outputs"]) ^ operator
+
+
+def _seen_operators(level, seen0, seen1):
+    found = []
+    for mode, seen in enumerate((seen0, seen1)):
+        if mode >= len(level["masks"]):
+            continue
+        for cursor, operator in enumerate(level["masks"][mode]):
+            if seen & (1 << cursor):
+                found.append((mode, cursor, operator))
+    return tuple(found)
+
+
+@lru_cache(None)
+def _evidence_search(masks, initial, target, outputs, delayed, steps, required_modes, seen0, seen1):
+    level = {"masks": masks, "outputs": outputs}
+    operators = _seen_operators(level, seen0, seen1)
+    if len(operators) < steps:
+        return False
+    required = (1 << required_modes) - 1
+    for sequence in permutations(operators, steps):
+        modes = 0
+        value = initial
+        for mode, _cursor, operator in sequence:
+            modes |= 1 << mode
+            value = delayed_apply(level, value, operator) if delayed else value ^ operator
+        if modes & required == required and value == target:
+            return True
+    return False
+
+
+def evidence_sufficient(level, seen0, seen1):
+    masks = tuple(tuple(family) for family in level["masks"])
+    return _evidence_search(
+        masks, level["initial"], level["target"], level["outputs"],
+        level["delayed"], level.get("evidence_steps", level["solution_steps"]),
+        level["required_modes"], seen0, seen1,
+    )
+
+
+def _mark_seen(level, code, seen0, seen1):
+    mode, cursor = decode_pending(level, code)
+    if mode == 0:
+        seen0 |= 1 << cursor
+    else:
+        seen1 |= 1 << cursor
+    return seen0, seen1
+
+
+def transition(level, state, action):
+    stage, cursor, test, live, probes, mode, pending, seen0, seen1, chances, terminal = state
+    if terminal or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    count = lever_count(level)
+    modes = len(level["masks"])
+
+    # Any deliberate next action launches a parked echo before that action is
+    # applied.  On the safe plate it also writes the learned ray into the ledger.
+    # On the live plate the clockwise pre-rotation makes pulse order meaningful.
+    if level["delayed"] and pending and action != 3:
+        old_mode, old_cursor = decode_pending(level, pending)
+        operator = level["masks"][old_mode][old_cursor]
+        if stage == 0:
+            test = delayed_apply(level, test, operator)
+            seen0, seen1 = _mark_seen(level, pending, seen0, seen1)
+        else:
+            live = delayed_apply(level, live, operator)
+        pending = 0
+
+    if action == 1:
+        return stage, (cursor - 1) % count, test, live, probes, mode, pending, seen0, seen1, chances, terminal
+    if action == 2:
+        return stage, (cursor + 1) % count, test, live, probes, mode, pending, seen0, seen1, chances, terminal
+    if action == 6:
+        if modes < 2:
+            return stage, cursor, test, live, probes, mode, pending, seen0, seen1, chances, terminal
+        return stage, cursor, test, live, probes, 1 - mode, pending, seen0, seen1, chances, terminal
+    if action == 4:
+        baseline = level["initial"]
+        if stage == 0:
+            return stage, cursor, baseline, live, probes, mode, 0, seen0, seen1, chances, terminal
+        return stage, cursor, test, baseline, probes, mode, 0, seen0, seen1, chances, terminal
+    if action == 3:
+        if stage == 0:
+            if probes <= 0 or (level["isolate"] and test != level["initial"]):
+                return state
+            if level["delayed"]:
+                if pending:
+                    old_mode, old_cursor = decode_pending(level, pending)
+                    operator = level["masks"][old_mode][old_cursor]
+                    test = delayed_apply(level, test, operator)
+                    seen0, seen1 = _mark_seen(level, pending, seen0, seen1)
+                pending = 1 + mode * count + cursor
+            else:
+                test ^= level["masks"][mode][cursor]
+                if mode == 0:
+                    seen0 |= 1 << cursor
+                else:
+                    seen1 |= 1 << cursor
+            return stage, cursor, test, live, probes - 1, mode, pending, seen0, seen1, chances, terminal
+        if level["delayed"]:
+            if pending:
+                old_mode, old_cursor = decode_pending(level, pending)
+                live = delayed_apply(level, live, level["masks"][old_mode][old_cursor])
+            pending = 1 + mode * count + cursor
+        else:
+            live ^= level["masks"][mode][cursor]
+        return stage, cursor, test, live, probes, mode, pending, seen0, seen1, chances, terminal
+
+    # ACTION5 is the only seal: first it transfers sufficient evidence to a
+    # clean plate; later it judges that plate.  A wrong judgment consumes one
+    # crescent for free, while the second wrong judgment ends the run.
+    if stage == 0:
+        if not evidence_sufficient(level, seen0, seen1):
+            return stage, cursor, test, live, probes, mode, pending, seen0, seen1, chances, terminal
+        return 1, cursor, test, level["initial"], probes, 0, 0, seen0, seen1, chances, terminal
+    if live == level["target"]:
+        terminal = 2
+    else:
+        chances -= 1
+        if chances <= 0:
+            terminal = 3
+    return stage, cursor, test, live, probes, mode, pending, seen0, seen1, chances, terminal
+
+
+def action_cost(state, after):
+    if after == state:
+        return 0
+    if state[0] == 1 and after[9] < state[9]:
+        return 0
+    return 1
+
+
+def solved(_level, state):
+    return state[-1] == 2
+
+
+class RelayDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius ** 2 and (not hollow or distance >= max(0, radius - 2) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def line(frame, a, b, color, dotted=False, thick=False):
+        x0, y0 = a
+        x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for i in range(steps + 1):
+            if dotted and i % 4 in (1, 2):
+                continue
+            x = x0 + (x1 - x0) * i // steps
+            y = y0 + (y1 - y0) * i // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+                if thick and 0 <= y + 1 < 64:
+                    frame[y + 1, x] = color
+
+    def background(self, frame):
+        frame[:, :] = INK
+        for y in range(2, 63, 6):
+            frame[y:y + 2, 3 + y % 4:62:8] = CHARCOAL
+        for x in range(5, 63, 10):
+            frame[3 + x % 5:61:12, x:x + 2] = SLATE
+        self.disc(frame, (32, 29), 31, SLATE, hollow=True)
+        self.disc(frame, (32, 29), 27, CHARCOAL, hollow=True)
+
+    def lever_center(self, index):
+        count = lever_count(self.game.level)
+        return 9 + index * (46 // max(1, count - 1)), 49
+
+    def lamp_center(self, index, live=False):
+        count = self.game.level["outputs"]
+        return 9 + index * (46 // max(1, count - 1)), 29 if live else 13
+
+    def lamp(self, frame, center, index, active, target=False):
+        x, y = center
+        color = AQUA if active else ASH
+        if index % 4 == 0:
+            self.disc(frame, center, 5, color, hollow=not active)
+        elif index % 4 == 1:
+            self.line(frame, (x, y - 5), (x + 5, y), color, thick=True)
+            self.line(frame, (x + 5, y), (x, y + 5), color, thick=True)
+            self.line(frame, (x, y + 5), (x - 5, y), color, thick=True)
+            self.line(frame, (x - 5, y), (x, y - 5), color, thick=True)
+        elif index % 4 == 2:
+            self.line(frame, (x, y - 5), (x + 5, y + 5), color, thick=True)
+            self.line(frame, (x + 5, y + 5), (x - 5, y + 5), color, thick=True)
+            self.line(frame, (x - 5, y + 5), (x, y - 5), color, thick=True)
+        else:
+            self.line(frame, (x - 5, y), (x + 5, y), color, thick=True)
+            self.line(frame, (x, y - 5), (x, y + 5), color, thick=True)
+        if active:
+            self.disc(frame, center, 3, PEARL)
+        if target:
+            self.disc(frame, center, 7, VIOLET, hollow=True)
+
+    def instrument(self, frame):
+        g = self.game
+        s = g.state
+        frame[6:21, 3:61] = CHARCOAL
+        frame[22:38, 3:61] = SLATE
+        frame[7:9, 5:59] = ASH
+        frame[35:37, 5:59] = CHARCOAL
+        for index in range(g.level["outputs"]):
+            bit = 1 << index
+            self.lamp(frame, self.lamp_center(index, False), index, bool(s[2] & bit))
+            self.lamp(frame, self.lamp_center(index, True), index, bool(s[3] & bit), bool(g.level["target"] & bit))
+
+        # Thick, persistent evidence rays are offset and patterned by mode.
+        for mode, seen in enumerate((s[7], s[8])):
+            if mode >= len(g.level["masks"]):
+                continue
+            for index in range(lever_count(g.level)):
+                if not seen & (1 << index):
+                    continue
+                operator = g.level["masks"][mode][index]
+                source = self.lever_center(index)
+                # A witnessed collar always gains a mode-shaped ledger stud,
+                # including the grounded zero operator that emits no ray.
+                if mode:
+                    self.line(frame, (source[0], 41), (source[0] + 2, 43), VIOLET, thick=True)
+                    self.line(frame, (source[0] + 2, 43), (source[0] - 2, 43), VIOLET, thick=True)
+                    self.line(frame, (source[0] - 2, 43), (source[0], 41), VIOLET, thick=True)
+                else:
+                    self.disc(frame, (source[0], 42), 2, AQUA, hollow=True)
+                for lamp_index in range(g.level["outputs"]):
+                    if not operator & (1 << lamp_index):
+                        continue
+                    destination = self.lamp_center(lamp_index, False)
+                    offset = 1 if mode else -1
+                    self.line(
+                        frame, (source[0] + offset, source[1]),
+                        (destination[0] + offset, destination[1]),
+                        VIOLET if mode else AQUA, dotted=not mode, thick=True,
+                    )
+                    if mode:
+                        midpoint = ((source[0] + destination[0]) // 2 + 1, (source[1] + destination[1]) // 2)
+                        self.disc(frame, midpoint, 1, PEARL)
+
+        for index in range(lever_count(g.level)):
+            x, y = self.lever_center(index)
+            selected = index == s[1]
+            self.disc(frame, (x, y), 6, PEARL if selected else SLATE, hollow=not selected)
+            tip = (x + 4, y - 4) if s[5] else (x - 3, y - 5)
+            self.line(frame, (x, y + 2), tip, VIOLET if s[5] else AQUA, thick=True)
+            if selected:
+                self.disc(frame, (x, y), 8, AQUA if not s[5] else VIOLET, hollow=True)
+
+        if s[6]:
+            pending_mode, pending_cursor = decode_pending(g.level, s[6])
+            x, y = self.lever_center(pending_cursor)
+            if pending_mode:
+                self.line(frame, (x, y - 15), (x + 5, y - 10), VIOLET, thick=True)
+                self.line(frame, (x + 5, y - 10), (x, y - 5), VIOLET, thick=True)
+                self.line(frame, (x, y - 5), (x - 5, y - 10), VIOLET, thick=True)
+                self.line(frame, (x - 5, y - 10), (x, y - 15), VIOLET, thick=True)
+            else:
+                self.disc(frame, (x, y - 10), 5, AQUA, hollow=True)
+            self.disc(frame, (x, y - 10), 2, PEARL)
+
+        # Lens and delayed rotation rule are both geometric, not color-only.
+        if s[5]:
+            self.line(frame, (26, 43), (38, 43), VIOLET, thick=True)
+            self.line(frame, (38, 43), (32, 37), VIOLET, thick=True)
+            self.line(frame, (32, 37), (26, 43), VIOLET, thick=True)
+        else:
+            self.line(frame, (26, 37), (38, 37), AQUA, thick=True)
+            self.line(frame, (38, 37), (32, 43), AQUA, thick=True)
+            self.line(frame, (32, 43), (26, 37), AQUA, thick=True)
+        if g.level["delayed"]:
+            self.disc(frame, (32, 29), 10, PEARL, hollow=True)
+            self.line(frame, (38, 23), (41, 27), AQUA, thick=True)
+            self.line(frame, (41, 27), (36, 27), AQUA, thick=True)
+
+    def hud(self, frame):
+        g = self.game
+        s = g.state
+        # Probe charge is grouped into exact four-cell cartridges.
+        for index in range(g.level["probes"]):
+            group, cell = divmod(index, 4)
+            x = 5 + cell * 4 + group * 19
+            color = AQUA if index < s[4] else CHARCOAL
+            self.disc(frame, (x, 60), 2, color, hollow=index >= s[4])
+        # Exact action cells form separated five-cell metal cassettes.
+        for index in range(g.budget_max):
+            group, cell = divmod(index, 5)
+            x = 1 + cell
+            y = 7 + group * 4
+            if index < g.budget_left:
+                frame[y:y + 2, x:x + 2] = PEARL
+            else:
+                frame[y, x] = CHARCOAL
+            if cell == 4:
+                frame[y:y + 2, 7] = SLATE
+        for index in range(s[9]):
+            self.disc(frame, (56 + index * 5, 60), 3, GOLD, hollow=True)
+
+        # Open fork means experiment; one large closed diamond means live seal.
+        if s[0] == 0:
+            self.line(frame, (44, 56), (49, 62), GREEN, thick=True)
+            self.line(frame, (54, 56), (49, 62), GREEN, thick=True)
+        else:
+            self.line(frame, (43, 60), (49, 54), RED, thick=True)
+            self.line(frame, (49, 54), (55, 60), RED, thick=True)
+            self.line(frame, (55, 60), (49, 63), RED, thick=True)
+            self.line(frame, (49, 63), (43, 60), RED, thick=True)
+
+    def animation(self, frame):
+        g = self.game
+        if not g.anim_kind:
+            if g.intro_mark:
+                self.disc(frame, self.lever_center(0), 10, AQUA, hollow=True)
+            if g.terminal_hold == "loss":
+                self.line(frame, (7, 8), (57, 53), RED, thick=True)
+                self.line(frame, (57, 8), (7, 53), RED, thick=True)
+            return
+        progress = g.anim_progress
+        total = max(1, g.anim_total)
+        before = g.state
+        after = g.pending_state
+        if g.anim_kind in ("cursor", "lens"):
+            self.disc(frame, self.lever_center(after[1]), 7 + progress // 2, VIOLET if after[5] else AQUA, hollow=True)
+        elif g.anim_kind in ("probe", "act", "park"):
+            source = self.lever_center(before[1])
+            if progress <= 2:
+                self.disc(frame, source, max(3, 8 - progress * 2), PEARL, hollow=True)
+            else:
+                destination = (source[0], source[1] - 10)
+                fraction = progress - 2
+                bead = (source[0], source[1] + (destination[1] - source[1]) * fraction // max(1, total - 2))
+                self.disc(frame, bead, 2, AQUA if before[5] == 0 else VIOLET)
+        elif g.anim_kind in ("echo", "echo_reset"):
+            pending_mode, pending_cursor = decode_pending(g.level, before[6])
+            source = (self.lever_center(pending_cursor)[0], 39)
+            destination = (32, 13 if before[0] == 0 else 29)
+            bead = (
+                source[0] + (destination[0] - source[0]) * progress // total,
+                source[1] + (destination[1] - source[1]) * progress // total,
+            )
+            self.line(frame, source, bead, VIOLET if pending_mode else AQUA, dotted=True, thick=True)
+            self.disc(frame, bead, 3, PEARL)
+            if g.anim_kind == "echo_reset" and progress > total // 2:
+                self.disc(frame, (32, 22), 5 + progress * 2, BLUE, hollow=True)
+        elif g.anim_kind == "reset":
+            for radius in range(5, min(31, 5 + progress * 4), 6):
+                self.disc(frame, (32, 22), radius, BLUE, hollow=True)
+        elif g.anim_kind == "seal":
+            left = max(5, 32 - progress * 5)
+            right = min(59, 32 + progress * 5)
+            frame[18:39, left:right] = SLATE
+            self.disc(frame, (32, 29), 5 + progress * 2, VIOLET, hollow=True)
+        elif g.anim_kind == "recoil":
+            y = 24 + progress
+            frame[y:y + 2, 10 + progress:54 - progress] = RED
+            self.disc(frame, (32, 29), 6 + progress, RED, hollow=True)
+        elif g.anim_kind == "success":
+            if before[6]:
+                _mode, pending_cursor = decode_pending(g.level, before[6])
+                source = (self.lever_center(pending_cursor)[0], 39)
+                self.line(frame, source, (32, 29), AQUA, dotted=True, thick=True)
+            for radius in range(6, min(32, 6 + progress * 4), 6):
+                self.disc(frame, (32, 29), radius, AQUA, hollow=True)
+        elif g.anim_kind == "loss":
+            self.line(frame, (7 + progress, 8), (57 - progress, 53), RED, thick=True)
+            self.line(frame, (57 - progress, 8), (7 + progress, 53), RED, thick=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self.background(frame)
+        self.instrument(frame)
+        self.hud(frame)
+        self.animation(frame)
+        return frame
+
+
+class Q021(ARCBaseGame):
+    def __init__(self):
+        self.display = RelayDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"]) for item in LEVELS]
+        super().__init__("q021", levels, Camera(0, 0, 64, 64, INK, INK, [self.display]), False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+
+    def begin(self, kind, frames, state, budget, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.pending_state = state
+        self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state
+        self.budget_left = self.pending_budget
+        self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.terminal_hold = "win"
+            self.next_level()
+        elif terminal == "loss":
+            self.terminal_hold = "loss"
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        self.intro_mark = False
+        after = transition(self.level, self.state, action)
+        if after == self.state:
+            self.begin("recoil", 5, after, self.budget_left)
+            return
+        budget = self.budget_left - action_cost(self.state, after)
+        won = after[-1] == 2
+        lost = after[-1] == 3 or (budget <= 0 and not won)
+        launched_echo = bool(self.level["delayed"] and self.state[6] and (
+            after[2] != self.state[2] or after[3] != self.state[3]
+        ))
+        if won:
+            kind = "success"
+        elif lost:
+            kind = "loss"
+        elif after[9] < self.state[9]:
+            kind = "recoil"
+        elif after[0] != self.state[0]:
+            kind = "seal"
+        elif launched_echo and action == 4:
+            kind = "echo_reset"
+        elif launched_echo:
+            kind = "echo"
+        elif after[5] != self.state[5]:
+            kind = "lens"
+        elif after[1] != self.state[1]:
+            kind = "cursor"
+        elif action == 4:
+            kind = "reset"
+        elif action == 3 and self.level["delayed"]:
+            kind = "park"
+        elif action == 3:
+            kind = "probe" if self.state[0] == 0 else "act"
+        else:
+            kind = "seal"
+        frames = 7 if kind in ("success", "loss", "seal") else 6
+        self.begin(kind, frames, after, budget, "win" if won else "loss" if lost else None)

--- a/data/community-games/sonpham/q022_v2_q022.py
+++ b/data/community-games/sonpham/q022_v2_q022.py
@@ -1,0 +1,641 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q022-v2 Daybreak Kinetic Scaffold.
+
+Large signed levers send exact tension quanta through visibly patterned ropes.
+Tower masses integrate those quanta, rigid rails reject out-of-bounds pulls,
+slack cables must be taken up, and target-height catches can latch one tower
+while later coupled pulls continue elsewhere.  Every stable value is integral;
+there is no timing, stochastic, or hidden-identity rule.
+
+The accepted mx002 deterministic-physics candidate is the tension-and-mass
+simulation itself. Concurrent strategy and hidden uncertainty were rejected:
+this is a fully observable side-view machine with deliberate discrete pulls.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+from typing import NamedTuple
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, MIST, PEARL, SLATE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, CYAN, SUN = 6, 7, 8, 9, 10, 11
+COPPER, OXBLOOD, MOSS, VIOLET = 12, 13, 14, 15
+
+ACTIVE, WIN, LOSS = 0, 2, 3
+LEVER_ACTIONS = (1, 2)
+TERMINAL_INDEX = 7
+LOW, HIGH = 0, 6
+
+
+class State(NamedTuple):
+    values: tuple
+    cursor: int
+    tension: tuple
+    taut: int
+    latched: int
+    audited: int
+    strikes: int
+    terminal: int
+
+
+def scaffold(name, start, target, lever_effects, witness, *, masses=None,
+             slack=(), latches=(), cursor=0, features=()):
+    start = tuple(int(value) for value in start)
+    target = tuple(int(value) for value in target)
+    effects = tuple(tuple(int(value) for value in row)
+                    for row in lever_effects)
+    masses = tuple(int(value) for value in (
+        masses if masses is not None else (1,) * len(start)))
+    assert len(start) == len(target) == len(masses)
+    assert effects and all(len(row) == len(start) for row in effects)
+    slack_mask = sum(1 << int(index) for index in slack)
+    latch_mask = sum(1 << int(index) for index in latches)
+    return {
+        "name": name,
+        "start": start,
+        "target": target,
+        "lever_effects": effects,
+        "masses": masses,
+        "slack_rigs": slack_mask,
+        "required_latches": latch_mask,
+        "cursor": int(cursor),
+        "budget": len(tuple(witness)),
+        "witness": tuple(witness),
+        "physical_features": tuple(features),
+        "bounds": (LOW, HIGH),
+    }
+
+
+LEVELS = (
+    scaffold(
+        "Opposed Rope",
+        (1, 3), (3, 1),
+        ((1, -1),),
+        (1, 1, 5, 6),
+        features=("signed_coupling",),
+    ),
+    scaffold(
+        "Three-Way Balance",
+        (0, 3, 6), (3, 3, 3),
+        ((1, -1, 0), (0, 1, -1)),
+        (1, 1, 1, 4, 1, 1, 1, 5, 6),
+        features=("signed_coupling",),
+    ),
+    scaffold(
+        "Ratio Flywheel",
+        (0, 4, 6), (2, 6, 3),
+        ((1, -1, 0), (0, 2, -1)),
+        (1, 1, 1, 4, 1, 1, 1, 5, 6),
+        masses=(1, 2, 1), slack=(0,),
+        features=("signed_coupling", "ratio_gears", "mass_quanta",
+                  "slack_takeup"),
+    ),
+    scaffold(
+        "Slack Sunrise",
+        (0, 3, 6), (3, 3, 3),
+        ((1, -1, 0), (0, 1, -1)),
+        (1, 1, 1, 1, 4, 1, 1, 1, 5, 6),
+        slack=(0,),
+        features=("signed_coupling", "slack_takeup"),
+    ),
+    scaffold(
+        "Catch and Return",
+        (6, 0, 6), (3, 3, 3),
+        ((1, -1, 0), (-1, 0, 1)),
+        (2, 2, 2, 4, 2, 2, 2, 5, 6),
+        latches=(0,),
+        features=("signed_coupling", "target_latches"),
+    ),
+    scaffold(
+        "Asymmetric Gantry",
+        (0, 6, 6, 0), (3, 6, 3, 3),
+        ((2, -1, 0, 0), (0, 1, -1, 0), (0, 0, 0, 1)),
+        (3, 1, 1, 1, 4, 1, 1, 1, 4, 1, 1, 1, 5, 6),
+        masses=(2, 1, 1, 1), latches=(0,), cursor=1,
+        features=("signed_coupling", "ratio_gears", "mass_quanta",
+                  "target_latches"),
+    ),
+    scaffold(
+        "Tension Choir",
+        (0, 6, 6, 0), (3, 6, 3, 3),
+        ((2, -1, 0, 0), (0, 1, -1, 0), (0, 0, 0, 1)),
+        (3, 1, 1, 1, 1, 4, 1, 1, 1, 4, 1, 1, 1, 5, 6),
+        masses=(2, 1, 1, 1), slack=(0,), latches=(0,), cursor=1,
+        features=("signed_coupling", "ratio_gears", "mass_quanta",
+                  "slack_takeup", "target_latches"),
+    ),
+    scaffold(
+        "Daybreak Kinetic Scaffold",
+        (0, 6, 6, 0), (3, 6, 4, 2),
+        ((2, -2, 0, 0), (0, 3, -1, 0), (0, 0, -1, 2)),
+        (1, 1, 1, 4, 1, 1, 1, 4, 1, 1, 5, 6),
+        masses=(2, 1, 1, 2), slack=(1,), latches=(0, 2),
+        features=("signed_coupling", "ratio_gears", "mass_quanta",
+                  "slack_takeup", "target_latches"),
+    ),
+)
+
+
+def parse_action(action):
+    if isinstance(action, (tuple, list)):
+        return int(action[0])
+    return int(action)
+
+
+def action_tokens(_level):
+    return (1, 2, 3, 4, 5, 6)
+
+
+def encode_action(_level, action):
+    return (parse_action(action),)
+
+
+def start_state(level):
+    return State(
+        level["start"], level["cursor"],
+        tuple(0 for _ in level["start"]), 0, 0, 0, 0, ACTIVE,
+    )
+
+
+def lever_tokens(level):
+    """Return the two public signed pull controls (forward and reverse)."""
+    return LEVER_ACTIONS
+
+
+def coupled_effect(level, state, lever_token=None):
+    """Return the current rig's signed vector for a public pull control.
+
+    Action 1 follows the printed signs and action 2 reverses them. The
+    optional two-argument form addresses an authored rig directly for
+    internal pure calculations.
+    """
+    if lever_token is None:
+        return tuple(level["lever_effects"][int(state)])
+    direction = 1 if parse_action(lever_token) == 1 else -1
+    return tuple(direction * value
+                 for value in level["lever_effects"][state.cursor])
+
+
+def physical_state(_level, state):
+    """Compact observable physics signature: height, residual tension, catches."""
+    return (tuple(state.values), tuple(state.tension), state.taut, state.latched)
+
+
+def _signed_quotient(value, divisor):
+    return (1 if value >= 0 else -1) * (abs(value) // divisor)
+
+
+def physics_step(level, state, lever, direction=1, *, mode="physics",
+                 missing_feature=None):
+    """Apply one exact tension quantum and return a settled immutable state."""
+    lever = int(lever); direction = 1 if int(direction) >= 0 else -1
+    if not 0 <= lever < len(level["lever_effects"]):
+        return state
+    if mode == "without_physics":
+        return state
+    if missing_feature == "slack_takeup" and level["slack_rigs"] & (1 << lever):
+        return state
+
+    bit = 1 << lever
+    if level["slack_rigs"] & bit and not state.taut & bit:
+        return state._replace(taut=state.taut | bit, audited=0)
+
+    effect = list(coupled_effect(level, lever))
+    if mode == "without_coupling":
+        keep = next((index for index, value in enumerate(effect) if value), None)
+        effect = [value if index == keep else 0
+                  for index, value in enumerate(effect)]
+    if missing_feature == "signed_coupling":
+        effect = [value if index == lever % len(effect) else 0
+                  for index, value in enumerate(effect)]
+    if missing_feature == "ratio_gears":
+        effect = [(value > 0) - (value < 0) for value in effect]
+
+    masses = ((1,) * len(level["masses"])
+              if missing_feature == "mass_quanta" else level["masses"])
+    latch_enabled = missing_feature != "target_latches"
+    values = list(state.values)
+    tension = list(state.tension)
+    for index, force in enumerate(effect):
+        if state.latched & (1 << index):
+            continue
+        total = tension[index] + direction * force
+        movement = _signed_quotient(total, masses[index])
+        tension[index] = total - movement * masses[index]
+        values[index] += movement
+
+    low, high = level["bounds"]
+    if any(value < low or value > high for value in values):
+        return state
+
+    latched = state.latched
+    if latch_enabled:
+        for index in range(len(values)):
+            bit = 1 << index
+            if (level["required_latches"] & bit
+                    and values[index] == level["target"][index]
+                    and tension[index] == 0):
+                latched |= bit
+    result = state._replace(
+        values=tuple(values), tension=tuple(tension), latched=latched,
+        audited=0,
+    )
+    return result
+
+
+def effective_delta(level, state, lever, direction=1):
+    """Public settled height delta for a candidate pull from ``state``."""
+    after = physics_step(level, state, lever, direction)
+    return tuple(right - left for left, right in zip(state.values, after.values))
+
+
+def ready(level, state):
+    return (state.values == level["target"]
+            and all(value == 0 for value in state.tension)
+            and state.latched & level["required_latches"]
+            == level["required_latches"]
+            and state.taut & level["slack_rigs"] == level["slack_rigs"])
+
+
+def _transition(level, state, action, *, mode="physics",
+                missing_feature=None, missing_lever=None):
+    if state.terminal != ACTIVE:
+        return state
+    aid = parse_action(action)
+    if aid not in action_tokens(level):
+        return state
+    if aid in LEVER_ACTIONS:
+        if missing_lever == state.cursor:
+            return state
+        return physics_step(
+            level, state, state.cursor, 1 if aid == 1 else -1,
+            mode=mode, missing_feature=missing_feature)
+    if aid in (3, 4):
+        size = len(level["lever_effects"])
+        cursor = max(0, min(size - 1,
+                            state.cursor + (-1 if aid == 3 else 1)))
+        if cursor == state.cursor:
+            return state
+        return state._replace(cursor=cursor, audited=0)
+    if aid == 5:
+        if ready(level, state):
+            return state._replace(audited=1)
+        strikes = state.strikes + 1
+        return state._replace(
+            strikes=strikes,
+            terminal=LOSS if strikes >= 2 else ACTIVE,
+        )
+    if not state.audited or not ready(level, state):
+        return state
+    return state._replace(terminal=WIN)
+
+
+def transition(level, state, action):
+    return _transition(level, state, action)
+
+
+def without_physics(level, state, action):
+    return _transition(level, state, action, mode="without_physics")
+
+
+def without_coupling(level, state, action):
+    return _transition(level, state, action, mode="without_coupling")
+
+
+def without_feature(level, state, action, feature):
+    return _transition(level, state, action, missing_feature=str(feature))
+
+
+def without_lever(level, state, action, lever):
+    return _transition(level, state, action, missing_lever=int(lever))
+
+
+def action_cost(before, after):
+    if after == before:
+        return 0
+    if after.strikes > before.strikes or after.terminal == LOSS:
+        return 0
+    return 1
+
+
+def solved(level, state):
+    return state.terminal == WIN and state.audited and ready(level, state)
+
+
+def execute(level, actions, transition_fn=transition):
+    state = start_state(level)
+    budget = level["budget"]
+    for action in actions:
+        after = transition_fn(level, state, action)
+        budget -= action_cost(state, after)
+        state = after
+    return state, budget
+
+
+for _level in LEVELS:
+    _state, _left = execute(_level, _level["witness"])
+    assert solved(_level, _state) and _left == 0, (
+        _level["name"], _state, _left)
+assert {parse_action(action) for level in LEVELS
+        for action in level["witness"]} == set(range(1, 7))
+
+
+class ScaffoldDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def line(frame, start, end, color, dotted=False, width=1):
+        x0, y0 = start; x1, y1 = end
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 4 in (1, 2):
+                continue
+            x = round(x0 + (x1 - x0) * step / steps)
+            y = round(y0 + (y1 - y0) * step / steps)
+            frame[max(0, y - width + 1):min(64, y + width),
+                  max(0, x - width + 1):min(64, x + width)] = color
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        yy, xx = np.ogrid[:64, :64]
+        distance = (xx - cx) ** 2 + (yy - cy) ** 2
+        mask = distance <= radius ** 2
+        if hollow:
+            mask &= distance >= max(0, radius - 1) ** 2
+        frame[mask] = color
+
+    @staticmethod
+    def diamond(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        yy, xx = np.ogrid[:64, :64]
+        distance = abs(xx - cx) + abs(yy - cy)
+        mask = distance <= radius
+        if hollow:
+            mask &= distance >= max(0, radius - 1)
+        frame[mask] = color
+
+    def tower_xs(self):
+        count = len(self.game.level["start"])
+        if count == 2:
+            return (20, 44)
+        if count == 3:
+            return (13, 32, 51)
+        return (10, 25, 40, 55)
+
+    @staticmethod
+    def value_y(value):
+        return 43 - int(value) * 5
+
+    def background(self, frame):
+        frame[:, :] = PAPER
+        frame[6:62, 3:61] = MIST
+        for y in range(8, 60, 4):
+            for x in range(5 + (y // 4) % 3, 60, 6):
+                frame[y, x] = PEARL if (x + y) % 4 else CYAN
+        frame[7:9, 5:59] = SUN
+        frame[45:48, 5:59] = COPPER
+        for x in range(5, 60, 7):
+            frame[46:50, x:x + 2] = SLATE
+
+    def effect_plate(self, frame, lever, center, selected, taut):
+        cx, cy = center
+        effect = coupled_effect(self.game.level, lever)
+        color = BLUE if selected else COPPER
+        frame[cy - 5:cy + 6, cx - 7:cx + 8] = CHARCOAL
+        frame[cy - 4:cy + 5, cx - 6:cx + 7] = PEARL
+        if self.game.level["slack_rigs"] & (1 << lever):
+            self.diamond(frame, center, 7, MAGENTA if taut else ROSE,
+                         hollow=True)
+        else:
+            self.disc(frame, center, 7, color, hollow=True)
+        start = cx - (len(effect) * 3) // 2 + 1
+        for index, force in enumerate(effect):
+            x = start + index * 3
+            hue = SUN if force > 0 else BLUE if force < 0 else SLATE
+            frame[cy - 1:cy + 2, x:x + 2] = hue
+            for notch in range(abs(force)):
+                y = cy - 3 - notch * 2 if force > 0 else cy + 3 + notch * 2
+                if 0 <= y < 64:
+                    frame[y:y + 1, x:x + 2] = hue
+        if selected:
+            frame[cy - 7:cy - 5, cx - 2:cx + 3] = BLUE
+
+    def ropes(self, frame, state):
+        xs = self.tower_xs()
+        count = len(self.game.level["lever_effects"])
+        centers = tuple((round((index + 1) * 64 / (count + 1)), 55)
+                        for index in range(count))
+        for lever, center in enumerate(centers):
+            for tower, force in enumerate(coupled_effect(self.game.level, lever)):
+                if not force:
+                    continue
+                target = (xs[tower], 10 + lever * 2)
+                color = SUN if force > 0 else BLUE
+                self.line(frame, center, target, color,
+                          dotted=force < 0, width=1)
+                for notch in range(abs(force)):
+                    x = target[0] + notch - abs(force) // 2
+                    frame[target[1] - 1:target[1] + 2, x:x + 1] = color
+        for lever, center in enumerate(centers):
+            self.effect_plate(frame, lever, center, lever == state.cursor,
+                              bool(state.taut & (1 << lever)))
+
+    def towers(self, frame, state):
+        for index, (x, value, target, mass, tension) in enumerate(zip(
+                self.tower_xs(), state.values, self.game.level["target"],
+                self.game.level["masses"], state.tension)):
+            frame[11:44, x - 4:x + 5] = PEARL
+            frame[11:44, x - 4:x - 2] = SLATE
+            frame[11:44:3, x - 1:x + 4] = SLATE
+            ty = self.value_y(target)
+            frame[ty - 1:ty + 2, x - 6:x + 7] = MOSS
+            frame[ty, x - 4:x + 5:2] = PAPER
+            y = self.value_y(value)
+            frame[y - 2:y + 3, x - 6:x + 7] = CHARCOAL
+            frame[y - 1:y + 2, x - 5:x + 6] = SUN
+            size = 2 + mass
+            frame[y + 3:y + 3 + size, x - size:x + size + 1] = COPPER
+            for mark in range(mass):
+                frame[y + 4:y + 5, x - mass + mark * 2:x - mass + mark * 2 + 1] = INK
+            if tension:
+                self.diamond(frame, (x + 5, y + 5), abs(tension),
+                             BLUE if tension < 0 else MAGENTA)
+            bit = 1 << index
+            if self.game.level["required_latches"] & bit:
+                self.disc(frame, (x, ty), 7,
+                          MOSS if state.latched & bit else ROSE, hollow=True)
+
+    def instruments(self, frame, state):
+        for bead in range(self.game.budget_max):
+            x = 5 + bead * 3
+            color = SUN if bead < self.game.budget_left else PEARL
+            self.diamond(frame, (x, 3), 1, color)
+        for seal in range(2):
+            center = (58, 13 + seal * 7)
+            self.disc(frame, center, 3,
+                      RED if seal < state.strikes else MOSS,
+                      hollow=seal >= state.strikes)
+            if seal < state.strikes:
+                self.line(frame, (center[0] - 2, center[1] - 2),
+                          (center[0] + 2, center[1] + 2), PAPER)
+        self.diamond(frame, (4, 13), 3,
+                     MOSS if state.audited else SLATE, hollow=not state.audited)
+        if state.terminal == LOSS:
+            self.line(frame, (4, 9), (60, 58), RED, width=2)
+            self.line(frame, (60, 9), (4, 58), OXBLOOD, width=2)
+
+    def animation(self, frame):
+        g = self.game
+        if not g.anim_kind:
+            return
+        before, after = g.state, g.pending_state
+        p = g.anim_progress; span = max(1, g.anim_total - 1)
+        wave = min(p, span - p)
+        count = len(g.level["lever_effects"])
+        controls = tuple((round((index + 1) * 64 / (count + 1)), 55)
+                         for index in range(count))
+        if g.anim_kind in ("pull", "slack"):
+            source = controls[before.cursor]
+            effect = coupled_effect(g.level, before.cursor)
+            for tower, force in enumerate(effect):
+                if not force:
+                    continue
+                target = (self.tower_xs()[tower], 10 + before.cursor * 2)
+                center = (round(source[0] + (target[0] - source[0]) * p / span),
+                          round(source[1] + (target[1] - source[1]) * p / span))
+                self.diamond(frame, center, 1 + wave // 2,
+                             SUN if force > 0 else BLUE)
+                if before.values[tower] != after.values[tower]:
+                    y0 = self.value_y(before.values[tower])
+                    y1 = self.value_y(after.values[tower])
+                    y = round(y0 + (y1 - y0) * p / span)
+                    frame[y - 1:y + 2, target[0] - 6:target[0] + 7] = MAGENTA
+        elif g.anim_kind == "select":
+            a = controls[before.cursor]; b = controls[after.cursor]
+            center = (round(a[0] + (b[0] - a[0]) * p / span),
+                      round(a[1] + (b[1] - a[1]) * p / span))
+            self.disc(frame, center, 7 + wave, BLUE, hollow=True)
+        elif g.anim_kind in ("audit", "reject", "success", "loss"):
+            self.disc(frame, (32, 31), 7 + p * 3, MOSS if g.anim_kind in ("audit", "success") else RED,
+                      hollow=True)
+            for index, x in enumerate(self.tower_xs()):
+                phase = (p + index) % 4
+                self.diamond(frame, (x, 8 + phase), 1 + wave // 2,
+                             MOSS if after.values[index] == g.level["target"][index] else RED)
+            if g.anim_kind == "loss":
+                inset = min(18, p * 3)
+                self.line(frame, (4 + inset, 8), (60 - inset, 58), RED, width=2)
+                self.line(frame, (60 - inset, 8), (4 + inset, 58), OXBLOOD, width=2)
+        else:
+            center = controls[before.cursor]
+            offset = (-2, 2, -1, 1, 0)[min(p, 4)]
+            self.disc(frame, (center[0] + offset, center[1]), 8, RED,
+                      hollow=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self.background(frame)
+        self.ropes(frame, self.game.state)
+        self.towers(frame, self.game.state)
+        self.instruments(frame, self.game.state)
+        self.animation(frame)
+        return frame
+
+
+class Q022(ARCBaseGame):
+    def __init__(self):
+        self.display = ScaffoldDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_total = self.anim_left = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(level),
+                        name=level["name"]) for level in LEVELS]
+        super().__init__("q022", levels,
+                         Camera(0, 0, 64, 64, PAPER, PAPER, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_total = self.anim_left = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+
+    def begin(self, kind, frames, after, budget, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.pending_state = after
+        self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state
+        self.budget_left = self.pending_budget
+        self.anim_kind = None
+        self.anim_total = self.anim_left = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        aid = self.action.id.value
+        if aid == 0:
+            self.complete_action()
+            return
+        before = self.state
+        after = transition(self.level, before, aid)
+        if after == before:
+            self.begin("blocked", 5, before, self.budget_left)
+            return
+        cost = action_cost(before, after)
+        budget = self.budget_left - cost
+        won = after.terminal == WIN
+        lost = after.terminal == LOSS or (budget <= 0 and not won)
+        if lost and after.terminal != LOSS:
+            after = after._replace(terminal=LOSS)
+        if won:
+            kind, frames, terminal = "success", 6, "win"
+        elif lost:
+            kind, frames, terminal = "loss", 6, "loss"
+        elif aid in LEVER_ACTIONS:
+            kind = "slack" if after.values == before.values else "pull"
+            frames, terminal = 7, None
+        elif aid in (3, 4):
+            kind, frames, terminal = "select", 6, None
+        elif aid == 5 and after.strikes > before.strikes:
+            kind, frames, terminal = "reject", 6, None
+        else:
+            kind, frames, terminal = "audit", 6, None
+        self.begin(kind, frames, after, budget, terminal)
+
+
+if __name__ == "__main__":
+    for configured in LEVELS:
+        result, left = execute(configured, configured["witness"])
+        assert solved(configured, result) and left == 0
+    print("q022-v2 ok")

--- a/data/community-games/sonpham/q030_v2_q030.py
+++ b/data/community-games/sonpham/q030_v2_q030.py
@@ -1,0 +1,324 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q030-v2 Rootward Clinic -- shape-coded treatment through a living network."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, PEARL, ASH, SLATE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, AQUA, GOLD, CORAL, EARTH, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+
+
+LEVELS = [
+    {"name": "First Root", "start": (2, 2, 1), "edges": ((0, 1), (1, 2)),
+     "plan": (5, 4, 5), "distance": False, "shields": (), "hidden": False,
+     "catalysts": (), "one_use": False, "required": (0, 1), "budget": 5},
+    {"name": "Second Ring", "start": (2, 1, 2, 1, 2), "edges": ((0, 1), (1, 2), (2, 3), (3, 4)),
+     "plan": (5, 4, 4, 5, 4, 4, 5, 3, 3, 5), "distance": True, "shields": (), "hidden": False,
+     "catalysts": (), "one_use": False, "required": (0, 2, 4), "budget": 7},
+    {"name": "Shell Nodes", "start": (2, 2, 1, 2, 1), "edges": ((0, 1), (0, 2), (2, 3), (2, 4)),
+     "plan": (4, 5, 4, 5, 4, 5, 3, 3, 3, 5), "distance": True, "shields": (1, 3), "hidden": False,
+     "catalysts": (), "one_use": False, "required": (0, 1, 2, 3), "budget": 11},
+    {"name": "Buried Mycelium", "start": (2, 1, 2, 1, 2, 1),
+     "edges": ((0, 1), (1, 2), (1, 3), (3, 4), (2, 5)),
+     "plan": (1, 5, 4, 4, 5, 4, 4, 5, 3, 3, 5), "distance": True, "shields": (4,), "hidden": True,
+     "catalysts": (), "one_use": False, "required": (0, 2, 4), "budget": 11},
+    {"name": "Star Sap", "start": (2, 2, 1, 2, 2, 1),
+     "edges": ((0, 1), (1, 2), (2, 3), (2, 4), (4, 5)),
+     "plan": (4, 4, 5, 4, 4, 5, 3, 3, 3, 5, 4, 5), "distance": True, "shields": (1,), "hidden": False,
+     "catalysts": (2, 4), "one_use": False, "required": (1, 2, 4), "budget": 9},
+    {"name": "Scar Memory", "start": (2, 1, 2, 2, 1, 2),
+     "edges": ((0, 1), (1, 2), (2, 3), (3, 4), (2, 5)),
+     "plan": (5, 4, 4, 5, 4, 5, 4, 5, 4, 5), "distance": True, "shields": (3,), "hidden": False,
+     "catalysts": (2,), "one_use": True, "required": (0, 2, 3, 4, 5), "budget": 12},
+    {"name": "Moonroot Ward", "start": (2, 2, 1, 2, 1, 2, 1),
+     "edges": ((0, 1), (1, 2), (1, 3), (3, 4), (3, 5), (5, 6)),
+     "plan": (1, 4, 5, 4, 4, 5, 4, 4, 5, 3, 3, 3, 5, 4, 4, 5), "distance": True,
+     "shields": (2, 5), "hidden": True, "catalysts": (1, 4), "one_use": True,
+     "required": (1, 2, 3, 4, 5), "budget": 14},
+    {"name": "Rootward Clinic", "start": (2, 1, 2, 2, 1, 2, 2, 1),
+     "edges": ((0, 1), (1, 2), (2, 3), (2, 4), (4, 5), (4, 6), (6, 7)),
+     "plan": (1, 5, 4, 4, 5, 4, 4, 5, 4, 5, 4, 4, 5), "distance": True,
+     "shields": (3, 6), "hidden": True, "catalysts": (2, 4), "one_use": True,
+     "required": (0, 2, 4, 5, 7), "budget": 15},
+]
+
+
+def adjacency(level):
+    out = {i: set() for i in range(len(level["start"]))}
+    for a, b in level["edges"]:
+        out[a].add(b); out[b].add(a)
+    return out
+
+
+def rings(level, node):
+    near = adjacency(level)[node]
+    graph = adjacency(level)
+    far = set().union(*(graph[n] for n in near)) - near - {node} if near else set()
+    return near, far
+
+
+def start_state(level):
+    return tuple(level["start"]), 0, not level.get("hidden"), 0, 2
+
+
+def transition(level, state, action):
+    values, cursor, probed, spent, chances = state
+    if chances <= 0:
+        return state
+    if action == 1 and level.get("hidden") and not probed:
+        return values, cursor, True, spent, chances
+    if action == 3:
+        return values, (cursor - 1) % len(values), probed, spent, chances
+    if action == 4:
+        return values, (cursor + 1) % len(values), probed, spent, chances
+    if action != 5:
+        return state
+    if level.get("one_use") and spent & (1 << cursor):
+        return state
+    near, far = rings(level, cursor)
+    revised = list(values)
+    revised[cursor] = max(0, revised[cursor] - 1)
+    shields = set(level.get("shields", ()))
+    for node in near:
+        if node not in shields:
+            revised[node] = max(0, revised[node] - 1)
+    if level.get("distance"):
+        healing_star = cursor in level.get("catalysts", ())
+        for node in far:
+            if node in shields:
+                continue
+            revised[node] = max(0, revised[node] - 1) if healing_star else min(2, revised[node] + 1)
+    return tuple(revised), cursor, probed, spent | (1 << cursor), chances
+
+
+def target_values(level):
+    state = start_state(level)
+    for action in level["plan"]:
+        state = transition(level, state, action)
+    return state[0]
+
+
+def solved(level, state):
+    values, _cursor, probed, spent, chances = state
+    required = sum(1 << node for node in level.get("required", ()))
+    return (values == target_values(level) and probed and spent & required == required and chances > 0)
+
+
+def submit_transition(level, state):
+    if solved(level, state):
+        return state
+    values, cursor, probed, spent, chances = state
+    return values, cursor, probed, spent, chances - 1
+
+
+class RootDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def _disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                d = (x - cx) ** 2 + (y - cy) ** 2
+                if d <= radius ** 2 and (not hollow or d >= max(0, radius - 2) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def _line(frame, a, b, color, dotted=False):
+        x0, y0 = a; x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for i in range(steps + 1):
+            if dotted and i % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * i // steps; y = y0 + (y1 - y0) * i // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    @staticmethod
+    def _positions(n):
+        return tuple((32 + round(19 * math.cos(-math.pi / 2 + 2 * math.pi * i / n)),
+                      33 + round(18 * math.sin(-math.pi / 2 + 2 * math.pi * i / n))) for i in range(n))
+
+    def _background(self, frame):
+        frame[:, :] = INK
+        frame[3:61, 3:61] = CHARCOAL
+        for y in range(5, 60, 6):
+            frame[y, 5 + y % 5:59:8] = EARTH
+        for x in range(6, 59, 9):
+            frame[7 + x % 4:58:7, x] = SLATE
+        self._disc(frame, (32, 34), 25, INK)
+
+    def _edges(self, frame):
+        g = self.game; positions = self._positions(len(g.state[0]))
+        if g.state[2]:
+            for a, b in g.level["edges"]:
+                self._line(frame, positions[a], positions[b], AQUA, dotted=False)
+                ax, ay = positions[a]; bx, by = positions[b]
+                self._line(frame, (ax, ay + 1), (bx, by + 1), GREEN, dotted=True)
+        elif g.level.get("hidden"):
+            # The buried network is represented by a closed root halo, not invisible pixels.
+            self._disc(frame, (32, 34), 23, VIOLET, hollow=True)
+            for i in range(12):
+                x, y = 32 + round(23 * math.cos(i * math.pi / 6)), 34 + round(23 * math.sin(i * math.pi / 6))
+                frame[y, x] = ASH
+
+    def _node(self, frame, node, center, value, target, cursor, spent):
+        g = self.game; x, y = center
+        color = (GREEN, GOLD, RED)[value]
+        # Organic six-petal body, with thorn count redundantly encoding sickness.
+        self._disc(frame, center, 6, SLATE)
+        for dx, dy in ((0, -5), (5, 0), (0, 5), (-5, 0)):
+            self._disc(frame, (x + dx, y + dy), 3, color)
+        self._disc(frame, center, 3, INK)
+        for i in range(value):
+            frame[y - 1 + i * 2:y + i * 2 + 1, x - 7:x + 8] = RED
+        # Mini target buds sit above every node as 0/1/2 distinct geometry.
+        for i in range(target):
+            self._disc(frame, (x - 2 + i * 4, y - 9), 1, PEARL)
+        if node in g.level.get("shields", ()):
+            self._disc(frame, center, 9, PEARL, hollow=True)
+            frame[y - 9:y - 7, x - 2:x + 3] = PEARL
+        if node in g.level.get("catalysts", ()):
+            frame[y - 3:y + 4, x] = GOLD; frame[y, x - 3:x + 4] = GOLD
+            self._line(frame, (x - 3, y - 3), (x + 3, y + 3), GOLD)
+        # A leaf flag marks nodes that must actually receive treatment.  Its
+        # silhouette closes into a round seed once treated, independent of hue.
+        if node in g.level.get("required", ()):
+            marker = (x + 8, y + 6)
+            if spent:
+                self._disc(frame, marker, 2, PEARL, hollow=True)
+                frame[marker[1], marker[0]] = PEARL
+            else:
+                self._line(frame, (x + 6, y + 3), (x + 6, y + 10), PEARL)
+                self._line(frame, (x + 6, y + 3), (x + 11, y + 5), PEARL)
+                self._line(frame, (x + 11, y + 5), (x + 6, y + 7), PEARL)
+        if spent and g.level.get("one_use"):
+            self._line(frame, (x - 6, y - 6), (x + 6, y + 6), ASH)
+            self._line(frame, (x + 6, y - 6), (x - 6, y + 6), ASH)
+        if cursor:
+            frame[y - 11:y - 9, x - 5:x + 6] = ROSE
+            frame[y + 9:y + 11, x - 5:x + 6] = ROSE
+            frame[y - 5:y + 6, x - 11:x - 9] = ROSE
+            frame[y - 5:y + 6, x + 9:x + 11] = ROSE
+
+    def _hud(self, frame):
+        g = self.game
+        groups, remainder = divmod(g.budget_left, 5)
+        for i in range(groups): self._disc(frame, (7 + i * 5, 59), 2, GREEN, hollow=True)
+        for i in range(remainder): frame[57:59, 44 + i * 2] = GOLD
+        for i in range(2):
+            x = 55 + i * 4
+            if i < g.state[4]: self._disc(frame, (x, 59), 2, ROSE, hollow=True)
+            else:
+                self._line(frame, (x - 2, 57), (x + 2, 61), RED)
+                self._line(frame, (x + 2, 57), (x - 2, 61), RED)
+        if g.level.get("hidden"):
+            # Probe state is closed bud versus branching eye.
+            if g.state[2]:
+                self._disc(frame, (6, 6), 4, AQUA, hollow=True)
+                frame[6, 2:11] = AQUA; frame[2:11, 6] = AQUA
+            else:
+                self._disc(frame, (6, 6), 4, VIOLET)
+                frame[5:8, 4:9] = INK
+
+    def _animation(self, frame):
+        g = self.game
+        if not g.anim_kind:
+            if g.intro_mark: self._disc(frame, (32, 34), 12, GOLD, hollow=True)
+            if g.terminal_hold == "loss":
+                self._line(frame, (9, 19), (55, 50), RED)
+                self._line(frame, (55, 19), (9, 50), RED)
+            elif g.terminal_hold == "win":
+                self._disc(frame, (32, 34), 20, GREEN, hollow=True)
+            return
+        p = g.anim_progress; positions = self._positions(len(g.state[0]))
+        if g.anim_kind == "cursor":
+            a = positions[g.anim_before[1]]; b = positions[g.pending_state[1]]
+            x = a[0] + (b[0] - a[0]) * p // g.anim_total
+            y = a[1] + (b[1] - a[1]) * p // g.anim_total
+            self._disc(frame, (x, y), 2 + p % 2, ROSE)
+        elif g.anim_kind == "probe":
+            self._disc(frame, (32, 34), min(25, 4 + p * 4), AQUA, hollow=True)
+        elif g.anim_kind == "treat":
+            center = positions[g.state[1]]
+            self._disc(frame, center, min(14, 3 + p * 2), GOLD, hollow=True)
+            near, far = rings(g.level, g.state[1])
+            for node in near: self._line(frame, center, positions[node], GREEN)
+            for node in far: self._line(frame, center, positions[node], VIOLET, dotted=True)
+        elif g.anim_kind == "blocked":
+            x, y = positions[g.state[1]]
+            self._line(frame, (x - 7 - p, y - 7), (x + 7 + p, y + 7), ASH)
+        elif g.anim_kind == "miss":
+            self._disc(frame, (32, 34), min(22, 5 + p * 3), RED, hollow=True)
+        elif g.anim_kind == "success":
+            self._disc(frame, (32, 34), min(25, 5 + p * 3), GREEN, hollow=True)
+            for x, y in positions:
+                self._disc(frame, (x, y), min(8, 2 + p), PEARL, hollow=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self._background(frame); self._edges(frame)
+        g = self.game; positions = self._positions(len(g.state[0])); targets = target_values(g.level)
+        for i, value in enumerate(g.state[0]):
+            self._node(frame, i, positions[i], value, targets[i], i == g.state[1], bool(g.state[3] & (1 << i)))
+        self._hud(frame); self._animation(frame)
+        return frame
+
+
+class Q030(ARCBaseGame):
+    def __init__(self):
+        self.display = RootDisplay(self); self.level = LEVELS[0]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0; self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0; self.anim_before = self.state
+        self.pending_state = None; self.pending_terminal = None; self.intro_mark = True; self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"]) for item in LEVELS]
+        super().__init__("q030", levels, Camera(0, 0, 64, 64, INK, INK, [self.display]), False, len(levels), [1, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = None; self.pending_terminal = None; self.intro_mark = True; self.terminal_hold = None
+
+    def _begin(self, kind, frames, state, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames; self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = state; self.pending_terminal = terminal
+
+    def _finish(self):
+        terminal = self.pending_terminal; self.state = self.pending_state
+        self.anim_kind = None; self.pending_state = None; self.pending_terminal = None
+        if terminal == "win": self.terminal_hold = "win"; self.next_level()
+        elif terminal == "loss" or self.budget_left <= 0: self.terminal_hold = "loss"; self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1; self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0: self._finish()
+            return
+        action = self.action.id.value
+        if action == 0: self.complete_action(); return
+        self.intro_mark = False
+        if action == 6:
+            won = solved(self.level, self.state); after = self.state if won else submit_transition(self.level, self.state)
+            if not won: self.budget_left -= 1
+            self._begin("success" if won else "miss", 7, after,
+                        "win" if won else "loss" if after[4] <= 0 or self.budget_left <= 0 else None)
+            return
+        after = transition(self.level, self.state, action)
+        if after == self.state:
+            self._begin("blocked", 4, after); return
+        self.budget_left -= 1
+        kind = "probe" if action == 1 else "cursor" if action in (3, 4) else "treat"
+        self._begin(kind, 5 if kind != "treat" else 7, after,
+                    "loss" if self.budget_left <= 0 else None)

--- a/data/community-games/sonpham/q031_v2_q031.py
+++ b/data/community-games/sonpham/q031_v2_q031.py
@@ -1,0 +1,627 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q031-v2 Cryogenic Manifold -- induce exact conserved-flow operators.
+
+A dark glass transfer bench exposes every quantity, capacity, conduit direction,
+movable bridge, phase filter, and linked-manifold consequence.  The player
+selects a conduit and a machine, then composes exact, deterministic transfers.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+WHITE, PEARL, ASH, SLATE, STEEL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, CYAN, GOLD, ORANGE, BROWN, GREEN, VIOLET = range(6, 16)
+
+DRIP, FLUSH, SPLIT, SLIDE, BALANCE, PHASE, MANIFOLD, ROTOR = range(8)
+
+
+RAW_LEVELS = [
+    {
+        "name": "Cold Start", "start": (4, 0, 0), "capacities": (4, 4, 4),
+        "ops": (DRIP,), "directions": (1, 1), "bridge": False,
+        "filter": False, "linked": False, "phase": 0,
+        "solution": (5, 2, 5),
+    },
+    {
+        "name": "Rated Chambers", "start": (6, 0, 0, 0),
+        "capacities": (6, 2, 3, 4),
+        "ops": (DRIP, FLUSH), "directions": (1, 1, 1), "bridge": False,
+        "filter": False, "linked": False, "phase": 0,
+        "solution": (4, 5, 2, 5, 2, 5),
+    },
+    {
+        "name": "Sliding Coupler", "start": (5, 0, 0, 0),
+        "capacities": (5, 5, 5, 5), "ops": (DRIP, SLIDE),
+        "directions": (1, 1, 1), "bridge": True, "filter": False,
+        "linked": False, "phase": 0,
+        "solution": (5, 2, 4, 5, 3, 5, 4, 5, 3, 2, 5),
+    },
+    {
+        "name": "Check-Valve Rack", "start": (0, 0, 8, 0),
+        "capacities": (8, 8, 8, 8), "ops": (DRIP, SPLIT),
+        "directions": (1, -1, 1), "bridge": False, "filter": False,
+        "linked": False, "phase": 0,
+        "solution": (2, 3, 5, 3, 5, 2, 5),
+    },
+    {
+        "name": "Phase Interlock", "start": (4, 0, 0, 0),
+        "capacities": (4, 4, 4, 4), "ops": (DRIP, PHASE, BALANCE),
+        "directions": (1, 1, 1), "bridge": False, "filter": True,
+        "linked": False, "phase": 0,
+        "solution": (5, 2, 4, 5, 3, 5, 2, 4, 5, 3, 5),
+    },
+    {
+        "name": "Mirrored Header", "start": (5, 0, 0, 0, 5),
+        "capacities": (6, 6, 6, 6, 6),
+        "ops": (MANIFOLD, BALANCE), "directions": (1, 1, -1, -1),
+        "bridge": False, "filter": False, "linked": True, "phase": 0,
+        "solution": (5, 5, 5, 2, 5, 5),
+    },
+    {
+        "name": "Commissioning Run", "start": (8, 0, 0, 0, 0),
+        "capacities": (8, 4, 3, 4, 4),
+        "ops": (SPLIT, SLIDE, ROTOR, FLUSH), "directions": (1, 1, 1, -1),
+        "bridge": True, "filter": False, "linked": False, "phase": 0,
+        "solution": (5, 2, 4, 5, 3, 5, 2, 4, 5, 4, 5, 4, 5),
+    },
+    {
+        "name": "Night Qualification", "start": (4, 0, 0, 0, 4),
+        "capacities": (5, 3, 4, 3, 5),
+        "ops": (MANIFOLD, PHASE, ROTOR, BALANCE),
+        "directions": (1, 1, -1, -1), "bridge": False, "filter": True,
+        "linked": True, "phase": 0,
+        "solution": (5, 5, 1, 1, 5, 4, 5, 4, 5),
+    },
+]
+
+
+def start_state(level):
+    # conduit cursor, machine cursor, quantities, bridge position, phase,
+    # two recoverable audit seals, terminal (0 live, 2 win, 3 loss)
+    return (0, 0, tuple(level["start"]), 0, level["phase"], 2, 0)
+
+
+def _edge_open(level, state, edge):
+    if level["bridge"] and edge != state[3]:
+        return False
+    if level["filter"] and edge % 2 != state[4]:
+        return False
+    return True
+
+
+def _oriented_pair(level, edge):
+    if level["directions"][edge] > 0:
+        return edge, edge + 1
+    return edge + 1, edge
+
+
+def _transfer(level, values, edge, amount=None):
+    source, destination = _oriented_pair(level, edge)
+    movable = values[source]
+    room = level["capacities"][destination] - values[destination]
+    count = min(movable, room) if amount is None else min(amount, movable, room)
+    if count <= 0:
+        return tuple(values)
+    result = list(values); result[source] -= count; result[destination] += count
+    return tuple(result)
+
+
+def _apply_machine(level, state):
+    channel, machine_cursor, values, bridge, phase, seals, terminal = state
+    machine = level["ops"][machine_cursor]
+    edges = len(values) - 1
+    if machine == SLIDE:
+        if not level["bridge"]:
+            return state
+        return (channel, machine_cursor, values, (bridge + 1) % edges,
+                phase, seals, terminal)
+    if machine == PHASE:
+        if not level["filter"]:
+            return state
+        return (channel, machine_cursor, values, bridge, 1 - phase, seals, terminal)
+    if machine == ROTOR:
+        rotated = (values[-1],) + values[:-1]
+        if any(value > capacity for value, capacity in zip(rotated, level["capacities"])):
+            return state
+        return (channel, machine_cursor, rotated, bridge, phase, seals, terminal)
+    if not _edge_open(level, state, channel):
+        return state
+    if machine == DRIP:
+        result = _transfer(level, values, channel, 1)
+    elif machine == FLUSH:
+        result = _transfer(level, values, channel)
+    elif machine == SPLIT:
+        source, destination = _oriented_pair(level, channel)
+        if values[source] <= 0 or values[source] % 2 or values[destination] != 0:
+            return state
+        half = values[source] // 2
+        if half > level["capacities"][destination]:
+            return state
+        result = list(values); result[source] = half; result[destination] = half
+        result = tuple(result)
+    elif machine == BALANCE:
+        left, right = channel, channel + 1
+        total = values[left] + values[right]
+        low, high = total // 2, total - total // 2
+        if level["directions"][channel] > 0:
+            candidate = (low, high)
+        else:
+            candidate = (high, low)
+        if candidate[0] > level["capacities"][left] or candidate[1] > level["capacities"][right]:
+            return state
+        result = list(values); result[left], result[right] = candidate
+        result = tuple(result)
+    elif machine == MANIFOLD:
+        if not level["linked"]:
+            return state
+        mirror = edges - 1 - channel
+        selected_edges = (channel,) if mirror == channel else (channel, mirror)
+        deltas = [0] * len(values)
+        for edge in selected_edges:
+            source, destination = _oriented_pair(level, edge)
+            deltas[source] -= 1; deltas[destination] += 1
+        if any(values[index] + delta < 0 or
+               values[index] + delta > level["capacities"][index]
+               for index, delta in enumerate(deltas)):
+            return state
+        result = tuple(value + delta for value, delta in zip(values, deltas))
+    else:
+        return state
+    if result == values:
+        return state
+    assert sum(result) == sum(values)
+    return (channel, machine_cursor, result, bridge, phase, seals, terminal)
+
+
+def configuration_solved(level, state):
+    return (not state[6] and state[2] == level["target"]
+            and (not level["bridge"] or state[3] == level["bridge_target"])
+            and (not level["filter"] or state[4] == level["phase_target"]))
+
+
+def transition(level, state, action):
+    channel, machine, values, bridge, phase, seals, terminal = state
+    if terminal or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    if action == 1:
+        return ((channel - 1) % (len(values) - 1), machine, values,
+                bridge, phase, seals, terminal)
+    if action == 2:
+        return ((channel + 1) % (len(values) - 1), machine, values,
+                bridge, phase, seals, terminal)
+    if action == 3:
+        return (channel, (machine - 1) % len(level["ops"]), values,
+                bridge, phase, seals, terminal)
+    if action == 4:
+        return (channel, (machine + 1) % len(level["ops"]), values,
+                bridge, phase, seals, terminal)
+    if action == 5:
+        return _apply_machine(level, state)
+    if configuration_solved(level, state):
+        return state[:-1] + (2,)
+    if seals > 1:
+        return state[:5] + (seals - 1, 0)
+    return state[:5] + (0, 3)
+
+
+def action_cost(before, after):
+    if before == after or before[5] != after[5] or after[6] in (2, 3):
+        return 0
+    return 1
+
+
+def solved(_level, state):
+    return state[6] == 2
+
+
+def _finalize_levels():
+    levels = []
+    for raw in RAW_LEVELS:
+        level = {key: deepcopy(value) for key, value in raw.items() if key != "solution"}
+        state = start_state(level)
+        for action in raw["solution"]:
+            before = state; state = transition(level, state, action)
+            assert state != before, (raw["name"], action, state)
+            assert not state[6]
+        assert state[2] != tuple(raw["start"])
+        level["target"] = state[2]
+        level["bridge_target"] = state[3]
+        level["phase_target"] = state[4]
+        level["budget"] = len(raw["solution"])
+        level["solution"] = tuple(raw["solution"])
+        assert configuration_solved(level, state)
+        levels.append(level)
+    return levels
+
+
+LEVELS = _finalize_levels()
+
+
+class ManifoldDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def line(frame, a, b, color, dotted=False, limit=100):
+        x0, y0 = a; x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        last = min(steps, max(0, limit * steps // 100))
+        for step in range(last + 1):
+            if dotted and step % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    @staticmethod
+    def diamond(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for dy in range(-radius, radius + 1):
+            y = cy + dy
+            if not 0 <= y < 64:
+                continue
+            width = radius - abs(dy)
+            if hollow:
+                for x in (cx - width, cx + width):
+                    if 0 <= x < 64:
+                        frame[y, x] = color
+            else:
+                frame[y, max(0, cx - width):min(64, cx + width + 1)] = color
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius * radius and (not hollow or distance >= (radius - 1) ** 2):
+                    frame[y, x] = color
+
+    def background(self, frame):
+        frame[:, :] = INK
+        for y in range(2, 52, 6):
+            self.line(frame, (0, y), (63, y - 5), STEEL, dotted=True)
+        for x in range(-12, 76, 12):
+            self.line(frame, (x, 0), (x + 24, 48), SLATE, dotted=True)
+        self.line(frame, (2, 18), (61, 18), BLUE)
+        self.line(frame, (2, 49), (61, 49), CYAN)
+        for x in range(4, 62, 8):
+            self.diamond(frame, (x, 49), 1, STEEL)
+        # Riveted asymmetric chassis corners keep the field instrument-like.
+        for x, y in ((3, 3), (60, 3), (3, 46), (60, 46)):
+            self.disc(frame, (x, y), 2, SLATE, hollow=True)
+            self.diamond(frame, (x, y), 0, PEARL)
+
+    @staticmethod
+    def vessel_positions(n):
+        spacing = 11 if n == 5 else 13
+        left = 32 - spacing * (n - 1) // 2
+        return tuple(left + spacing * index for index in range(n))
+
+    def glass_vessel(self, frame, x, value, capacity, target=False):
+        top, bottom = (7, 16) if target else (23, 45)
+        half = 3 if target else 4
+        color = VIOLET if target else CYAN
+        # Chamfered glass rather than a rectangular tank.
+        self.line(frame, (x - half + 1, top), (x + half - 1, top), BLUE)
+        self.line(frame, (x - half + 1, top), (x - half, top + 2), BLUE)
+        self.line(frame, (x - half, top + 2), (x - half + 1, bottom - 2), BLUE)
+        self.line(frame, (x - half + 1, bottom - 2), (x - half + 2, bottom), BLUE)
+        self.line(frame, (x - half + 2, bottom), (x + half - 2, bottom), BLUE)
+        self.line(frame, (x + half - 2, bottom), (x + half - 1, bottom - 2), BLUE)
+        self.line(frame, (x + half - 1, bottom - 2), (x + half, top + 2), BLUE)
+        self.line(frame, (x + half, top + 2), (x + half - 1, top), BLUE)
+        span = bottom - top - 3
+        cap_y = bottom - max(1, span * capacity // 8)
+        self.line(frame, (x - half + 1, cap_y), (x + half - 1, cap_y), GOLD, dotted=True)
+        if target:
+            fill_y = bottom - max(0, span * value // 8)
+            self.line(frame, (x - half + 1, fill_y), (x + half - 1, fill_y), VIOLET)
+            for unit in range(value):
+                y = bottom - 1 - unit
+                if y > top:
+                    frame[y, x] = VIOLET
+        else:
+            for unit in range(value):
+                y = bottom - 2 - unit * 2
+                if y > top:
+                    self.diamond(frame, (x, y), 1, color, hollow=unit % 2 == 1)
+            fill_y = bottom - max(0, span * value // 8)
+            self.line(frame, (x - half + 2, fill_y), (x + half - 2, fill_y), WHITE)
+
+    def conduits(self, frame, state):
+        level = self.game.level; xs = self.vessel_positions(len(state[2]))
+        for edge in range(len(xs) - 1):
+            left, right = xs[edge], xs[edge + 1]; y = 35
+            open_edge = _edge_open(level, state, edge)
+            color = CYAN if open_edge else SLATE
+            self.line(frame, (left + 5, y), (right - 5, y), color,
+                      dotted=not open_edge)
+            direction = level["directions"][edge]
+            tip = (right - 5 if direction > 0 else left + 5, y)
+            wing = -2 if direction > 0 else 2
+            self.line(frame, tip, (tip[0] + wing, y - 2), color)
+            self.line(frame, tip, (tip[0] + wing, y + 2), color)
+            if level["filter"]:
+                mark = GOLD if edge % 2 == state[4] else STEEL
+                for dx in (-2, 0, 2):
+                    self.line(frame, ((left + right) // 2 + dx, 20),
+                              ((left + right) // 2 + dx - 1, 22), mark)
+        if level["bridge"]:
+            edge = state[3]; center = (xs[edge] + xs[edge + 1]) // 2
+            self.line(frame, (center - 4, 31), (center, 27), WHITE)
+            self.line(frame, (center, 27), (center + 4, 31), WHITE)
+            self.line(frame, (center - 4, 31), (center + 4, 31), BLUE)
+        selected = state[0]; center = (xs[selected] + xs[selected + 1]) // 2
+        for dx in (-4, 4):
+            self.line(frame, (center + dx, 38), (center + dx // 2, 41), WHITE)
+            self.line(frame, (center + dx // 2, 41), (center, 41), WHITE)
+        if level["linked"]:
+            mirror = len(xs) - 2 - selected
+            mirror_center = (xs[mirror] + xs[mirror + 1]) // 2
+            self.line(frame, (center, 20), (32, 19), MAGENTA, dotted=True)
+            self.line(frame, (32, 19), (mirror_center, 20), MAGENTA, dotted=True)
+            self.diamond(frame, (32, 19), 2, MAGENTA, hollow=True)
+
+    def target_topology(self, frame):
+        """Pair live topology controls with a compact violet blueprint above."""
+        level = self.game.level; xs = self.vessel_positions(len(level["target"]))
+        if level["bridge"]:
+            edge = level["bridge_target"]
+            center = (xs[edge] + xs[edge + 1]) // 2
+            self.line(frame, (center - 3, 16), (center, 12), VIOLET)
+            self.line(frame, (center, 12), (center + 3, 16), VIOLET)
+            self.line(frame, (center - 3, 16), (center + 3, 16), VIOLET)
+        if level["filter"]:
+            for edge in range(len(xs) - 1):
+                if edge % 2 != level["phase_target"]:
+                    continue
+                center = (xs[edge] + xs[edge + 1]) // 2
+                self.line(frame, (center - 2, 11), (center - 1, 14), VIOLET)
+                self.line(frame, (center + 1, 11), (center + 2, 14), VIOLET)
+
+    def machine_icon(self, frame, center, machine, color):
+        x, y = center
+        if machine == DRIP:
+            self.diamond(frame, (x, y - 1), 3, color, hollow=True)
+            self.line(frame, (x, y + 2), (x, y + 4), color)
+        elif machine == FLUSH:
+            self.line(frame, (x - 4, y - 2), (x + 4, y - 2), color)
+            self.line(frame, (x - 4, y - 2), (x, y + 4), color)
+            self.line(frame, (x + 4, y - 2), (x, y + 4), color)
+        elif machine == SPLIT:
+            self.line(frame, (x, y - 4), (x, y), color)
+            self.line(frame, (x, y), (x - 4, y + 3), color)
+            self.line(frame, (x, y), (x + 4, y + 3), color)
+            self.diamond(frame, (x, y - 4), 1, color)
+        elif machine == SLIDE:
+            self.line(frame, (x - 5, y), (x + 5, y), color)
+            self.diamond(frame, (x - 2, y), 2, color, hollow=True)
+        elif machine == BALANCE:
+            self.line(frame, (x - 5, y + 3), (x + 5, y + 3), color)
+            self.line(frame, (x, y - 4), (x, y + 3), color)
+            self.diamond(frame, (x - 3, y), 2, color, hollow=True)
+            self.diamond(frame, (x + 3, y), 2, color, hollow=True)
+        elif machine == PHASE:
+            self.diamond(frame, (x - 2, y), 3, color, hollow=True)
+            self.diamond(frame, (x + 2, y), 3, color, hollow=True)
+        elif machine == MANIFOLD:
+            self.line(frame, (x - 5, y - 3), (x - 2, y), color)
+            self.line(frame, (x - 2, y), (x - 5, y + 3), color)
+            self.line(frame, (x + 5, y - 3), (x + 2, y), color)
+            self.line(frame, (x + 2, y), (x + 5, y + 3), color)
+            self.diamond(frame, (x, y), 1, color)
+        else:
+            self.disc(frame, center, 4, color, hollow=True)
+            self.line(frame, (x + 1, y - 4), (x + 4, y - 2), color)
+            self.line(frame, (x + 4, y - 2), (x + 2, y), color)
+
+    @staticmethod
+    def machine_positions(count):
+        spacing = 14 if count == 4 else 16
+        left = 32 - spacing * (count - 1) // 2
+        return tuple((left + spacing * index, 57) for index in range(count))
+
+    def console(self, frame, state):
+        positions = self.machine_positions(len(self.game.level["ops"]))
+        for index, (center, machine) in enumerate(zip(positions, self.game.level["ops"])):
+            color = WHITE if index == state[1] else STEEL
+            self.machine_icon(frame, center, machine, color)
+            if index == state[1]:
+                x, y = center
+                self.line(frame, (x - 6, y - 5), (x - 4, y - 5), CYAN)
+                self.line(frame, (x - 6, y - 5), (x - 6, y - 3), CYAN)
+                self.line(frame, (x + 6, y + 5), (x + 4, y + 5), CYAN)
+                self.line(frame, (x + 6, y + 5), (x + 6, y + 3), CYAN)
+
+    def hud(self, frame):
+        game = self.game
+        shown = game.budget_left
+        if (game.anim_kind and game.pending_budget is not None
+                and game.anim_progress >= max(1, game.anim_total - 1)
+                and game.anim_kind != "success"):
+            shown = game.pending_budget
+        for unit in range(game.budget_max):
+            x = 7 + (unit % 9) * 3; y = 3 + (unit // 9) * 3
+            color = CYAN if unit < shown else STEEL
+            if unit < shown:
+                self.diamond(frame, (x, y), 1, color)
+            else:
+                self.line(frame, (x - 1, y), (x + 1, y), color)
+        for index, x in enumerate((55, 61)):
+            live = index < self.game.state[5]
+            self.diamond(frame, (x, 4), 3, VIOLET if live else RED, hollow=True)
+            if live:
+                self.line(frame, (x, 2), (x, 6), WHITE)
+            else:
+                self.line(frame, (x - 2, 2), (x + 2, 6), RED)
+                self.line(frame, (x + 2, 2), (x - 2, 6), RED)
+
+    def apparatus(self, frame):
+        state = self.game.state; level = self.game.level
+        xs = self.vessel_positions(len(state[2]))
+        for x, target, capacity in zip(xs, level["target"], level["capacities"]):
+            self.glass_vessel(frame, x, target, capacity, target=True)
+        self.target_topology(frame)
+        for x, value, capacity in zip(xs, state[2], level["capacities"]):
+            self.glass_vessel(frame, x, value, capacity)
+        self.conduits(frame, state); self.console(frame, state); self.hud(frame)
+
+    def animation(self, frame):
+        game = self.game
+        if game.intro_mark:
+            for radius in (3, 6, 9):
+                self.diamond(frame, (32, 34), radius, BLUE, hollow=True)
+        if not game.anim_kind:
+            return
+        p = game.anim_progress; span = max(1, game.anim_total - 1)
+        before, after = game.anim_before, game.pending_state
+        xs = self.vessel_positions(len(before[2]))
+        if game.anim_kind == "channel" and p < span:
+            a = (xs[before[0]] + xs[before[0] + 1]) // 2
+            b = (xs[after[0]] + xs[after[0] + 1]) // 2
+            x = a + (b - a) * p // span
+            self.diamond(frame, (x, 41), 3, WHITE, hollow=True)
+        elif game.anim_kind == "machine" and p < span:
+            positions = self.machine_positions(len(game.level["ops"]))
+            a, b = positions[before[1]], positions[after[1]]
+            point = (a[0] + (b[0] - a[0]) * p // span, a[1])
+            self.diamond(frame, point, 5, CYAN, hollow=True)
+        elif game.anim_kind == "execute" and p < span:
+            machine = game.level["ops"][before[1]]
+            if machine == SLIDE:
+                old = (xs[before[3]] + xs[before[3] + 1]) // 2
+                new = (xs[after[3]] + xs[after[3] + 1]) // 2
+                x = old + (new - old) * p // span
+                self.line(frame, (x - 4, 30), (x, 26), WHITE)
+                self.line(frame, (x, 26), (x + 4, 30), WHITE)
+            elif machine == PHASE:
+                for edge in range(len(xs) - 1):
+                    if edge % 2 == after[4]:
+                        center = (xs[edge] + xs[edge + 1]) // 2
+                        self.diamond(frame, (center, 21), 1 + p * 2 // span,
+                                     GOLD, hollow=True)
+            elif machine == ROTOR:
+                angle = 2 * math.pi * p / max(1, span)
+                point = (32 + round(12 * math.cos(angle)), 34 + round(8 * math.sin(angle)))
+                self.diamond(frame, point, 2, WHITE, hollow=True)
+                self.line(frame, (32, 34), point, CYAN, dotted=True)
+            else:
+                changed = [i for i, (a, b) in enumerate(zip(before[2], after[2])) if a != b]
+                for index in changed:
+                    source = (xs[index], 34); destination = (xs[index], 25)
+                    amount = p * 100 // span
+                    self.line(frame, source, destination, WHITE, dotted=True, limit=amount)
+                    y = source[1] + (destination[1] - source[1]) * amount // 100
+                    self.diamond(frame, (xs[index], y), 2, CYAN, hollow=True)
+        elif game.anim_kind == "audit" and p < span:
+            x = 5 + 54 * p // span
+            self.line(frame, (x, 7), (x, 46), GOLD, dotted=True)
+        elif game.anim_kind == "blocked" and p < span:
+            folded = min(p, span - p)
+            center = (xs[before[0]] + xs[before[0] + 1]) // 2
+            self.diamond(frame, (center, 35), 3 + folded, RED, hollow=True)
+        elif game.anim_kind == "success":
+            for index, x in enumerate(xs):
+                if index <= p:
+                    self.diamond(frame, (x, 34), 5, GREEN, hollow=True)
+            for radius in range(5, min(31, 5 + p * 4), 6):
+                self.diamond(frame, (32, 34), radius, CYAN, hollow=True)
+        elif game.anim_kind == "loss" and p < span:
+            inset = 26 * p // span
+            self.line(frame, (2 + inset, 4), (2 + inset, 47), RED)
+            self.line(frame, (61 - inset, 4), (61 - inset, 47), RED)
+            for y in range(8, 47, 6):
+                self.line(frame, (2 + inset, y), (61 - inset, y + 3), STEEL)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        game = self.game
+        preview = (game.anim_kind in ("channel", "machine", "execute", "audit", "blocked", "loss")
+                   and game.pending_state is not None
+                   and game.anim_progress >= max(1, game.anim_total - 1))
+        current = game.state
+        if preview:
+            game.state = game.pending_state
+        self.background(frame); self.apparatus(frame)
+        if preview:
+            game.state = current
+        self.animation(frame)
+        return frame
+
+
+class Q031(ARCBaseGame):
+    def __init__(self):
+        self.display = ManifoldDisplay(self); self.level = LEVELS[0]
+        self.state = start_state(self.level); self.budget_left = self.budget_max = 0
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = None; self.pending_budget = None
+        self.pending_terminal = None; self.intro_mark = True
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(level), name=level["name"])
+                  for level in LEVELS]
+        super().__init__("q031", levels, Camera(0, 0, 64, 64, INK, INK, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = self.pending_budget = None
+        self.pending_terminal = None; self.intro_mark = True
+
+    def begin(self, kind, frames, before, after, budget, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames; self.anim_progress = 0
+        self.anim_before = before; self.pending_state = after; self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal; self.state = self.pending_state
+        self.budget_left = self.pending_budget; self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1; self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action(); return
+        self.intro_mark = False; before = self.state
+        after = transition(self.level, before, action)
+        if after == before:
+            self.begin("blocked", 5, before, before, self.budget_left); return
+        cost = action_cost(before, after)
+        if cost > self.budget_left:
+            lost = before[:-1] + (3,)
+            self.begin("loss", 7, before, lost, self.budget_left, "loss"); return
+        budget = self.budget_left - cost
+        if after[6] == 2:
+            kind, frames, terminal = "success", 7, "win"
+        elif after[6] == 3:
+            kind, frames, terminal = "loss", 7, "loss"
+        elif action in (1, 2):
+            kind, frames, terminal = "channel", 5, None
+        elif action in (3, 4):
+            kind, frames, terminal = "machine", 5, None
+        elif action == 5:
+            kind, frames, terminal = "execute", 7, None
+        else:
+            kind, frames, terminal = "audit", 6, None
+        self.begin(kind, frames, before, after, budget, terminal)

--- a/data/community-games/sonpham/q032_v2_q032.py
+++ b/data/community-games/sonpham/q032_v2_q032.py
@@ -1,0 +1,475 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q032-v2 Parity Orrery -- cast exact even-parity states in a radial forge.
+
+Every hammer face connects an even number of radial billets.  Clamps reject a
+connector before impact, ratchets change the next die geometry, delayed echoes
+retain a visible second mask, and late gated dies require a live billet.  The
+target includes billet pattern, station, face, ratchet phase, and empty echo.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+SILVER, ASH, IRON, CHARCOAL, BLACK = 0, 1, 2, 4, 5
+ACID, ROSE, RED, BLUE, GLASS, GOLD, COPPER, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 14, 15
+
+
+def forge(name, n, start, faces, steps, plan, budget, **rules):
+    base = {
+        "name": name,
+        "n": n,
+        "start": start,
+        "faces": faces,
+        "steps": tuple(tuple(row) for row in steps),
+        "plan": tuple(plan),
+        "budget": budget,
+        "clamps": 0,
+        "echo_shift": 0,
+        "gate_face": -1,
+        "gate_bit": -1,
+        "gate_phase_only": False,
+    }
+    base.update(rules)
+    return base
+
+
+LEVELS = [
+    forge("First Casting", 4, 0b0000, 1, ((1,),), (5, 4, 5), 4),
+    forge("Twin Dies", 5, 0b00001, 2, ((1, 2),),
+          (3, 3, 5, 1, 4, 4, 5), 8),
+    forge("Clamped Crown", 6, 0b000011, 2, ((1, 2),),
+          (1, 3, 3, 3, 5, 3, 3, 3, 5), 10, clamps=1 << 1),
+    forge("Ratchet Teeth", 6, 0b001001, 2, ((1, 2), (2, 3)),
+          (1, 3, 3, 3, 5, 1, 3, 5, 3, 3, 5), 12),
+    forge("Echo Crucible", 7, 0b0000101, 2, ((1, 2), (2, 3)),
+          (1, 3, 3, 3, 5, 1, 3, 5, 5, 3, 3, 3, 5, 5, 5), 16,
+          echo_shift=3),
+    forge("Keyed Link", 6, 0b000000, 2, ((1, 2), (1, 2)),
+          (3, 3, 3, 5, 4, 4, 5, 1, 4, 5, 1, 3), 13,
+          gate_face=1, gate_bit=0, gate_phase_only=True),
+    forge("Crowned Echo", 7, 0b0010101, 2, ((1, 2), (2, 3)),
+          (1, 3, 5, 3, 5, 5, 4, 4, 4, 5, 5, 1, 3, 5), 15,
+          clamps=1 << 0, echo_shift=3),
+    forge("Parity Orrery", 8, 0b00100101, 3, ((1, 2, 3), (2, 3, 1)),
+          (2, 3, 3, 5, 5, 5, 1, 4, 4, 5), 11,
+          clamps=1 << 0, echo_shift=4, gate_face=2, gate_bit=0),
+]
+
+
+def start_state(level):
+    # bits, radial station, hammer face, ratchet phase, queued echo,
+    # audit seals, terminal (0 play / 2 win / 3 loss)
+    return level["start"], 0, 0, 0, 0, 2, 0
+
+
+def rotate_mask(mask, amount, n):
+    result = 0
+    for node in range(n):
+        if mask & (1 << node):
+            result |= 1 << ((node + amount) % n)
+    return result
+
+
+def strike_mask(level, station, face, phase):
+    step = level["steps"][phase % len(level["steps"])][face]
+    return (1 << station) | (1 << ((station + step) % level["n"]))
+
+
+def connector_allowed(level, state, mask):
+    bits, _station, face, _phase, _pending = state[:5]
+    echo = rotate_mask(mask, level["echo_shift"], level["n"]) if level["echo_shift"] else 0
+    if (mask | echo) & level["clamps"]:
+        return False
+    if face == level["gate_face"] and not (bits & (1 << level["gate_bit"])):
+        return False
+    return True
+
+
+def transition(level, state, action):
+    bits, station, face, phase, pending, audits, terminal = state
+    if terminal or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    if action == 1:
+        return bits, station, (face + 1) % level["faces"], phase, pending, audits, terminal
+    if action == 2:
+        return bits, station, (face - 1) % level["faces"], phase, pending, audits, terminal
+    if action == 3:
+        return bits, (station - 1) % level["n"], face, phase, pending, audits, terminal
+    if action == 4:
+        return bits, (station + 1) % level["n"], face, phase, pending, audits, terminal
+    if action == 6:
+        if configuration_solved(level, state):
+            return bits, station, face, phase, pending, audits, 2
+        audits -= 1
+        return bits, station, face, phase, pending, audits, 3 if audits <= 0 else 0
+    if pending:
+        return bits ^ pending, station, face, phase, 0, audits, terminal
+    mask = strike_mask(level, station, face, phase)
+    if not connector_allowed(level, state, mask):
+        return state
+    bits ^= mask
+    if level["echo_shift"]:
+        pending = rotate_mask(mask, level["echo_shift"], level["n"])
+    if level["gate_phase_only"]:
+        if face == level["gate_face"]:
+            phase = (phase + 1) % len(level["steps"])
+    else:
+        phase = (phase + 1) % len(level["steps"])
+    return bits, station, face, phase, pending, audits, terminal
+
+
+_TARGETS = {}
+
+
+def target_core(level):
+    key = level["name"]
+    if key not in _TARGETS:
+        state = start_state(level)
+        for action in level["plan"]:
+            state = transition(level, state, action)
+        if state[4] or state[-1]:
+            raise ValueError(f"target plan for {key} did not settle")
+        _TARGETS[key] = state[:5]
+    return _TARGETS[key]
+
+
+def configuration_solved(level, state):
+    return state[:5] == target_core(level)
+
+
+def action_cost(state, after):
+    if after == state or after[5] < state[5] or after[-1] == 2:
+        return 0
+    return 1
+
+
+def solved(_level, state):
+    return state[-1] == 2
+
+
+NODE_LAYOUTS = {
+    4: ((32, 12), (52, 32), (32, 52), (12, 32)),
+    5: ((32, 10), (52, 25), (44, 49), (20, 49), (12, 25)),
+    6: ((32, 9), (50, 19), (50, 43), (32, 53), (14, 43), (14, 19)),
+    7: ((32, 8), (49, 16), (55, 33), (44, 50), (20, 50), (9, 33), (15, 16)),
+    8: ((32, 8), (48, 14), (56, 30), (49, 47), (32, 55), (15, 47), (8, 30), (16, 14)),
+}
+
+
+class OrreryDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                d = (x - cx) ** 2 + (y - cy) ** 2
+                if d <= radius ** 2 and (not hollow or d >= max(0, radius - 1) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def line(frame, a, b, color, dotted=False):
+        x0, y0 = a; x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    @staticmethod
+    def diamond(frame, center, radius, color, hollow=False):
+        x, y = center
+        for dy in range(-radius, radius + 1):
+            width = radius - abs(dy)
+            yy = y + dy
+            if not 0 <= yy < 64:
+                continue
+            if hollow:
+                left, right = x - width, x + width
+                if 0 <= left < 64:
+                    frame[yy, left] = color
+                if 0 <= right < 64:
+                    frame[yy, right] = color
+            else:
+                left, right = max(0, x - width), min(64, x + width + 1)
+                if left < right:
+                    frame[yy, left:right] = color
+
+    def background(self, frame):
+        frame[:, :] = BLACK
+        for radius in (13, 21, 28):
+            self.disc(frame, (32, 31), radius, CHARCOAL, hollow=True)
+        for x, y in ((4, 4), (60, 4), (4, 58), (60, 58), (32, 3), (3, 31), (61, 31)):
+            self.disc(frame, (x, y), 1, COPPER)
+        for y in range(5, 60, 9):
+            frame[y, 5 + y % 7:60:13] = IRON
+
+    def face(self, frame, center, face, color=COPPER, scale=1):
+        x, y = center; kind = face % 3; r = 2 + scale
+        if kind == 0:
+            self.diamond(frame, center, r, color, hollow=True)
+            self.line(frame, (x - r, y), (x + r, y), color)
+        elif kind == 1:
+            self.line(frame, (x, y - r), (x + r, y + r), color)
+            self.line(frame, (x + r, y + r), (x - r, y + r), color)
+            self.line(frame, (x - r, y + r), (x, y - r), color)
+        else:
+            self.disc(frame, center, r, color, hollow=True)
+            self.line(frame, (x - r, y), (x + r, y), color)
+            self.line(frame, (x, y - r), (x, y + r), color)
+
+    def node(self, frame, index, current, target, selected, target_station):
+        center = NODE_LAYOUTS[self.game.level["n"]][index]; x, y = center
+        if current:
+            self.diamond(frame, center, 5, GOLD)
+            self.diamond(frame, center, 3, COPPER, hollow=True)
+            frame[y, x] = SILVER
+        else:
+            self.disc(frame, center, 5, IRON, hollow=True)
+            self.line(frame, (x - 4, y + 3), (x - 1, y + 5), ASH)
+        if target:
+            for dx, dy in ((0, -6), (6, 0), (0, 6), (-6, 0)):
+                self.diamond(frame, (x + dx, y + dy), 1, ACID)
+        else:
+            self.disc(frame, center, 7, ASH, hollow=True)
+        if target_station:
+            # Twin inward anvils stay fully inside the frame at every radial node;
+            # the current carriage is the separate glass ring/crown below.
+            inward_x = 0 if x == 32 else (1 if x < 32 else -1)
+            inward_y = 0 if y == 31 else (1 if y < 31 else -1)
+            anchor = (x + inward_x * 11, y + inward_y * 11)
+            tangent = (-inward_y * 2, inward_x * 2)
+            self.diamond(frame, (anchor[0] + tangent[0], anchor[1] + tangent[1]),
+                         1, ACID, hollow=True)
+            self.diamond(frame, (anchor[0] - tangent[0], anchor[1] - tangent[1]),
+                         1, ACID, hollow=True)
+        if selected:
+            self.disc(frame, center, 7, GLASS, hollow=True)
+            inward_x = 0 if x == 32 else (1 if x < 32 else -1)
+            inward_y = 0 if y == 31 else (1 if y < 31 else -1)
+            self.diamond(frame, (x + inward_x * 8, y + inward_y * 8), 1, SILVER)
+        if self.game.level["clamps"] & (1 << index):
+            self.line(frame, (x - 7, y - 5), (x + 7, y + 5), RED)
+            self.line(frame, (x + 7, y - 5), (x - 7, y + 5), RED)
+            self.disc(frame, center, 8, RED, hollow=True)
+
+    def connector(self, frame, mask, color, progress=None, total=1, dotted=False):
+        nodes = [i for i in range(self.game.level["n"]) if mask & (1 << i)]
+        if len(nodes) < 2:
+            return
+        a = NODE_LAYOUTS[self.game.level["n"]][nodes[0]]
+        for node in nodes[1:]:
+            b = NODE_LAYOUTS[self.game.level["n"]][node]
+            if progress is None:
+                self.line(frame, a, b, color, dotted=dotted)
+            else:
+                p = min(total, progress)
+                end = (a[0] + (b[0] - a[0]) * p // total,
+                       a[1] + (b[1] - a[1]) * p // total)
+                self.line(frame, a, end, color, dotted=dotted)
+                self.diamond(frame, end, 1 + p // max(1, total // 2), SILVER)
+
+    def mechanics(self, frame):
+        g = self.game; state = g.state
+        mask = strike_mask(g.level, state[1], state[2], state[3])
+        allowed = connector_allowed(g.level, state, mask)
+        self.connector(frame, mask, COPPER if allowed else RED, dotted=not allowed)
+        if state[4]:
+            self.connector(frame, state[4], VIOLET, dotted=True)
+            self.diamond(frame, (32, 31), 4, VIOLET, hollow=True)
+        elif g.level["echo_shift"]:
+            preview = rotate_mask(mask, g.level["echo_shift"], g.level["n"])
+            self.connector(frame, preview, VIOLET if allowed else RED, dotted=True)
+        # The ratchet has one filled tooth per current phase and an outer target tooth.
+        phase_points = ((32, 24), (38, 35), (26, 35))
+        for index in range(len(g.level["steps"])):
+            self.diamond(frame, phase_points[index], 2, GOLD if index == state[3] else IRON,
+                         hollow=index != state[3])
+            if index == target_core(g.level)[3]:
+                self.disc(frame, phase_points[index], 3, ACID, hollow=True)
+        if g.level["gate_face"] >= 0:
+            gate_node = NODE_LAYOUTS[g.level["n"]][g.level["gate_bit"]]
+            open_gate = bool(state[0] & (1 << g.level["gate_bit"]))
+            self.line(frame, (29, 28), gate_node, GREEN if open_gate else RED, dotted=not open_gate)
+            self.diamond(frame, (32, 27), 3, GREEN if open_gate else RED, hollow=True)
+
+    def hud(self, frame):
+        g = self.game; target = target_core(g.level)
+        self.face(frame, (7, 7), g.state[2], COPPER)
+        self.face(frame, (15, 7), target[2], ACID, scale=0)
+        for index in range(2):
+            center = (54 + index * 6, 7)
+            self.disc(frame, center, 2, GOLD if index < g.state[5] else ASH,
+                      hollow=index >= g.state[5])
+            self.line(frame, (center[0] - 2, center[1] + 3),
+                      (center[0] + 2, center[1] - 3), COPPER)
+        # Four energy points form one gear cluster; spent teeth collapse to rivets.
+        offsets = ((0, -2), (2, 0), (0, 2), (-2, 0))
+        for group in range((g.budget_max + 3) // 4):
+            center = (7 + group * 8, 60)
+            self.disc(frame, center, 1, IRON)
+            for tooth, (dx, dy) in enumerate(offsets):
+                number = group * 4 + tooth
+                if number >= g.budget_max:
+                    continue
+                if number < g.budget_left:
+                    self.diamond(frame, (center[0] + dx, center[1] + dy), 1, ACID)
+                else:
+                    frame[center[1] + dy, center[0] + dx] = ASH
+
+    def animation(self, frame):
+        g = self.game
+        if g.intro_mark:
+            self.disc(frame, (32, 31), 11, COPPER, hollow=True)
+            self.disc(frame, (32, 31), 14, ACID, hollow=True)
+        if not g.anim_kind:
+            return
+        p = g.anim_progress
+        if g.anim_kind == "face":
+            scale = max(0, 3 - abs(g.anim_total // 2 - p))
+            self.face(frame, (32, 31), g.pending_state[2], ACID, scale=scale)
+        elif g.anim_kind == "rotate":
+            a = NODE_LAYOUTS[g.level["n"]][g.anim_from]
+            b = NODE_LAYOUTS[g.level["n"]][g.anim_to]
+            x = a[0] + (b[0] - a[0]) * p // g.anim_total
+            y = a[1] + (b[1] - a[1]) * p // g.anim_total
+            self.disc(frame, (x, y), 7, GLASS, hollow=True)
+        elif g.anim_kind in ("strike", "echo"):
+            mask = g.state[4] if g.anim_kind == "echo" else strike_mask(
+                g.level, g.state[1], g.state[2], g.state[3])
+            if p <= 2:
+                self.face(frame, (32, 31), g.state[2], GOLD, scale=3 - p)
+            self.connector(frame, mask, ACID if g.anim_kind == "strike" else VIOLET,
+                           p, g.anim_total)
+            for node, center in enumerate(NODE_LAYOUTS[g.level["n"]]):
+                if mask & (1 << node):
+                    self.disc(frame, center, 5 + min(2, p // 3), SILVER, hollow=True)
+        elif g.anim_kind == "blocked":
+            mask = strike_mask(g.level, g.state[1], g.state[2], g.state[3])
+            self.connector(frame, mask, RED, p, g.anim_total, dotted=True)
+            self.diamond(frame, (32, 31), 3 + p, RED, hollow=True)
+        elif g.anim_kind == "audit_reject":
+            for offset in range(0, 54, 9):
+                self.line(frame, (5 + offset, 8 + p), (10 + offset, 3 + p), RED)
+        elif g.anim_kind == "success":
+            for node, center in enumerate(NODE_LAYOUTS[g.level["n"]]):
+                self.diamond(frame, center, 3 + p // 2,
+                             GREEN if node % 2 else GOLD, hollow=True)
+            self.disc(frame, (32, 31), 5 + p * 2, ACID, hollow=True)
+        elif g.anim_kind == "loss":
+            self.line(frame, (5 + p * 3, 6), (59 - p * 3, 57), RED)
+            self.line(frame, (59 - p * 3, 6), (5 + p * 3, 57), RED)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        g = self.game; self.background(frame)
+        target = target_core(g.level)
+        self.mechanics(frame)
+        for node in range(g.level["n"]):
+            self.node(frame, node, bool(g.state[0] & (1 << node)),
+                      bool(target[0] & (1 << node)),
+                      node == g.state[1] and g.anim_kind != "rotate",
+                      node == target[1])
+        self.hud(frame)
+        self.animation(frame)
+        if g.state[-1] == 3 and not g.anim_kind:
+            # Retain a settled fracture after the transient loss strike.
+            self.line(frame, (20, 19), (29, 28), RED)
+            self.line(frame, (35, 34), (44, 43), RED)
+            self.line(frame, (44, 19), (36, 27), RED)
+            self.line(frame, (28, 35), (20, 43), RED)
+            self.diamond(frame, (32, 31), 8, ASH, hollow=True)
+        return frame
+
+
+class Q032(ARCBaseGame):
+    def __init__(self):
+        self.display = OrreryDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_from = self.anim_to = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        self.intro_mark = True
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q032", levels, Camera(0, 0, 64, 64, BLACK, BLACK, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_from = self.anim_to = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        self.intro_mark = True
+
+    def begin(self, kind, frames, after, budget, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames
+        self.anim_progress = 0; self.pending_state = after
+        self.pending_budget = budget; self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state; self.budget_left = self.pending_budget
+        self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1; self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action(); return
+        self.intro_mark = False
+        before = self.state; after = transition(self.level, before, action)
+        if after == before:
+            kind = "face" if action in (1, 2) else "blocked"
+            self.begin(kind, 5, before, self.budget_left); return
+        cost = action_cost(before, after)
+        if cost > self.budget_left:
+            exhausted = before[:-1] + (3,)
+            self.begin("loss", 7, exhausted, self.budget_left, "loss"); return
+        budget = self.budget_left - cost
+        won, lost = after[-1] == 2, after[-1] == 3
+        self.anim_from, self.anim_to = before[1], after[1]
+        if won:
+            kind, frames = "success", 7
+        elif lost:
+            kind, frames = "loss", 7
+        elif action == 6:
+            kind, frames = "audit_reject", 5
+        elif action in (1, 2):
+            kind, frames = "face", 5
+        elif action in (3, 4):
+            kind, frames = "rotate", 5
+        elif before[4]:
+            kind, frames = "echo", 7
+        else:
+            kind, frames = "strike", 7
+        self.begin(kind, frames, after, budget, "win" if won else "loss" if lost else None)

--- a/data/community-games/sonpham/q038_v3_q038.py
+++ b/data/community-games/sonpham/q038_v3_q038.py
@@ -1,0 +1,542 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q038-v3 Moonpool Balance Web -- route conserved light through a living web."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+INK, MIST, SLATE, KELP_DARK, ABYSS = 0, 1, 2, 4, 5
+FUCHSIA, PEARL, RED, BLUE, CYAN, SUN, ORANGE, BARK, GREEN, VIOLET = range(6, 16)
+
+
+def edge(a, b, *, oneway=False, phase=None, link=None, amount=1, bend=0):
+    return {
+        "a": a,
+        "b": b,
+        "oneway": oneway,
+        "phase": phase,
+        "link": link,
+        "amount": amount,
+        "bend": bend,
+    }
+
+
+LEVELS = [
+    {
+        "name": "First Current", "start": (3, 0), "targets": ((1, 2),), "cap": (3, 3),
+        "pos": ((15, 33), (49, 29)), "edges": (edge(0, 1, bend=-7),), "budget": 5,
+    },
+    {
+        "name": "Forked Current", "start": (2, 2, 0),
+        "targets": ((1, 2, 1), (2, 2, 0), (1, 2, 1), (1, 1, 2)), "cap": (3, 3, 3),
+        "pos": ((13, 19), (15, 47), (50, 32)),
+        "edges": (edge(0, 2, bend=-8), edge(2, 1, bend=9)), "budget": 11,
+    },
+    {
+        "name": "Petal Capacity", "start": (4, 0, 1),
+        "targets": ((3, 1, 1), (2, 2, 1), (2, 1, 2), (1, 2, 2), (2, 1, 2)),
+        "cap": (4, 2, 3),
+        "pos": ((12, 34), (34, 14), (51, 43)),
+        "edges": (edge(0, 1, bend=-7), edge(1, 2, bend=-6), edge(0, 2, bend=11)),
+        "budget": 11,
+    },
+    {
+        "name": "Anemone Valves", "start": (3, 0, 1, 0),
+        "targets": ((3, 1, 0, 0), (3, 0, 1, 0), (2, 1, 1, 0), (1, 1, 1, 1)),
+        "cap": (3, 2, 2, 2), "pos": ((10, 33), (30, 14), (33, 50), (54, 29)),
+        "edges": (edge(0, 1, oneway=True, bend=-6), edge(1, 2, bend=-7),
+                  edge(0, 3, oneway=True, bend=8)), "budget": 12,
+    },
+    {
+        "name": "Moon Gills", "start": (3, 0, 0),
+        "targets": ((2, 1, 0), (3, 0, 0), (2, 1, 0), (1, 1, 1)), "cap": (3, 2, 2),
+        "pos": ((12, 33), (49, 16), (49, 49)),
+        "edges": (edge(0, 1, phase=0, bend=-10),
+                  edge(0, 2, oneway=True, phase=1, bend=10)), "budget": 12,
+    },
+    {
+        "name": "Twin Ripple", "start": (4, 0, 0, 0),
+        "targets": ((2, 1, 0, 1), (1, 1, 0, 2), (1, 0, 1, 2),
+                    (1, 1, 0, 2), (1, 0, 1, 2)), "cap": (4, 2, 2, 2),
+        "pos": ((10, 32), (31, 13), (53, 31), (31, 51)),
+        "edges": (edge(0, 1, oneway=True, link=1, bend=-6), edge(0, 3, oneway=True, bend=6),
+                  edge(1, 2, bend=-5), edge(2, 3, bend=-5)), "budget": 12,
+    },
+    {
+        "name": "Double-Braid Bloom", "start": (6, 0, 0, 0),
+        "targets": ((4, 2, 0, 0), (4, 1, 0, 1), (2, 3, 0, 1), (2, 2, 0, 2)),
+        "cap": (6, 3, 2, 3), "pos": ((9, 33), (28, 13), (53, 30), (31, 52)),
+        "edges": (edge(0, 1, oneway=True, phase=0, amount=2, bend=-8),
+                  edge(1, 2, oneway=True, link=2, bend=-6),
+                  edge(2, 3, oneway=True, bend=-6), edge(0, 2, bend=9)), "budget": 10,
+    },
+    {
+        "name": "Moonpool Balance Web", "start": (8, 0, 0, 0, 0),
+        "targets": ((6, 2, 0, 0, 0), (6, 1, 0, 0, 1), (5, 1, 1, 0, 1),
+                    (5, 1, 0, 1, 1), (3, 3, 0, 1, 1), (3, 2, 0, 1, 2),
+                    (3, 2, 1, 0, 2)),
+        "cap": (8, 4, 3, 3, 3),
+        "pos": ((8, 33), (24, 13), (23, 52), (44, 17), (55, 40)),
+        "edges": (edge(0, 1, oneway=True, phase=0, amount=2, bend=-7),
+                  edge(0, 2, oneway=True, bend=7),
+                  edge(1, 3, oneway=True, link=4, bend=-5),
+                  edge(2, 3, phase=1, bend=8),
+                  edge(3, 4, oneway=True, bend=-5),
+                  edge(4, 2, bend=8)),
+        "budget": 23,
+    },
+]
+
+
+def start_state(level):
+    # loads, tide, selected strand, reversed, milestone, error seals, terminal
+    # terminal: 0 active, 2 win, 3 loss.
+    return tuple(level["start"]), 0, 0, False, 0, 0, 0
+
+
+def _sealed(state):
+    values, tide, cursor, reverse, stage, seals, _terminal = state
+    seals += 1
+    return values, tide, cursor, reverse, stage, seals, 3 if seals >= 3 else 0
+
+
+def _move(values, authored, reverse, cap):
+    a, b = authored["a"], authored["b"]
+    if reverse:
+        if authored["oneway"]:
+            return tuple(values), False
+        a, b = b, a
+    amount = authored["amount"]
+    if values[a] < amount or values[b] + amount > cap[b]:
+        return tuple(values), False
+    changed = list(values)
+    changed[a] -= amount
+    changed[b] += amount
+    return tuple(changed), True
+
+
+def _open(authored, tide):
+    return authored["phase"] is None or tide % 2 == authored["phase"]
+
+
+def pump_trace(level, state):
+    """Return the settled loads and every visibly fired edge in cascade order."""
+    values, tide, cursor, reverse, _stage, _seals, _terminal = state
+    selected = level["edges"][cursor]
+    if not _open(selected, tide):
+        return values, (), "gate"
+    values, moved = _move(values, selected, reverse, level["cap"])
+    if not moved:
+        return values, (), "blocked"
+    trace = [(cursor, bool(reverse))]
+    linked_index = selected["link"]
+    visited = {cursor}
+    while linked_index is not None and linked_index not in visited:
+        visited.add(linked_index)
+        linked = level["edges"][linked_index]
+        if not _open(linked, tide):
+            break
+        values, linked_moved = _move(values, linked, False, level["cap"])
+        if not linked_moved:
+            break
+        trace.append((linked_index, False))
+        linked_index = linked["link"]
+    return values, tuple(trace), "moved"
+
+
+def transition(level, state, action):
+    """Pure transition shared by runtime, BFS qualification, and fuzz invariants."""
+    values, tide, cursor, reverse, stage, seals, terminal = state
+    if terminal or action not in (1, 3, 4, 5, 6):
+        return state
+    if action == 1:
+        return values, tide, cursor, not reverse, stage, seals, terminal
+    if action in (3, 4):
+        if len(level["edges"]) == 1:
+            return _sealed(state)
+        delta = -1 if action == 3 else 1
+        return values, tide, (cursor + delta) % len(level["edges"]), reverse, stage, seals, terminal
+    if action == 6:
+        if stage == len(level["targets"]):
+            return values, tide, cursor, reverse, stage, seals, 2
+        return _sealed(state)
+
+    moved_values, _trace, result = pump_trace(level, state)
+    tide += 1
+    if result == "blocked":
+        blocked = values, tide, cursor, reverse, stage, seals, terminal
+        return _sealed(blocked)
+    if result == "gate":
+        return values, tide, cursor, reverse, stage, seals, terminal
+    if stage < len(level["targets"]) and moved_values == tuple(level["targets"][stage]):
+        stage += 1
+    return moved_values, tide, cursor, reverse, stage, seals, terminal
+
+
+def solved(_level, state):
+    return state[-1] == 2
+
+
+def action_cost(state, _after):
+    return 0 if state[-1] else 1
+
+
+def _curve_point(a, b, bend, numerator, denominator):
+    x0, y0 = a
+    x1, y1 = b
+    dx, dy = x1 - x0, y1 - y0
+    length = max(1, abs(dx) + abs(dy))
+    cx = (x0 + x1) // 2 - dy * bend // length
+    cy = (y0 + y1) // 2 + dx * bend // length
+    t = numerator
+    u = denominator - t
+    den2 = denominator * denominator
+    x = (u * u * x0 + 2 * u * t * cx + t * t * x1) // den2
+    y = (u * u * y0 + 2 * u * t * cy + t * t * y1) // den2
+    return x, y
+
+
+def _curve(frame, a, b, bend, color, *, dotted=False, companion=0):
+    steps = max(abs(b[0] - a[0]), abs(b[1] - a[1]), 12)
+    for index in range(steps + 1):
+        if dotted and index % 4 in (1, 2):
+            continue
+        x, y = _curve_point(a, b, bend + companion, index, steps)
+        if 0 <= x < 64 and 0 <= y < 64:
+            frame[y, x] = color
+
+
+class BalanceWebDisplay(RenderableUserDisplay):
+    PETALS = ((0, -7), (5, -5), (7, 0), (5, 5), (0, 7), (-5, 5), (-7, 0), (-5, -5))
+    LOADS = ((-2, 2), (2, 2), (0, -2), (-3, -1), (3, -1), (-1, 0), (1, 0), (0, 3))
+
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius * radius and (not hollow or distance >= max(0, radius - 1) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def line(frame, a, b, color, dotted=False):
+        x0, y0 = a
+        x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for index in range(steps + 1):
+            if dotted and index % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * index // steps
+            y = y0 + (y1 - y0) * index // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    def background(self, frame):
+        frame[:, :] = ABYSS
+        # Deep water particulate, soft current arcs, and kelp commas establish
+        # a tactile organic material without encoding gameplay state.
+        for y in range(5, 61, 7):
+            for x in range(4 + (y // 7) % 3, 62, 11):
+                self.disc(frame, (x, y), 1 if (x + y) % 3 else 2, KELP_DARK, hollow=(x + y) % 3 == 0)
+        _curve(frame, (1, 10), (62, 7), -6, SLATE, dotted=True)
+        _curve(frame, (2, 57), (61, 54), 7, BLUE, dotted=True)
+        for y in (18, 31, 44):
+            self.disc(frame, (2, y), 3, KELP_DARK, hollow=True)
+            self.line(frame, (3, y + 2), (6, y - 3), GREEN, dotted=True)
+
+    def edge(self, frame, index, authored):
+        g = self.game
+        a = g.level["pos"][authored["a"]]
+        b = g.level["pos"][authored["b"]]
+        selected = index == g.cursor
+        phase_open = _open(authored, g.tide)
+        base = CYAN if phase_open else SLATE
+        _curve(frame, a, b, authored["bend"], SUN if selected else base, dotted=not phase_open)
+        _curve(frame, a, b, authored["bend"], PEARL if selected else BLUE,
+               dotted=True, companion=3)
+        if authored["amount"] == 2:
+            _curve(frame, a, b, authored["bend"], VIOLET if selected else CYAN,
+                   dotted=False, companion=-3)
+        midpoint = _curve_point(a, b, authored["bend"], 5, 9)
+        nextpoint = _curve_point(a, b, authored["bend"], 6, 9)
+        dx = 1 if nextpoint[0] > midpoint[0] else -1 if nextpoint[0] < midpoint[0] else 0
+        dy = 1 if nextpoint[1] > midpoint[1] else -1 if nextpoint[1] < midpoint[1] else 0
+        if g.reverse and not authored["oneway"]:
+            dx, dy = -dx, -dy
+        mx, my = midpoint
+        # A directional seed has a tail and paired side fins; reversible
+        # strands show a second opposing seed, while valves show one sharp fin.
+        self.disc(frame, midpoint, 2, SUN if selected else MIST)
+        self.line(frame, (mx - dx * 3, my - dy * 3), midpoint, PEARL)
+        if authored["oneway"]:
+            self.line(frame, midpoint, (mx - dy * 3 - dx, my + dx * 3 - dy), ORANGE)
+            self.line(frame, midpoint, (mx + dy * 3 - dx, my - dx * 3 - dy), ORANGE)
+        else:
+            self.disc(frame, (mx - dx * 4, my - dy * 4), 1, PEARL)
+        if authored["phase"] is not None:
+            # Two-lobed moon gill: filled on its required tide, hollow otherwise.
+            gate = _curve_point(a, b, authored["bend"], 3, 8)
+            self.disc(frame, gate, 3, VIOLET, hollow=not phase_open)
+            self.disc(frame, (gate[0] + (1 if authored["phase"] else -1), gate[1]), 1, ABYSS)
+        if authored["link"] is not None:
+            knot = _curve_point(a, b, authored["bend"], 2, 7)
+            self.disc(frame, (knot[0] - 2, knot[1]), 2, FUCHSIA, hollow=True)
+            self.disc(frame, (knot[0] + 2, knot[1]), 2, FUCHSIA, hollow=True)
+
+    def node(self, frame, index, value, target, cap):
+        cx, cy = self.game.level["pos"][index]
+        # Uneven nested rings make every reservoir a living circular basin.
+        self.disc(frame, (cx, cy), 8, KELP_DARK)
+        self.disc(frame, (cx - 1, cy + 1), 7, CYAN)
+        self.disc(frame, (cx, cy), 6, BLUE)
+        self.disc(frame, (cx, cy), 5, ABYSS)
+        for px, py in self.PETALS[:cap]:
+            self.disc(frame, (cx + px, cy + py), 1, MIST)
+            frame[cy + py, cx + px] = PEARL
+        # Target beads live outside the waterline; current droplets live inside.
+        for px, py in self.PETALS[:target]:
+            self.disc(frame, (cx + px, cy + py), 2, ORANGE, hollow=True)
+        for dx, dy in self.LOADS[:value]:
+            self.disc(frame, (cx + dx, cy + dy), 2, SUN)
+            frame[cy + dy, cx + dx] = PEARL
+        if value == target:
+            self.disc(frame, (cx, cy), 5, GREEN, hollow=True)
+        # Node identity is positional plus a unique radial notch count.
+        for notch in range(index + 1):
+            angle_slot = self.PETALS[(notch * 3) % len(self.PETALS)]
+            nx, ny = cx + angle_slot[0], cy + angle_slot[1]
+            self.disc(frame, (nx, ny), 1, FUCHSIA)
+
+    def hud(self, frame):
+        g = self.game
+        # Stage pearls use filled, active-cross, and hollow geometries.
+        count = len(g.level["targets"])
+        start = 32 - (count - 1) * 4
+        for index in range(count):
+            x = start + index * 8
+            if index < g.stage:
+                self.disc(frame, (x, 5), 2, GREEN)
+                frame[5, x] = PEARL
+            elif index == g.stage:
+                self.line(frame, (x - 3, 5), (x + 3, 5), SUN)
+                self.line(frame, (x, 2), (x, 8), SUN)
+                self.disc(frame, (x, 5), 1, ORANGE)
+            else:
+                self.disc(frame, (x, 5), 2, SLATE, hollow=True)
+        # Two distinct moon silhouettes redundantly expose tide phase.
+        self.disc(frame, (5, 5), 4, VIOLET if g.tide % 2 else CYAN)
+        if g.tide % 2:
+            self.disc(frame, (7, 4), 3, ABYSS)
+        else:
+            self.line(frame, (2, 5), (8, 5), MIST)
+            self.line(frame, (5, 2), (5, 8), MIST)
+        # Direction is a curling seed at top-right, not a color-only chevron.
+        self.disc(frame, (58, 5), 3, ORANGE, hollow=True)
+        if g.reverse:
+            self.line(frame, (61, 5), (56, 2), PEARL)
+            self.line(frame, (56, 2), (57, 6), PEARL)
+        else:
+            self.line(frame, (55, 5), (60, 2), PEARL)
+            self.line(frame, (60, 2), (59, 6), PEARL)
+        # Three shell seals: closed shells are persistent mistakes.
+        for index in range(3):
+            y = 20 + index * 8
+            closed = index < g.seals
+            self.disc(frame, (61, y), 3, RED if closed else SLATE, hollow=not closed)
+            self.line(frame, (59, y + 2), (63, y - 2), PEARL if closed else MIST)
+        # Exact unary action budget curls along the lower waterline.
+        for index in range(g.budget_max):
+            x = 5 + index * 2
+            remaining = index < g.budget_left
+            frame[61:63, x] = CYAN if remaining else SLATE
+            if remaining and index % 2 == 0:
+                frame[60, x] = PEARL
+
+    def moving_drop(self, frame, edge_index, reverse, progress, total, color=SUN):
+        authored = self.game.level["edges"][edge_index]
+        a = self.game.level["pos"][authored["a"]]
+        b = self.game.level["pos"][authored["b"]]
+        if reverse and not authored["oneway"]:
+            a, b = b, a
+        x, y = _curve_point(a, b, -authored["bend"] if reverse else authored["bend"], progress, total)
+        self.disc(frame, (x, y), 3 if authored["amount"] == 2 else 2, color)
+        self.disc(frame, (x, y), 1, PEARL)
+        if authored["amount"] == 2:
+            self.disc(frame, (x + 2, y - 2), 1, VIOLET)
+
+    def animation(self, frame):
+        g = self.game
+        if not g.anim_kind:
+            if g.intro_mark:
+                for pos in g.level["pos"]:
+                    self.disc(frame, pos, 10, CYAN, hollow=True)
+            if g.terminal_hold == "win":
+                for pos in g.level["pos"]:
+                    self.disc(frame, pos, 10, GREEN, hollow=True)
+            elif g.terminal_hold == "loss":
+                self.line(frame, (8, 10), (56, 54), RED, dotted=True)
+                self.line(frame, (56, 10), (8, 54), RED, dotted=True)
+            return
+        p, total = g.anim_progress, g.anim_total
+        if g.anim_kind == "select":
+            edge_index = g.pending_state[2]
+            self.moving_drop(frame, edge_index, False, p, total, PEARL)
+            authored = g.level["edges"][edge_index]
+            a, b = g.level["pos"][authored["a"]], g.level["pos"][authored["b"]]
+            # Selection is a local scout with a short, steadily advancing
+            # wake. The settled braid never blinks between full and dotted.
+            for wake in range(max(0, p - 2), p):
+                x, y = _curve_point(a, b, authored["bend"] + 2, wake, total)
+                self.disc(frame, (x, y), 1, SUN)
+        elif g.anim_kind == "reverse":
+            edge_index = g.cursor
+            self.moving_drop(frame, edge_index, False, p, total, FUCHSIA)
+            self.moving_drop(frame, edge_index, True, p, total, PEARL)
+        elif g.anim_kind == "pump":
+            trace = g.anim_trace
+            segment = min(len(trace) - 1, p * len(trace) // max(1, total + 1))
+            local_start = segment * total // len(trace)
+            local_end = max(local_start + 1, (segment + 1) * total // len(trace))
+            local = min(local_end - local_start, max(0, p - local_start))
+            edge_index, reverse = trace[segment]
+            self.moving_drop(frame, edge_index, reverse, local, local_end - local_start)
+            for completed in range(segment):
+                authored = g.level["edges"][trace[completed][0]]
+                destination = authored["a"] if trace[completed][1] else authored["b"]
+                self.disc(frame, g.level["pos"][destination], 9, GREEN, hollow=True)
+        elif g.anim_kind == "gate":
+            authored = g.level["edges"][g.cursor]
+            gate = _curve_point(g.level["pos"][authored["a"]], g.level["pos"][authored["b"]],
+                                authored["bend"], 3, 8)
+            self.disc(frame, gate, 3 + p, VIOLET, hollow=True)
+            self.disc(frame, (5, 5), min(8, 3 + p), CYAN if g.tide % 2 else VIOLET, hollow=True)
+        elif g.anim_kind in ("blocked", "seal"):
+            authored = g.level["edges"][g.cursor]
+            a, b = g.level["pos"][authored["a"]], g.level["pos"][authored["b"]]
+            extent = min(p, max(0, total - p))
+            x, y = _curve_point(a, b, authored["bend"], extent, max(1, total * 2))
+            self.disc(frame, (x, y), 2, RED)
+            self.disc(frame, (61, 20 + min(2, g.pending_state[5] - 1) * 8), 3 + p // 2, RED, hollow=True)
+        elif g.anim_kind == "success":
+            for index, pos in enumerate(g.level["pos"]):
+                radius = 7 + (p + index) % 5
+                self.disc(frame, pos, radius, GREEN, hollow=True)
+            self.disc(frame, (32, 32), 4 + p * 3, CYAN, hollow=True)
+        elif g.anim_kind == "loss":
+            for pos in g.level["pos"]:
+                self.disc(frame, pos, max(2, 9 - p), SLATE, hollow=True)
+            self.line(frame, (7 + p, 9), (57 - p, 55), RED, dotted=True)
+            self.line(frame, (57 - p, 9), (7 + p, 55), RED, dotted=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        g = self.game
+        self.background(frame)
+        for index, authored in enumerate(g.level["edges"]):
+            self.edge(frame, index, authored)
+        target = g.level["targets"][min(g.stage, len(g.level["targets"]) - 1)]
+        for index, (value, wanted, cap) in enumerate(zip(g.values, target, g.level["cap"])):
+            self.node(frame, index, value, wanted, cap)
+        self.hud(frame)
+        self.animation(frame)
+        return frame
+
+
+class Q038(ARCBaseGame):
+    def __init__(self):
+        self.display = BalanceWebDisplay(self)
+        self.level = LEVELS[0]
+        self.values = ()
+        self.tide = self.cursor = self.stage = self.seals = self.terminal = 0
+        self.reverse = False
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_trace = ()
+        self.pending_state = self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q038", levels, Camera(0, 0, 64, 64, ABYSS, ABYSS, [self.display]),
+                         False, len(levels), [1, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        (self.values, self.tide, self.cursor, self.reverse, self.stage,
+         self.seals, self.terminal) = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_trace = ()
+        self.pending_state = self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+
+    def begin(self, kind, frames, state, trace=(), terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.anim_trace = trace
+        self.pending_state = state
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        (self.values, self.tide, self.cursor, self.reverse, self.stage,
+         self.seals, self.terminal) = self.pending_state
+        self.anim_kind = None
+        self.anim_trace = ()
+        self.pending_state = self.pending_terminal = None
+        if terminal == "win":
+            self.terminal_hold = "win"
+            self.next_level()
+        elif terminal == "loss" or self.budget_left <= 0:
+            self.terminal_hold = "loss"
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        self.intro_mark = False
+        before = (self.values, self.tide, self.cursor, self.reverse, self.stage,
+                  self.seals, self.terminal)
+        after = transition(self.level, before, action)
+        self.budget_left -= action_cost(before, after)
+        lost = after[-1] == 3 or (self.budget_left <= 0 and after[-1] != 2)
+        if after[-1] == 2:
+            self.begin("success", 7, after, terminal="win")
+        elif lost:
+            self.begin("loss", 7, after, terminal="loss")
+        elif after[5] > before[5]:
+            self.begin("seal", 6, after)
+        elif action == 1:
+            self.begin("reverse", 6, after)
+        elif action in (3, 4):
+            self.begin("select", 5, after)
+        elif action == 5:
+            _values, trace, result = pump_trace(self.level, before)
+            self.begin("gate" if result == "gate" else "pump", 7 if len(trace) <= 1 else 8,
+                       after, trace=trace)
+        else:
+            self.begin("seal", 6, after)

--- a/data/community-games/sonpham/q041_v2_q041.py
+++ b/data/community-games/sonpham/q041_v2_q041.py
@@ -1,0 +1,682 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q041-v2 Cinder Keyhole Catacomb.
+
+An exact, fully deterministic hex-vault navigation game. Five keyboard
+controls traverse five axial neighbors; action six generously snaps to the
+sixth neighbor or to a brass information aperture. Purchased apertures reveal
+true radius-one hex neighborhoods. Keys, doors, and pressure bridges are
+visible terrain: leaving a bridge collapses it permanently, and late doors
+require both a carried key and specified collapsed pressure seals.
+
+The accepted mx006 candidate is the six-neighbor topology itself. A generic
+counter layer and direct-mouse navigation as a separate mechanic were
+rejected; pointer input is only the accessible interface for the sixth axial
+direction and authored apertures.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import NamedTuple
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, BONE, ASH, SLATE, STONE, CINDER = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, EMBER, BLUE, GLASS, BRASS = 6, 7, 8, 9, 10, 11
+COPPER, OXBLOOD, MOSS, VIOLET = 12, 13, 14, 15
+
+ACTIVE, WIN, LOSS = 0, 2, 3
+TERMINAL_INDEX = 9
+HEX_ACTIONS = (1, 2, 3, 4, 5, 6)
+HEX_DELTAS = {
+    1: (1, 0), 2: (0, 1), 3: (-1, 1),
+    4: (-1, 0), 5: (0, -1), 6: (1, -1),
+}
+class State(NamedTuple):
+    position: tuple
+    revealed: int
+    has_key: bool
+    collapsed: int
+    used_apertures: int
+    opened_doors: int
+    strikes: int
+    last_event: int
+    free_action: int
+    terminal: int
+
+
+def hex_center(cell):
+    q, r = cell
+    return 30 + 7 * q + 3 * r, 25 + 6 * r
+
+
+def hex_distance(left, right):
+    dq = left[0] - right[0]
+    dr = left[1] - right[1]
+    return (abs(dq) + abs(dr) + abs(dq + dr)) // 2
+
+
+def _move_cell(cell, aid, deltas=HEX_DELTAS):
+    dq, dr = deltas[int(aid)]
+    return cell[0] + dq, cell[1] + dr
+
+
+def vault(name, start, moves, apertures, *, keys=(), doors=(),
+          fragile=(), required_collapse=(), require_key=False,
+          curriculum=()):
+    route = [tuple(start)]
+    for aid in moves:
+        route.append(_move_cell(route[-1], aid))
+    cells = tuple(dict.fromkeys(route))
+    index = {cell: offset for offset, cell in enumerate(cells)}
+    apertures = tuple(tuple(cell) for cell in apertures)
+    aperture_masks = []
+    for center in apertures:
+        mask = 0
+        for cell, offset in index.items():
+            if hex_distance(center, cell) <= 1:
+                mask |= 1 << offset
+        aperture_masks.append(frozenset(
+            cell for cell in cells if mask & (1 << index[cell])))
+    initial_revealed = frozenset((tuple(start),))
+    witness = [(6, *hex_center(cell)) for cell in apertures]
+    position = tuple(start)
+    for aid in moves:
+        position = _move_cell(position, aid)
+        witness.append((6, *hex_center(position)) if aid == 6 else aid)
+    result = {
+        "name": name,
+        "cells": cells,
+        "cell_index": index,
+        "start": tuple(start),
+        "goal": route[-1],
+        "hex_audit_cell": tuple(start),
+        "route": tuple(route),
+        "apertures": apertures,
+        "aperture_masks": tuple(aperture_masks),
+        "initial_revealed": initial_revealed,
+        "keys": tuple(tuple(cell) for cell in keys),
+        "doors": tuple(tuple(cell) for cell in doors),
+        "fragile": tuple(tuple(cell) for cell in fragile),
+        "required_collapse": tuple(tuple(cell) for cell in required_collapse),
+        "require_key": bool(require_key),
+        "budget": len(witness),
+        "witness": tuple(witness),
+        "curriculum": tuple(curriculum),
+    }
+    covered = set(initial_revealed)
+    for mask in aperture_masks:
+        covered.update(mask)
+    assert all(cell in covered for cell in route)
+    return result
+
+
+LEVELS = (
+    vault(
+        "First Ember", (0, 0), (1, 1), ((1, 0),),
+        curriculum=("hex-east", "radius-one-aperture"),
+    ),
+    vault(
+        "Descending Keyholes", (0, -2), (2, 2, 2, 2, 2, 2),
+        ((0, -1), (0, 1), (0, 3)),
+        curriculum=("hex-southeast", "two-information-cuts"),
+    ),
+    vault(
+        "Brass Detour", (0, 0), (3, 6, 1, 1, 1, 1),
+        ((0, 0), (2, 0), (4, 0)), keys=((-1, 1),), doors=((3, 0),),
+        require_key=True,
+        curriculum=("hex-southwest", "pointer-return", "key-door-detour"),
+    ),
+    vault(
+        "Pressure Span", (3, 0), (4, 4, 4, 4, 4, 4),
+        ((2, 0), (0, 0), (-2, 0)), doors=((-2, 0),), fragile=((2, 0),),
+        required_collapse=((2, 0),),
+        curriculum=("hex-west", "collapse-pressure-door"),
+    ),
+    vault(
+        "Ashen Ascent", (0, 4), (5, 5, 5, 5, 5, 5),
+        ((0, 3), (0, 1), (0, -1)),
+        curriculum=("hex-northwest", "aperture-overlap"),
+    ),
+    vault(
+        "Needle Causeway", (-1, 4), (6, 6, 6, 6, 6, 6),
+        ((0, 3), (3, 0), (4, -1)), keys=((0, 3),), doors=((3, 0),),
+        fragile=((2, 1),), required_collapse=((2, 1),),
+        require_key=True,
+        curriculum=("pointer-sixth-neighbor", "key", "collapse", "door"),
+    ),
+    vault(
+        "Cinder Circuit", (0, 0), (1, 2, 3, 4, 5, 6),
+        ((0, 0), (1, 1), (-1, 2)), keys=((1, 0),), doors=((1, 1),),
+        fragile=((1, 0),), required_collapse=((1, 0),),
+        require_key=True,
+        curriculum=("hex-cycle", "future-route-cut", "opened-door-goal-cut"),
+    ),
+    vault(
+        "Cinder Keyhole Catacomb", (0, 0),
+        (5, 2, 1, 2, 3, 4, 5, 6, 6),
+        ((0, 0), (1, 1), (-1, 2)),
+        keys=((0, -1),), doors=((1, 1),), fragile=((1, 0),),
+        required_collapse=((1, 0),), require_key=True,
+        curriculum=("all-six-neighbors", "three-aperture-plan", "key-spur",
+                    "future-reachability-collapse", "door-cut", "return-seal"),
+    ),
+)
+
+
+def action_id(action):
+    return int(action[0]) if isinstance(action, (tuple, list)) else int(action)
+
+
+def action_tokens(level):
+    pointer = tuple((6, *hex_center(cell)) for cell in level["cells"])
+    return (1, 2, 3, 4, 5) + pointer
+
+
+def encode_action(_level, action):
+    if isinstance(action, (tuple, list)):
+        return tuple(int(value) for value in action)
+    return (int(action),)
+
+
+def _bit(level, cell):
+    index = level["cell_index"].get(tuple(cell))
+    return 0 if index is None else 1 << index
+
+
+def _mask(level, cells):
+    result = 0
+    for cell in cells:
+        result |= _bit(level, cell)
+    return result
+
+
+def terrain_at(level, cell):
+    cell = tuple(cell)
+    if cell not in level["cell_index"]:
+        return "wall"
+    if cell == level["goal"]:
+        return "goal"
+    if cell in level["keys"]:
+        return "key"
+    if cell in level["doors"]:
+        return "door"
+    if cell in level["fragile"]:
+        return "fragile"
+    return "floor"
+
+
+def hex_neighbor(_level, cell, action):
+    """Return one of the six unique axial neighbors for an action id."""
+    return _move_cell(tuple(cell), action_id(action))
+
+
+def _clicked_cell(level, action):
+    if not isinstance(action, (tuple, list)) or len(action) != 3:
+        return None
+    x, y = int(action[1]), int(action[2])
+    return min(level["cells"],
+               key=lambda cell: abs(x - hex_center(cell)[0])
+               + abs(y - hex_center(cell)[1]))
+
+
+def action6_mode(level, state, action):
+    """Classify action six with the same aperture-first priority as runtime."""
+    if action_id(action) != 6:
+        return "blocked"
+    clicked = _clicked_cell(level, action)
+    if clicked is None:
+        return "blocked"
+    for index, center in enumerate(level["apertures"]):
+        if clicked == center and not state.used_apertures & (1 << index):
+            return "aperture"
+    return ("move" if clicked == hex_neighbor(level, state.position, 6)
+            else "blocked")
+
+
+def start_state(level):
+    return State(
+        level["start"], level["initial_revealed"], False, frozenset(), 0, 0,
+        0, 0, 0, ACTIVE,
+    )
+
+
+def _warning(state, event):
+    strikes = state.strikes + 1
+    return state._replace(
+        strikes=strikes, last_event=event,
+        free_action=0,
+        terminal=LOSS if strikes >= 2 else ACTIVE,
+    )
+
+
+def _goal_ready(level, state, mode):
+    key_ok = (not level["require_key"] or state.has_key
+              or mode == "without_key_gate")
+    collapse_ok = set(level["required_collapse"]).issubset(state.collapsed)
+    doors_ok = (_mask(level, level["doors"]) & state.opened_doors
+                == _mask(level, level["doors"])
+                or not level["doors"])
+    return key_ok and collapse_ok and doors_ok
+
+
+def _enter(level, state, target, aid, mode):
+    """Apply terrain physics after a topology rule chooses a destination."""
+    bit = _bit(level, target)
+    collapsed_block = (target in state.collapsed
+                       and mode != "without_collapse")
+    if not bit or target not in state.revealed or collapsed_block:
+        return _warning(state, aid)
+    terrain = terrain_at(level, target)
+    prospective_collapse = state.collapsed
+    if state.position in level["fragile"]:
+        prospective_collapse = prospective_collapse | frozenset((state.position,))
+    if terrain == "door":
+        collapse_mask = _mask(level, level["required_collapse"])
+        keyed = (not level["require_key"] or state.has_key
+                 or mode == "without_key_gate")
+        pressured = set(level["required_collapse"]).issubset(
+            prospective_collapse)
+        if not keyed or not pressured:
+            return _warning(state, aid)
+    if target == level["goal"] and not _goal_ready(level, state, mode):
+        return _warning(state, aid)
+
+    collapsed = prospective_collapse
+    opened = state.opened_doors
+    if terrain == "door":
+        opened |= bit
+    result = state._replace(
+        position=target,
+        has_key=state.has_key or terrain == "key",
+        collapsed=collapsed,
+        opened_doors=opened,
+        last_event=aid,
+        free_action=0,
+    )
+    if target == level["goal"] and _goal_ready(level, result, mode):
+        result = result._replace(terminal=WIN)
+    return result
+
+
+def _step(level, state, aid, mode):
+    return _enter(level, state, _move_cell(state.position, aid), aid, mode)
+
+
+def _transition(level, state, action, mode="normal"):
+    if state.terminal != ACTIVE:
+        return state
+    aid = action_id(action)
+    if aid not in HEX_ACTIONS:
+        return state
+    if aid != 6:
+        return _step(level, state, aid, mode)
+
+    clicked = _clicked_cell(level, action)
+    if clicked is None:
+        return state
+    for index, center in enumerate(level["apertures"]):
+        bit = 1 << index
+        if clicked == center and not state.used_apertures & bit:
+            return state._replace(
+                revealed=state.revealed | level["aperture_masks"][index],
+                used_apertures=state.used_apertures | bit,
+                last_event=60 + index,
+                free_action=1 if mode == "without_information_cost" else 0,
+            )
+    expected = _move_cell(state.position, 6)
+    if clicked == expected:
+        return _step(level, state, 6, mode)
+    if mode == "without_hex_adjacency":
+        # Removing the adjacency constraint is a strict superset mutation:
+        # every production hex move remains valid, while any revealed cell
+        # may additionally be selected directly with action six.
+        return _enter(level, state, clicked, 6, mode)
+    return state
+
+
+def transition(level, state, action):
+    return _transition(level, state, action)
+
+
+def without_hex_adjacency(level, state, action):
+    return _transition(level, state, action, "without_hex_adjacency")
+
+
+def without_information_cost(level, state, action):
+    return _transition(level, state, action, "without_information_cost")
+
+
+def without_key_gate(level, state, action):
+    return _transition(level, state, action, "without_key_gate")
+
+
+def without_collapse(level, state, action):
+    return _transition(level, state, action, "without_collapse")
+
+
+def action_cost(before, after):
+    if (after == before or after.strikes > before.strikes
+            or after.free_action):
+        return 0
+    return 1
+
+
+def solved(_level, state):
+    return state.terminal == WIN
+
+
+def execute(level, actions, transition_fn=transition):
+    state = start_state(level)
+    budget = level["budget"]
+    for action in actions:
+        after = transition_fn(level, state, action)
+        budget -= action_cost(state, after)
+        state = after
+    return state, budget
+
+
+for _level in LEVELS:
+    _state, _left = execute(_level, _level["witness"])
+    assert solved(_level, _state) and _left == 0, (
+        _level["name"], _state, _left, _level["witness"])
+assert {action_id(action) for level in LEVELS
+        for action in level["witness"]} == set(HEX_ACTIONS)
+
+
+class CatacombDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def pixel(frame, x, y, color):
+        if 0 <= x < 64 and 0 <= y < 64:
+            frame[y, x] = color
+
+    @classmethod
+    def line(cls, frame, start, end, color, dotted=False):
+        x0, y0 = start; x1, y1 = end
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for index in range(steps + 1):
+            if dotted and index % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * index // steps
+            y = y0 + (y1 - y0) * index // steps
+            cls.pixel(frame, x, y, color)
+
+    @classmethod
+    def hexagon(cls, frame, cell, color, inner=None):
+        x, y = hex_center(cell)
+        spans = (2, 3, 4, 4, 3, 2, 1)
+        for dy, span in zip(range(-3, 4), spans):
+            frame[y + dy, max(0, x - span):min(64, x + span + 1)] = color
+        if inner is not None:
+            for dy in range(-1, 2):
+                frame[y + dy, max(0, x - 2):min(64, x + 3)] = inner
+
+    @classmethod
+    def outline_hex(cls, frame, center, color):
+        x, y = center
+        points = ((x, y - 5), (x + 5, y - 2), (x + 5, y + 2),
+                  (x, y + 5), (x - 5, y + 2), (x - 5, y - 2))
+        for left, right in zip(points, points[1:] + points[:1]):
+            cls.line(frame, left, right, color)
+
+    def background(self, frame):
+        frame[:, :] = CINDER
+        # A dense field of interlocked dark wall hexes makes the axial vault
+        # legible even where the purchased route remains unrevealed.
+        for r in range(-3, 6):
+            for q in range(-5, 6):
+                x, y = hex_center((q, r))
+                if 4 <= x < 60 and 5 <= y < 56:
+                    self.hexagon(frame, (q, r), STONE, CINDER)
+        frame[0:3, :] = OXBLOOD
+        frame[57:64, :] = STONE
+
+    def tile(self, frame, level, state, cell):
+        bit = _bit(level, cell)
+        terrain = terrain_at(level, cell)
+        visible = cell in state.revealed
+        if not visible:
+            self.hexagon(frame, cell, SLATE, CINDER)
+            x, y = hex_center(cell)
+            self.pixel(frame, x, y, ASH)
+            return
+        color = ASH if terrain == "floor" else STONE
+        if terrain == "goal":
+            color = MOSS
+        elif terrain == "door":
+            color = BRASS if not state.opened_doors & bit else ASH
+        elif terrain == "fragile":
+            color = EMBER
+        elif terrain == "key":
+            color = BLUE if not state.has_key else ASH
+        if cell in state.collapsed:
+            color = OXBLOOD
+        self.hexagon(frame, cell, color, BONE if color in (ASH, STONE) else None)
+        x, y = hex_center(cell)
+        if terrain == "key" and not state.has_key:
+            self.outline_hex(frame, (x - 2, y), PAPER)
+            self.line(frame, (x + 1, y), (x + 5, y), PAPER)
+            self.line(frame, (x + 4, y), (x + 4, y + 2), CINDER)
+        elif terrain == "door":
+            self.line(frame, (x - 3, y - 3), (x - 3, y + 3), CINDER)
+            self.line(frame, (x, y - 3), (x, y + 3), CINDER)
+            self.line(frame, (x + 3, y - 3), (x + 3, y + 3), CINDER)
+            self.line(frame, (x - 4, y - 1), (x + 4, y - 1), PAPER)
+            self.line(frame, (x - 4, y + 2), (x + 4, y + 2), CINDER)
+        elif terrain == "goal":
+            self.hexagon(frame, cell, MOSS, CINDER)
+        elif terrain == "fragile" and cell not in state.collapsed:
+            self.line(frame, (x - 3, y - 2), (x + 2, y + 2), PAPER,
+                      dotted=True)
+            self.line(frame, (x + 3, y - 2), (x - 2, y + 2), CINDER,
+                      dotted=True)
+        if cell in state.collapsed:
+            self.line(frame, (x - 3, y - 2), (x + 3, y + 2), EMBER)
+            self.line(frame, (x + 2, y - 3), (x - 2, y + 3), BRASS)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        game = self.game; level = game.level; state = game.visual_state()
+        self.background(frame)
+        # True six-neighbor stone seams remain visible under the vault floor.
+        for cell in level["cells"]:
+            for aid in (1, 2, 3):
+                other = hex_neighbor(level, cell, aid)
+                if other in level["cell_index"]:
+                    self.line(frame, hex_center(cell), hex_center(other), SLATE)
+        for cell in level["cells"]:
+            self.tile(frame, level, state, cell)
+
+        # Aperture crowns are always visible targets, but their revealed radius
+        # is shown by six short brass spokes only after purchase.
+        for index, cell in enumerate(level["apertures"]):
+            x, y = hex_center(cell); used = bool(state.used_apertures & (1 << index))
+            color = COPPER if used else BRASS
+            for aid in HEX_ACTIONS:
+                neighbor = _move_cell(cell, aid)
+                nx, ny = hex_center(neighbor)
+                self.line(frame, (x, y), ((x * 2 + nx) // 3,
+                                           (y * 2 + ny) // 3), color)
+            self.pixel(frame, x, y, PAPER if not used else COPPER)
+
+        px, py = hex_center(state.position)
+        self.hexagon(frame, state.position, MAGENTA, VIOLET)
+        self.pixel(frame, px, py, PAPER)
+
+        # Action six has an explicit destination halo. If that neighbor is an
+        # unused aperture, a rose double halo signals aperture priority;
+        # otherwise the glass halo signals a sixth-direction movement.
+        sixth = hex_neighbor(level, state.position, 6)
+        sixth_bit = _bit(level, sixth)
+        if sixth_bit:
+            target = hex_center(sixth)
+            priority = any(
+                sixth == cell and not state.used_apertures & (1 << index)
+                for index, cell in enumerate(level["apertures"]))
+            self.outline_hex(frame, target, ROSE if priority else GLASS)
+            if priority:
+                self.outline_hex(frame, (target[0], target[1] + 1), BRASS)
+
+        # Exact action reserve: one bottom brass tooth per remaining action.
+        for index in range(game.budget_left):
+            x = 3 + index * 4
+            frame[59:62, x:x + 3] = BRASS
+        # Exact unused aperture count and two visible warning seals.
+        remaining = len(level["apertures"]) - state.used_apertures.bit_count()
+        for index in range(remaining):
+            self.hexagon(frame, (-4 + index, 5), BLUE)
+        for index in range(2):
+            y = 6 + index * 8
+            color = EMBER if index < state.strikes else MOSS
+            self.outline_hex(frame, (59, y), color)
+            if index < state.strikes:
+                self.line(frame, (56, y - 3), (62, y + 3), PAPER)
+                self.line(frame, (62, y - 3), (56, y + 3), EMBER)
+            elif index == 0:
+                self.line(frame, (57, y), (61, y), PAPER)
+            else:
+                self.line(frame, (59, y - 2), (59, y + 2), PAPER)
+
+        # A settled loss keeps a large, non-color-only tomb seal.  The same
+        # crossed silhouette appears during the loss animation and afterward.
+        if state.terminal == LOSS:
+            self.line(frame, (16, 15), (48, 47), PAPER)
+            self.line(frame, (48, 15), (16, 47), PAPER)
+            self.line(frame, (13, 12), (51, 12), OXBLOOD)
+            self.line(frame, (13, 50), (51, 50), OXBLOOD)
+
+        kind = game.anim_kind
+        if kind:
+            progress = game.anim_progress
+            direction = 1 if progress % 4 < 2 else -1
+            if kind in ("move", "key", "door", "collapse"):
+                target = game.pending_state.position
+                tx, ty = hex_center(target)
+                self.line(frame, (px, py), (tx, ty),
+                          GLASS if progress % 2 else BRASS, dotted=True)
+                self.pixel(frame, tx + direction, ty, PAPER)
+            elif kind == "aperture":
+                event = max(0, game.pending_state.last_event - 60)
+                center = level["apertures"][min(event, len(level["apertures"]) - 1)]
+                cx, cy = hex_center(center)
+                radius = 1 + progress % 4
+                for aid in HEX_ACTIONS:
+                    nx, ny = hex_center(_move_cell(center, aid))
+                    self.pixel(frame, cx + (nx - cx) * radius // 4,
+                               cy + (ny - cy) * radius // 4, BRASS)
+            elif kind == "blocked":
+                color = BRASS if progress % 2 else COPPER
+                self.line(frame, (2, 30), (6 + progress % 3, 30), color)
+                self.line(frame, (61, 30), (57 - progress % 3, 30), color)
+            elif kind == "warning":
+                frame[29:35, 1 + progress % 4:5 + progress % 4] = EMBER
+                frame[29:35, 59 - progress % 4:63 - progress % 4] = EMBER
+                self.outline_hex(frame, (32, 8), PAPER if progress % 2 else EMBER)
+                self.line(frame, (29, 5), (35, 11), EMBER)
+            elif kind == "loss":
+                color = EMBER if progress % 2 else BRASS
+                self.line(frame, (16, 15), (48, 47), color)
+                self.line(frame, (48, 15), (16, 47), color)
+                self.line(frame, (13, 12), (51, 12), OXBLOOD)
+                self.line(frame, (13, 50), (51, 50), OXBLOOD)
+            elif kind == "success":
+                for y in range(4, min(57, 8 + progress * 8)):
+                    self.pixel(frame, 32 + (y % 3) - 1, y, BRASS)
+        return frame
+
+
+class Q041(ARCBaseGame):
+    def __init__(self):
+        self.display = CatacombDisplay(self)
+        self.level = None; self.state = None
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None; self.anim_total = 0
+        self.anim_left = 0; self.anim_progress = 0
+        self.pending_state = None; self.pending_budget = None
+        self.pending_terminal = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item),
+                        name=item["name"]) for item in LEVELS]
+        super().__init__("q041", levels,
+                         Camera(0, 0, 64, 64, CINDER, CINDER, [self.display]),
+                         False, len(levels), list(HEX_ACTIONS))
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None; self.anim_total = 0
+        self.anim_left = 0; self.anim_progress = 0
+        self.pending_state = None; self.pending_budget = None
+        self.pending_terminal = None
+
+    def visual_state(self):
+        return self.pending_state if self.anim_kind and self.anim_progress >= 4 else self.state
+
+    def begin(self, kind, frames, after, budget, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames
+        self.anim_progress = 0; self.pending_state = after
+        self.pending_budget = budget; self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state; self.budget_left = self.pending_budget
+        self.anim_kind = None; self.anim_total = self.anim_left = 0
+        self.anim_progress = 0; self.pending_state = self.pending_budget = None
+        self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        aid = self.action.id.value
+        if aid == 0:
+            self.complete_action(); return
+        action = aid
+        if aid == 6:
+            action = (6, int(self.action.data.get("x", -99)),
+                      int(self.action.data.get("y", -99)))
+        before = self.state; after = transition(self.level, before, action)
+        if after == before:
+            self.begin("blocked", 5, before, self.budget_left); return
+        cost = action_cost(before, after); budget = self.budget_left - cost
+        won = after.terminal == WIN
+        lost = after.terminal == LOSS or (budget <= 0 and not won)
+        if lost and after.terminal != LOSS:
+            after = after._replace(terminal=LOSS)
+        if won:
+            kind, frames, terminal = "success", 6, "win"
+        elif lost:
+            kind, frames, terminal = "loss", 6, "loss"
+        elif after.strikes > before.strikes:
+            kind, frames, terminal = "warning", 6, None
+        elif after.used_apertures != before.used_apertures:
+            kind, frames, terminal = "aperture", 7, None
+        elif after.has_key and not before.has_key:
+            kind, frames, terminal = "key", 7, None
+        elif after.opened_doors != before.opened_doors:
+            kind, frames, terminal = "door", 7, None
+        elif after.collapsed != before.collapsed:
+            kind, frames, terminal = "collapse", 7, None
+        else:
+            kind, frames, terminal = "move", 7, None
+        self.begin(kind, frames, after, budget, terminal)
+
+
+if __name__ == "__main__":
+    print("q041-v2 ok")

--- a/data/community-games/sonpham/q044_v2_q044.py
+++ b/data/community-games/sonpham/q044_v2_q044.py
@@ -1,0 +1,640 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q044-v2 Pressed Wildflower Atlas -- selective future-facing memory.
+
+The player inspects a small garden through two semantic lenses, keeps only a
+bounded set of specimens, and closes the garden forever.  The resulting
+pressings can then be lifted, relocated, turned over, and developed into the
+future forms engraved on an atlas plate.  Later pages stitch cards together:
+turning or developing one also transforms its neighbor.
+
+The pure tuple transition below is intentionally independent of rendering so
+that exact search, replay, and random-policy qualification can share one model.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+WHITE, PEARL, ASH, SLATE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, AQUA, GOLD, CORAL, EARTH, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+
+
+RAW_LEVELS = [
+    {
+        "name": "One Keepsake", "faces": ((1, 6), (4, 3), (2, 5)),
+        "bank": 1, "recipe": ((2, 0, 0),), "reorder": False,
+        "flip": False, "develop": False, "paired_flip": False,
+        "spread": False, "season": 1, "budget": 3,
+    },
+    {
+        "name": "Small Folio", "faces": ((2, 5), (6, 1), (3, 4), (5, 2)),
+        "bank": 2, "recipe": ((3, 0, 0), (1, 0, 0)), "reorder": True,
+        "flip": False, "develop": False, "paired_flip": False,
+        "spread": False, "season": 2, "budget": 9,
+    },
+    {
+        "name": "Underleaf", "faces": ((1, 5), (4, 2), (7, 0), (3, 6), (6, 1)),
+        "bank": 2, "recipe": ((3, 1, 0), (1, 0, 0)), "reorder": True,
+        "flip": True, "develop": False, "paired_flip": False,
+        "spread": False, "season": 4, "budget": 12,
+    },
+    {
+        "name": "Tomorrow's Press", "faces": ((0, 7), (2, 5), (6, 1), (3, 4), (5, 0)),
+        "bank": 2, "recipe": ((4, 0, 1), (1, 1, 0)), "reorder": True,
+        "flip": True, "develop": True, "paired_flip": False,
+        "spread": False, "season": 3, "budget": 13,
+    },
+    {
+        "name": "Stitched Pair", "faces": ((1, 4), (6, 2), (0, 5), (3, 7), (5, 1), (2, 6)),
+        "bank": 3, "recipe": ((3, 1, 0), (1, 1, 0), (4, 0, 0)), "reorder": True,
+        "flip": True, "develop": False, "paired_flip": True,
+        "spread": False, "season": 2, "budget": 13,
+    },
+    {
+        "name": "Root Ink", "faces": ((4, 1), (7, 2), (2, 6), (0, 5), (5, 3), (1, 4)),
+        "bank": 3, "recipe": ((4, 0, 1), (2, 0, 1), (0, 0, 0)), "reorder": True,
+        "flip": False, "develop": True, "paired_flip": False,
+        "spread": True, "season": 3, "budget": 17,
+    },
+    {
+        "name": "Braided Herbarium", "faces": ((3, 6), (0, 5), (5, 1), (2, 7), (6, 4), (1, 3)),
+        "bank": 3, "recipe": ((5, 1, 1), (2, 1, 1), (4, 0, 0)), "reorder": True,
+        "flip": True, "develop": True, "paired_flip": True,
+        "spread": True, "season": 5, "budget": 15,
+    },
+    {
+        "name": "Wildflower Atlas", "faces": ((0, 5), (6, 1), (3, 7), (5, 2), (1, 4), (7, 0)),
+        "bank": 3, "recipe": ((5, 1, 0), (1, 1, 1), (4, 0, 1)), "reorder": True,
+        "flip": True, "develop": True, "paired_flip": True,
+        "spread": True, "season": 3, "budget": 15,
+    },
+]
+
+
+def encode_card(source, flipped=0, developed=0):
+    return source * 4 + int(bool(flipped)) * 2 + int(bool(developed))
+
+
+def decode_card(card):
+    return card // 4, (card // 2) & 1, card & 1
+
+
+def card_value(level, card):
+    source, flipped, developed = decode_card(card)
+    value = level["faces"][source][flipped]
+    return value ^ level["season"] if developed else value
+
+
+def target_cards(level):
+    return tuple(encode_card(*item) for item in level["recipe"])
+
+
+def start_state(level):
+    # phase, cursor, pressed cards, held card, inspection lens,
+    # two independent audit seals, remaining operation budget, terminal
+    return (0, 0, (), -1, 0, 2, level["budget"], 0)
+
+
+def solved(level, state):
+    return (state[0] == 1 and state[2] == target_cards(level)
+            and state[3] == -1 and state[7] == 0)
+
+
+def action_cost(before, after):
+    return max(0, before[6] - after[6])
+
+
+def _replace(state, **updates):
+    names = ("phase", "cursor", "cards", "held", "lens", "seals", "budget", "terminal")
+    values = dict(zip(names, state)); values.update(updates)
+    return tuple(values[name] for name in names)
+
+
+def _mistake(state):
+    if state[5] > 1:
+        return _replace(state, seals=state[5] - 1)
+    return _replace(state, seals=0, terminal=2)
+
+
+def _spend(state, **updates):
+    if state[6] <= 0:
+        return _replace(state, terminal=2)
+    updates["budget"] = state[6] - 1
+    return _replace(state, **updates)
+
+
+def _transform(card, flip=False, develop=False):
+    source, flipped, developed = decode_card(card)
+    return encode_card(source, flipped ^ int(flip), developed ^ int(develop))
+
+
+def transition(level, state, action):
+    """Return one deterministic settled state for an exposed action id."""
+    phase, cursor, cards, held, lens, seals, budget, terminal = state
+    if terminal or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    if action == 6:
+        return _replace(state, terminal=1) if solved(level, state) else _mistake(state)
+
+    if phase == 0:
+        count = len(level["faces"])
+        if action == 1:
+            return _spend(state, cursor=(cursor - 1) % count)
+        if action == 2:
+            return _spend(state, cursor=(cursor + 1) % count)
+        if action == 3:
+            sources = {decode_card(card)[0] for card in cards}
+            if cursor in sources or len(cards) >= level["bank"]:
+                return state
+            # The pressing preserves the face under the active inspection
+            # lens, making semantic inspection an operational choice rather
+            # than an optional preview of an already identified specimen.
+            pressing = encode_card(cursor, flipped=lens)
+            # The drying pocket sorts pressings by their garden position.
+            placed = tuple(sorted(cards + (pressing,), key=lambda card: decode_card(card)[0]))
+            return _spend(state, cards=placed)
+        if action == 4:
+            if len(cards) != level["bank"]:
+                return _mistake(state)
+            return _spend(state, phase=1, cursor=0, lens=0)
+        if action == 5:
+            return _spend(state, lens=1 - lens)
+        return state
+
+    count = len(cards) + (1 if held != -1 else 0)
+    if action == 1 and count:
+        return _spend(state, cursor=(cursor - 1) % count)
+    if action == 2 and count:
+        return _spend(state, cursor=(cursor + 1) % count)
+    if action == 3 and level["reorder"]:
+        if held == -1 and cards:
+            picked = cards[cursor]
+            remainder = cards[:cursor] + cards[cursor + 1:]
+            return _spend(state, cards=remainder, held=picked,
+                          cursor=min(cursor, len(remainder)))
+        if held != -1:
+            insertion = max(0, min(cursor, len(cards)))
+            placed = cards[:insertion] + (held,) + cards[insertion:]
+            return _spend(state, cards=placed, held=-1,
+                          cursor=min(insertion, len(placed) - 1))
+        return state
+    if action == 4 and level["flip"] and held == -1 and cards:
+        changed = list(cards); changed[cursor] = _transform(changed[cursor], flip=True)
+        if level["paired_flip"] and len(changed) > 1:
+            neighbor = (cursor + 1) % len(changed)
+            changed[neighbor] = _transform(changed[neighbor], flip=True)
+        return _spend(state, cards=tuple(changed))
+    if action == 5 and level["develop"] and held == -1 and cards:
+        changed = list(cards); changed[cursor] = _transform(changed[cursor], develop=True)
+        if level["spread"] and len(changed) > 1:
+            neighbor = (cursor + 1) % len(changed)
+            changed[neighbor] = _transform(changed[neighbor], develop=True)
+        return _spend(state, cards=tuple(changed))
+    return state
+
+
+LEVELS = []
+for raw in RAW_LEVELS:
+    level = deepcopy(raw)
+    level["target"] = target_cards(level)
+    LEVELS.append(level)
+
+
+class AtlasDisplay(RenderableUserDisplay):
+    SOURCE_POSITIONS = ((8, 19), (16, 10), (26, 18), (36, 9), (47, 17), (55, 9), (55, 28))
+
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def pixel(frame, x, y, color):
+        if 0 <= x < 64 and 0 <= y < 64:
+            frame[y, x] = color
+
+    @classmethod
+    def line(cls, frame, a, b, color, dotted=False):
+        x0, y0 = a; x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for index in range(steps + 1):
+            if dotted and index % 3 == 1:
+                continue
+            cls.pixel(frame, round(x0 + (x1 - x0) * index / steps),
+                      round(y0 + (y1 - y0) * index / steps), color)
+
+    @classmethod
+    def diamond(cls, frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(cy - radius, cy + radius + 1):
+            for x in range(cx - radius, cx + radius + 1):
+                distance = abs(x - cx) + abs(y - cy)
+                if distance == radius if hollow else distance <= radius:
+                    cls.pixel(frame, x, y, color)
+
+    @classmethod
+    def disc(cls, frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(cy - radius, cy + radius + 1):
+            for x in range(cx - radius, cx + radius + 1):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius ** 2 and (not hollow or distance >= max(0, radius - 1) ** 2):
+                    cls.pixel(frame, x, y, color)
+
+    @classmethod
+    def polygon(cls, frame, points, color):
+        for start, end in zip(points, points[1:] + points[:1]):
+            cls.line(frame, start, end, color)
+
+    def paper(self, frame):
+        frame[:, :] = PEARL
+        # Layered, torn handmade paper: no rectangular field carries meaning.
+        self.polygon(frame, [(2, 3), (12, 1), (24, 3), (35, 1), (47, 4), (61, 2),
+                             (60, 53), (50, 55), (39, 53), (27, 55), (15, 53), (3, 55)], ASH)
+        frame[5:52, 4:60] = WHITE
+        for x, y, color in ((7, 6, ROSE), (20, 4, GOLD), (31, 6, GREEN), (43, 5, CORAL),
+                            (56, 6, VIOLET), (10, 34, EARTH), (23, 32, AQUA),
+                            (39, 34, ROSE), (54, 33, GREEN)):
+            self.diamond(frame, (x, y), 1, color)
+        self.line(frame, (5, 37), (59, 37), EARTH, dotted=True)
+
+    def botanical(self, frame, center, value, color, small=False, developed=False):
+        x, y = center; scale = 1 if small else 2
+        self.line(frame, (x, y + 3 * scale), (x, y - 2 * scale), GREEN)
+        # Each value bit has shape as well as hue: round leaf, triangular leaf,
+        # and a four-point seed head.  Missing bits retain a crossed scar.
+        if value & 1:
+            self.disc(frame, (x - 2 * scale, y), scale, color, hollow=True)
+        else:
+            self.line(frame, (x - 3 * scale, y - scale), (x - scale, y + scale), SLATE)
+            self.line(frame, (x - scale, y - scale), (x - 3 * scale, y + scale), SLATE)
+        if value & 2:
+            self.polygon(frame, [(x, y - scale), (x + 3 * scale, y - 2 * scale),
+                                 (x + 2 * scale, y + scale)], color)
+        else:
+            self.diamond(frame, (x + 2 * scale, y), scale, SLATE, hollow=True)
+        if value & 4:
+            self.diamond(frame, (x, y - 3 * scale), scale + (0 if small else 1), color, hollow=True)
+            self.pixel(frame, x, y - 3 * scale, GOLD)
+        else:
+            self.disc(frame, (x, y - 3 * scale), scale, SLATE, hollow=True)
+        if developed:
+            for dx, dy in ((-2, -2), (2, -2), (-2, 2), (2, 2)):
+                self.diamond(frame, (x + dx * scale, y + dy * scale), 1, GOLD)
+
+    def identity(self, frame, center, source, color, small=False):
+        x, y = center
+        if source % 3 == 0:
+            self.disc(frame, (x, y), 2 if not small else 1, color, hollow=True)
+        elif source % 3 == 1:
+            self.diamond(frame, (x, y), 2 if not small else 1, color, hollow=True)
+        else:
+            reach = 2 if not small else 1
+            self.line(frame, (x - reach, y + reach), (x, y - reach), color)
+            self.line(frame, (x, y - reach), (x + reach, y + reach), color)
+        # Binary stitches make every source identity unique without color.
+        for bit in range(3):
+            px = x - 3 + bit * 3
+            if source & (1 << bit): self.diamond(frame, (px, y + 3), 1, color)
+            else: self.pixel(frame, px, y + 3, SLATE)
+
+    def card(self, frame, center, card, target=False, selected=False, small=False):
+        level = self.game.level
+        source, flipped, developed = decode_card(card)
+        x, y = center; half_w = 4 if small else 6; half_h = 6 if small else 8
+        color = (CORAL, GREEN, VIOLET, GOLD, ROSE, AQUA, EARTH)[source % 7]
+        points = [(x - half_w, y - half_h + 1), (x - half_w + 2, y - half_h),
+                  (x + half_w, y - half_h + 1), (x + half_w - 1, y + half_h),
+                  (x - half_w, y + half_h - 1)]
+        self.polygon(frame, points, GOLD if target else EARTH)
+        if selected:
+            for corner in ((x - half_w, y - half_h), (x + half_w, y - half_h),
+                           (x - half_w, y + half_h), (x + half_w, y + half_h)):
+                self.diamond(frame, corner, 1, INK)
+        self.botanical(frame, (x, y - 1), card_value(level, card), color,
+                       small=True, developed=bool(developed))
+        self.identity(frame, (x, y + half_h - 3), source, color, small=True)
+        # A left or right cut corner redundantly exposes face orientation.
+        notch_x = x + half_w if flipped else x - half_w
+        self.line(frame, (notch_x, y - 3), (notch_x + (-2 if flipped else 2), y - 1), INK)
+
+    def source(self, frame, source, center, captured, lens, selected):
+        level = self.game.level; color = (CORAL, GREEN, VIOLET, GOLD, ROSE, AQUA, EARTH)[source % 7]
+        value = level["faces"][source][lens]
+        if captured:
+            self.disc(frame, center, 5, ASH, hollow=True)
+            self.line(frame, (center[0] - 3, center[1] - 3), (center[0] + 3, center[1] + 3), EARTH)
+            self.line(frame, (center[0] + 3, center[1] - 3), (center[0] - 3, center[1] + 3), EARTH)
+        else:
+            self.botanical(frame, center, value, color)
+            self.identity(frame, (center[0], center[1] + 8), source, color)
+        if selected:
+            self.polygon(frame, [(center[0], center[1] - 10), (center[0] + 7, center[1] - 3),
+                                 (center[0], center[1] + 10), (center[0] - 7, center[1] - 3)], INK)
+
+    @staticmethod
+    def row_positions(count, y):
+        gap = 13 if count >= 4 else 16
+        start = 32 - gap * (count - 1) / 2
+        return [(round(start + index * gap), y) for index in range(count)]
+
+    def target_row(self, frame, y=11, small=False):
+        target = target_cards(self.game.level)
+        for position, card in zip(self.row_positions(len(target), y), target):
+            self.card(frame, position, card, target=True, small=small)
+
+    def atlas_row(self, frame, state, y=43, *, omit=None):
+        cards = state[2]
+        for index, (position, card) in enumerate(zip(self.row_positions(len(cards), y), cards)):
+            if index != omit:
+                self.card(frame, position, card, selected=state[3] == -1 and index == state[1])
+        if state[3] != -1:
+            positions = self.row_positions(len(cards) + 1, y)
+            insertion = max(0, min(state[1], len(cards)))
+            self.card(frame, (positions[insertion][0], y - 8), state[3], selected=True)
+            self.line(frame, (positions[insertion][0], y + 2), (positions[insertion][0], y + 9), VIOLET, dotted=True)
+        positions = self.row_positions(max(1, len(cards)), y)
+        # Ribbon and root links remain separate when both late mechanics are
+        # active.  Parallel height lanes, unlike colors, and arrowheads expose
+        # both the link type and its clockwise direction after hue collapse.
+        for active, color, link_y in (
+                (self.game.level["paired_flip"], VIOLET, y + 9),
+                (self.game.level["spread"], GREEN, y + 11)):
+            if not active:
+                continue
+            for start, finish in zip(positions, positions[1:] + positions[:1]):
+                direction = 1 if finish[0] > start[0] else -1
+                source_x = start[0] + direction * 4
+                target_x = finish[0] - direction * 4
+                self.line(frame, (source_x, link_y), (target_x, link_y), color, dotted=True)
+                self.polygon(frame, [(target_x, link_y),
+                                     (target_x - direction * 2, link_y - 1),
+                                     (target_x - direction * 2, link_y + 1)], color)
+
+    def garden(self, frame, state):
+        captured = {decode_card(card)[0] for card in state[2]}
+        for source in range(len(self.game.level["faces"])):
+            self.source(frame, source, self.SOURCE_POSITIONS[source], source in captured,
+                        state[4], source == state[1])
+        # A future plate is present before closure: it asks for identities and
+        # eventual morphology while the finite garden remains selectable.
+        self.target_row(frame, y=43, small=True)
+        for index in range(self.game.level["bank"]):
+            x = 25 + index * 7
+            self.disc(frame, (x, 52), 2, EARTH, hollow=True)
+            if index < len(state[2]): self.diamond(frame, (x, 52), 1, GREEN)
+        # The two inspection models have distinct physical lenses.
+        if state[4] == 0:
+            self.disc(frame, (58, 35), 3, AQUA, hollow=True)
+        else:
+            self.diamond(frame, (58, 35), 3, VIOLET, hollow=True)
+            self.line(frame, (56, 37), (60, 33), INK)
+
+    def atlas(self, frame, state):
+        # The closed garden becomes an irregular theatrical curtain.
+        self.polygon(frame, [(5, 6), (13, 8), (22, 5), (31, 8), (41, 5),
+                             (50, 8), (59, 5), (57, 30), (45, 33), (34, 30),
+                             (23, 33), (10, 30)], ROSE)
+        for x in (10, 21, 33, 46, 57):
+            self.line(frame, (x, 7), (x - 2, 30), CORAL, dotted=True)
+        self.target_row(frame, y=18)
+        self.line(frame, (7, 34), (57, 34), EARTH, dotted=True)
+        self.atlas_row(frame, state)
+
+    def hud(self, frame, state):
+        budget = state[6]
+        # Compact three-pixel stitches expose the exact remaining operation budget.
+        for number in range(self.game.level["budget"]):
+            row, column = divmod(number, 8)
+            x, y = 4 + column * 7, 56 + row * 3
+            if number < budget:
+                self.diamond(frame, (x, y), 1, GREEN)
+            else:
+                self.line(frame, (x - 1, y - 1), (x + 1, y + 1), SLATE)
+        # Circle and diamond seals remain distinguishable after hue collapse.
+        if state[5] >= 1: self.disc(frame, (60, 57), 2, VIOLET, hollow=True)
+        else:
+            self.line(frame, (58, 55), (62, 59), RED); self.line(frame, (62, 55), (58, 59), RED)
+        if state[5] >= 2: self.diamond(frame, (60, 62), 1, GOLD, hollow=True)
+        else:
+            self.line(frame, (58, 60), (62, 63), RED); self.line(frame, (62, 60), (58, 63), RED)
+
+    def terminal(self, frame, state):
+        if state[7] == 1:
+            for radius in (5, 10, 15):
+                self.polygon(frame, [(32, 26 - radius), (32 + radius, 26),
+                                     (32, 26 + radius), (32 - radius, 26)], GOLD)
+        elif state[7] == 2:
+            self.line(frame, (9, 8), (55, 51), EARTH)
+            self.line(frame, (55, 8), (9, 51), RED)
+            for y in (15, 25, 35): self.line(frame, (7, y), (57, y + 3), SLATE, dotted=True)
+
+    def scene(self, frame, state):
+        self.paper(frame)
+        if state[0] == 0: self.garden(frame, state)
+        else: self.atlas(frame, state)
+        self.hud(frame, state); self.terminal(frame, state)
+
+    @staticmethod
+    def interpolate(start, finish, amount):
+        return (round(start[0] + (finish[0] - start[0]) * amount),
+                round(start[1] + (finish[1] - start[1]) * amount))
+
+    def animation(self, frame, before, after, kind, p, span):
+        # Reach the committed geometry one displayed frame before completion,
+        # so settlement holds instead of snapping on the engine's final frame.
+        motion_span = max(1, span - 1)
+        amount = min(1.0, p / motion_span)
+        if kind == "navigate":
+            self.scene(frame, before)
+            positions = (self.SOURCE_POSITIONS if before[0] == 0
+                         else self.row_positions(max(1, len(before[2]) + (before[3] != -1)), 43))
+            start = positions[before[1]]; finish = positions[after[1]]
+            point = self.interpolate(start, finish, amount)
+            self.diamond(frame, point, 8 if before[0] == 0 else 7, INK, hollow=True)
+        elif kind == "capture":
+            # Render the emptied garden socket, then move the sole pressing;
+            # no stale copy remains at the source.
+            self.scene(frame, after)
+            source = self.SOURCE_POSITIONS[before[1]]
+            finish = (32, 51)
+            point = self.interpolate(source, finish, amount)
+            self.card(frame, point, encode_card(before[1], flipped=before[4]),
+                      selected=True, small=True)
+            self.line(frame, source, point, VIOLET, dotted=True)
+        elif kind == "reveal":
+            self.scene(frame, before if p * 2 < motion_span else after)
+            reach = round(27 * (1 - abs(2 * p - motion_span) / motion_span))
+            for y in range(7, 35, 4): self.line(frame, (32 - reach, y), (32 + reach, y), ROSE)
+        elif kind == "lens":
+            # A horizontal chemical wipe progressively replaces the complete
+            # old semantic model; the new garden does not appear in one snap.
+            self.scene(frame, before)
+            developed = np.empty_like(frame)
+            self.scene(developed, after)
+            cut = round(64 * amount)
+            if cut:
+                frame[:, :cut] = developed[:, :cut]
+            if 0 < cut < 64:
+                self.line(frame, (cut, 5), (cut, 52),
+                          AQUA if after[4] == 0 else VIOLET, dotted=True)
+                self.disc(frame, (cut, 35), 3, INK, hollow=True)
+        elif kind in ("lift", "drop"):
+            # Clear the album strip and interpolate every existing card as a
+            # gap opens or closes.  No neighbor teleports at either endpoint.
+            self.scene(frame, after if amount >= .5 else before)
+            frame[35:52, 4:60] = WHITE
+            old_cards, new_cards = before[2], after[2]
+            old_positions = self.row_positions(max(1, len(old_cards)), 43)
+            new_positions = self.row_positions(max(1, len(new_cards)), 43)
+            if kind == "lift":
+                removed = before[1]
+                for new_index, card in enumerate(new_cards):
+                    old_index = new_index if new_index < removed else new_index + 1
+                    point = self.interpolate(old_positions[old_index], new_positions[new_index], amount)
+                    self.card(frame, point, card, selected=False)
+                held = after[3]
+                source = old_positions[removed]
+                finish = (source[0], 35)
+            else:
+                inserted = after[1]
+                for old_index, card in enumerate(old_cards):
+                    new_index = old_index if old_index < inserted else old_index + 1
+                    point = self.interpolate(old_positions[old_index], new_positions[new_index], amount)
+                    self.card(frame, point, card, selected=False)
+                held = before[3]
+                finish = new_positions[inserted]
+                source = (finish[0], 35)
+            self.card(frame, self.interpolate(source, finish, amount), held, selected=True)
+            # Slot relationships are physical page marks, independent of the
+            # cards currently moving above them.
+            link_count = len(new_cards) if kind == "lift" else len(old_cards) + 1
+            positions = self.row_positions(max(1, link_count), 43)
+            for active, color, link_y in (
+                    (self.game.level["paired_flip"], VIOLET, 52),
+                    (self.game.level["spread"], GREEN, 54)):
+                if not active:
+                    continue
+                for start, finish_pos in zip(positions, positions[1:] + positions[:1]):
+                    direction = 1 if finish_pos[0] > start[0] else -1
+                    source_x = start[0] + direction * 4
+                    target_x = finish_pos[0] - direction * 4
+                    self.line(frame, (source_x, link_y), (target_x, link_y), color, dotted=True)
+                    self.polygon(frame, [(target_x, link_y),
+                                         (target_x - direction * 2, link_y - 1),
+                                         (target_x - direction * 2, link_y + 1)], color)
+        elif kind == "flip":
+            self.scene(frame, before if p * 2 < motion_span else after)
+            positions = self.row_positions(len(after[2]), 43)
+            for index, (old, new) in enumerate(zip(before[2], after[2])):
+                if old != new:
+                    squeeze = max(1, round(6 * abs(2 * p - motion_span) / motion_span))
+                    x, y = positions[index]
+                    self.line(frame, (x - squeeze, y), (x + squeeze, y), VIOLET)
+                    self.diamond(frame, (x, y), 2, GOLD, hollow=True)
+        elif kind == "develop":
+            self.scene(frame, before if p * 2 < motion_span else after)
+            positions = self.row_positions(len(after[2]), 43)
+            radius = 1 + round(5 * amount)
+            for index, (old, new) in enumerate(zip(before[2], after[2])):
+                if old != new:
+                    self.disc(frame, positions[index], radius, GREEN, hollow=True)
+                    for dx, dy in ((-radius, 0), (radius, 0), (0, -radius), (0, radius)):
+                        self.diamond(frame, (positions[index][0] + dx, positions[index][1] + dy), 1, GOLD)
+        elif kind in ("audit", "success", "loss"):
+            self.scene(frame, before if p < motion_span else after)
+            if kind == "audit":
+                center = (60, 62 if before[5] == 2 else 57)
+                reach = 1 + round(3 * amount)
+                self.line(frame, (center[0] - reach, center[1] - reach),
+                          (center[0] + reach, center[1] + reach), RED)
+            elif kind == "success":
+                for radius in range(3, 3 + round(17 * amount), 4):
+                    self.diamond(frame, (32, 26), radius, GOLD, hollow=True)
+            else:
+                reach = round(23 * amount)
+                self.line(frame, (32 - reach, 8), (32 + reach, 51), EARTH)
+                self.line(frame, (32 + reach, 8), (32 - reach, 51), RED)
+        else:
+            self.scene(frame, before)
+            center = self.SOURCE_POSITIONS[before[1]] if before[0] == 0 else (32, 43)
+            radius = 2 + round(3 * (1 - abs(2 * p - motion_span) / motion_span))
+            self.disc(frame, center, radius, CORAL, hollow=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        game = self.game
+        if not game.anim_kind:
+            self.scene(frame, game.state)
+            if game.intro_mark:
+                self.polygon(frame, [(32, 2), (36, 5), (32, 8), (28, 5)], GOLD)
+            return frame
+        span = max(1, game.anim_total - 1)
+        if game.anim_progress >= span:
+            self.scene(frame, game.pending_state)
+        else:
+            self.animation(frame, game.anim_before, game.pending_state,
+                           game.anim_kind, game.anim_progress, span)
+        return frame
+
+
+class Q044(ARCBaseGame):
+    def __init__(self):
+        self.display = AtlasDisplay(self); self.level = LEVELS[0]
+        self.state = start_state(self.level); self.budget_left = self.state[6]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = None; self.pending_terminal = None
+        self.intro_mark = True
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q044", levels, Camera(0, 0, 64, 64, PEARL, PEARL, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]; self.state = start_state(self.level)
+        self.budget_left = self.state[6]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = None; self.pending_terminal = None
+        self.intro_mark = True
+
+    def begin(self, kind, after, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = 7; self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = after; self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal; self.state = self.pending_state
+        self.budget_left = self.state[6]; self.anim_kind = None
+        self.pending_state = None; self.pending_terminal = None
+        if terminal == "win": self.next_level()
+        elif terminal == "loss": self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1; self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0: self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action(); return
+        self.intro_mark = False
+        before = self.state; after = transition(self.level, before, action)
+        terminal = "win" if after[7] == 1 else "loss" if after[7] == 2 else None
+        if after == before: kind = "blocked"
+        elif action in (1, 2): kind = "navigate"
+        elif action == 3 and before[0] == 0: kind = "capture"
+        elif action == 3 and before[3] == -1: kind = "lift"
+        elif action == 3: kind = "drop"
+        elif action == 4 and before[0] == 0: kind = "reveal" if after[0] == 1 else "audit"
+        elif action == 4: kind = "flip"
+        elif action == 5 and before[0] == 0: kind = "lens"
+        elif action == 5: kind = "develop"
+        elif terminal == "win": kind = "success"
+        elif terminal == "loss": kind = "loss"
+        else: kind = "audit"
+        self.begin(kind, after, terminal)

--- a/data/community-games/sonpham/q051_v2_q051.py
+++ b/data/community-games/sonpham/q051_v2_q051.py
@@ -1,0 +1,629 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q051-v2 Festival Scaffold -- build and test a tactile load-bearing graph.
+
+Members are placed directly on drawn joints with coordinate actions.  Timber,
+cable, and steel have visible, typed structural behavior; later spans require
+redundant paths, complete triangular braces, non-buckling members, and several
+static load cases.  All structural checks are exact and deterministic.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from copy import deepcopy
+from math import hypot
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+WHITE, PEARL, ASH, SLATE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, CYAN, GOLD, ORANGE, BROWN, GREEN, VIOLET = range(6, 16)
+
+EMPTY, TIMBER, CABLE, STEEL = 0, 1, 2, 3
+ANY, COMPRESSION, TENSION = 0, 1, 2
+
+
+RAW_LEVELS = [
+    {
+        "name": "Ribbon Span",
+        "nodes": ((7, 35), (31, 23), (57, 35), (31, 47)),
+        "edges": ((0, 1), (1, 2), (0, 3), (3, 2), (1, 3)),
+        "roles": (ANY, ANY, ANY, ANY, ANY), "buckling": (),
+        "stock": (2, 0, 0), "stress": ((0, 2, 1),),
+        "brace_sets": (), "brace_need": 0,
+        "solution": (("edge", 0), ("edge", 1)),
+    },
+    {
+        "name": "Twin Footpaths",
+        "nodes": ((4, 35), (20, 18), (43, 18), (60, 35),
+                  (20, 50), (43, 50), (32, 35)),
+        "edges": ((0, 1), (1, 2), (2, 3), (0, 4), (4, 5), (5, 3),
+                  (0, 6), (6, 3), (1, 6), (6, 5)),
+        "roles": (ANY, ANY, ANY, ANY, ANY, ANY, ANY, ANY, ANY, ANY), "buckling": (),
+        "stock": (8, 0, 0), "stress": ((0, 3, 3),),
+        "brace_sets": (), "brace_need": 0,
+        "solution": (("edge", 0), ("edge", 1), ("edge", 2),
+                     ("edge", 3), ("edge", 4), ("edge", 5),
+                     ("edge", 6), ("edge", 7)),
+    },
+    {
+        "name": "Steel Viaduct",
+        "nodes": ((4, 35), (20, 18), (43, 18), (60, 35), (20, 50), (43, 50)),
+        "edges": ((0, 1), (1, 2), (2, 3), (0, 4), (4, 5), (5, 3)),
+        "roles": (ANY, ANY, ANY, ANY, ANY, ANY),
+        "buckling": (),
+        "stock": (3, 0, 3), "stress": ((0, 3, 3),),
+        "brace_sets": (), "brace_need": 0,
+        "solution": (("edge", 0), ("edge", 1), ("edge", 2),
+                     3, ("edge", 3), ("edge", 4), ("edge", 5)),
+    },
+    {
+        "name": "Gusset Lesson",
+        "nodes": ((5, 40), (20, 17), (32, 45), (44, 17), (59, 40)),
+        "edges": ((0, 1), (1, 2), (0, 2), (2, 3), (3, 4), (2, 4),
+                  (1, 3), (0, 4), (0, 3), (1, 4)),
+        "roles": (ANY, ANY, ANY, ANY, ANY, ANY, ANY, ANY, ANY, ANY),
+        "buckling": (),
+        "stock": (6, 0, 0), "stress": ((0, 4, 2),),
+        "brace_sets": ((0, 1, 2), (3, 4, 5)), "brace_need": 2,
+        "solution": (("edge", 0), ("edge", 1), ("edge", 2),
+                     ("edge", 3), ("edge", 4), ("edge", 5)),
+    },
+    {
+        "name": "Tension Canopy",
+        "nodes": ((5, 40), (20, 17), (32, 45), (44, 17), (59, 40)),
+        "edges": ((0, 1), (1, 2), (0, 2), (2, 3), (3, 4), (2, 4)),
+        "roles": (COMPRESSION, TENSION, COMPRESSION, ANY, TENSION, COMPRESSION),
+        "buckling": (3,), "stock": (3, 2, 1), "stress": ((0, 4, 2),),
+        "brace_sets": ((0, 1, 2), (3, 4, 5)), "brace_need": 2,
+        "solution": (("edge", 0), ("edge", 2), ("edge", 5),
+                     4, ("edge", 1), ("edge", 4), 4, ("edge", 3)),
+    },
+    {
+        "name": "Traveling Lanterns",
+        "nodes": ((4, 35), (28, 17), (28, 51), (60, 19), (60, 49)),
+        "edges": ((0, 1), (1, 3), (1, 4), (0, 2), (2, 3), (2, 4)),
+        "roles": (COMPRESSION, TENSION, COMPRESSION,
+                  COMPRESSION, COMPRESSION, TENSION), "buckling": (),
+        "stock": (4, 2, 0),
+        "stress": ((0, 3, 2), (0, 4, 2), (3, 4, 2)),
+        "brace_sets": (), "brace_need": 0,
+        "solution": (("edge", 0), ("edge", 2), ("edge", 3), ("edge", 4),
+                     4, ("edge", 1), ("edge", 5)),
+    },
+    {
+        "name": "Two-Bay Pavilion",
+        "nodes": ((5, 40), (20, 17), (32, 45), (44, 17), (59, 40)),
+        "edges": ((0, 1), (1, 2), (0, 2), (2, 3), (3, 4), (2, 4), (1, 3)),
+        "roles": (COMPRESSION, TENSION, COMPRESSION, COMPRESSION,
+                  TENSION, COMPRESSION, ANY),
+        "buckling": (6,), "stock": (4, 2, 0), "stress": ((0, 4, 2),),
+        "brace_sets": ((0, 1, 2), (3, 4, 5)), "brace_need": 2,
+        "solution": (("edge", 0), ("edge", 2), ("edge", 3), ("edge", 5),
+                     4, ("edge", 1), ("edge", 4)),
+    },
+    {
+        "name": "Festival Crossing",
+        "nodes": ((4, 36), (18, 14), (18, 49), (45, 14), (45, 49), (60, 36)),
+        "edges": ((0, 1), (0, 2), (1, 2), (1, 3), (2, 4),
+                  (3, 4), (3, 5), (4, 5)),
+        "roles": (COMPRESSION, COMPRESSION, TENSION, ANY, COMPRESSION,
+                  TENSION, COMPRESSION, COMPRESSION),
+        "buckling": (3,), "stock": (5, 2, 1),
+        "stress": ((0, 5, 2), (0, 3, 2), (0, 4, 2), (2, 4, 3)),
+        "brace_sets": ((0, 1, 2), (5, 6, 7)), "brace_need": 2,
+        "solution": (("edge", 0), ("edge", 1), ("edge", 4), ("edge", 6),
+                     ("edge", 7), 4, ("edge", 2), ("edge", 5),
+                     4, ("edge", 3)),
+    },
+]
+
+
+def edge_action(level, edge_index):
+    """Return a stable on-member coordinate, offset from shared crossings."""
+    a, b = level["edges"][edge_index]
+    ax, ay = level["nodes"][a]; bx, by = level["nodes"][b]
+    for numerator, denominator in ((1, 4), (1, 3), (2, 3), (3, 4), (1, 2)):
+        x = (ax * (denominator - numerator) + bx * numerator) // denominator
+        y = (ay * (denominator - numerator) + by * numerator) // denominator
+        if _edge_at(level, x, y) == edge_index:
+            return (6, x, y)
+    return (6, (2 * ax + bx) // 3, (2 * ay + by) // 3)
+
+
+def actions_for_level(level, include_audit=True):
+    actions = [3, 4]
+    actions.extend(edge_action(level, index) for index in range(len(level["edges"])))
+    if include_audit:
+        actions.append(5)
+    return tuple(actions)
+
+
+def start_state(level):
+    # selected material, material per candidate edge, remaining material stocks,
+    # two recoverable load-test seals, terminal (0 live, 2 win, 3 loss)
+    return (TIMBER, (EMPTY,) * len(level["edges"]), tuple(level["stock"]), 2, 0)
+
+
+def _action_parts(action):
+    if isinstance(action, (tuple, list)):
+        if not action:
+            return 0, 0, 0
+        return int(action[0]), int(action[1]) if len(action) > 1 else 0, int(action[2]) if len(action) > 2 else 0
+    return int(action), 0, 0
+
+
+def _edge_at(level, x, y):
+    best = None
+    for index, (a, b) in enumerate(level["edges"]):
+        ax, ay = level["nodes"][a]; bx, by = level["nodes"][b]
+        dx, dy = bx - ax, by - ay
+        t = max(0.0, min(1.0, ((x - ax) * dx + (y - ay) * dy)
+                              / max(1, dx * dx + dy * dy)))
+        distance = hypot(x - (ax + t * dx), y - (ay + t * dy))
+        candidate = (distance, index)
+        if best is None or candidate < best:
+            best = candidate
+    return best[1] if best is not None and best[0] <= 4 else None
+
+
+def member_capacity(level, edge_index, material):
+    if material == EMPTY:
+        return 0
+    role = level["roles"][edge_index]
+    if role == COMPRESSION and material == CABLE:
+        return 0
+    if role == TENSION and material == TIMBER:
+        return 0
+    if edge_index in level["buckling"] and material == TIMBER:
+        return 0
+    return 2 if material == STEEL else 1
+
+
+def max_flow(level, installed, source, sink):
+    residual = {}
+    for edge_index, (a, b) in enumerate(level["edges"]):
+        capacity = member_capacity(level, edge_index, installed[edge_index])
+        if capacity:
+            residual[(a, b)] = residual.get((a, b), 0) + capacity
+            residual[(b, a)] = residual.get((b, a), 0) + capacity
+    flow = 0
+    while True:
+        parent = {source: None}; queue = deque([source])
+        while queue and sink not in parent:
+            node = queue.popleft()
+            for neighbor in range(len(level["nodes"])):
+                if neighbor not in parent and residual.get((node, neighbor), 0) > 0:
+                    parent[neighbor] = node; queue.append(neighbor)
+        if sink not in parent:
+            return flow
+        node = sink
+        while parent[node] is not None:
+            previous = parent[node]
+            residual[(previous, node)] -= 1
+            residual[(node, previous)] = residual.get((node, previous), 0) + 1
+            node = previous
+        flow += 1
+
+
+def brace_count(level, installed):
+    return sum(all(member_capacity(level, edge, installed[edge]) > 0 for edge in brace)
+               for brace in level["brace_sets"])
+
+
+def configuration_solved(level, state):
+    if state[4] or brace_count(level, state[1]) < level["brace_need"]:
+        return False
+    return all(max_flow(level, state[1], source, sink) >= load
+               for source, sink, load in level["stress"])
+
+
+def transition(level, state, action):
+    material, installed, stock, seals, terminal = state
+    if terminal:
+        return state
+    action_id, x, y = _action_parts(action)
+    if action_id in (3, 4):
+        delta = -1 if action_id == 3 else 1
+        selected = (material - 1 + delta) % 3 + 1
+        return (selected, installed, stock, seals, terminal)
+    if action_id == 6:
+        edge = _edge_at(level, x, y)
+        if edge is None:
+            return state
+        members = list(installed); supplies = list(stock)
+        existing = members[edge]
+        if existing:
+            members[edge] = EMPTY; supplies[existing - 1] += 1
+        elif supplies[material - 1] > 0:
+            members[edge] = material; supplies[material - 1] -= 1
+        else:
+            return state
+        return (material, tuple(members), tuple(supplies), seals, terminal)
+    if action_id == 5:
+        if configuration_solved(level, state):
+            return state[:-1] + (2,)
+        if seals > 1:
+            return state[:3] + (seals - 1, 0)
+        return state[:3] + (0, 3)
+    return state
+
+
+def action_cost(before, after):
+    if before == after or before[3] != after[3] or after[4] in (2, 3):
+        return 0
+    return 1
+
+
+def solved(_level, state):
+    return state[4] == 2
+
+
+def _finalize_levels():
+    levels = []
+    for raw in RAW_LEVELS:
+        level = {key: deepcopy(value) for key, value in raw.items() if key != "solution"}
+        compiled = tuple(edge_action(level, token[1]) if isinstance(token, tuple) else token
+                         for token in raw["solution"])
+        state = start_state(level)
+        for action in compiled:
+            before = state; state = transition(level, state, action)
+            assert state != before, (raw["name"], action)
+            assert not state[4]
+        assert configuration_solved(level, state), raw["name"]
+        level["solution"] = compiled
+        level["optimal_cost"] = len(compiled)
+        level["budget"] = len(compiled) + 2
+        levels.append(level)
+    return levels
+
+
+LEVELS = _finalize_levels()
+
+
+class ScaffoldDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def line(frame, a, b, color, width=1, dotted=False, limit=100):
+        x0, y0 = a; x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        last = min(steps, max(0, limit * steps // 100))
+        for step in range(last + 1):
+            if dotted and step % 4 in (2, 3):
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            frame[max(0, y - width + 1):min(64, y + width),
+                  max(0, x - width + 1):min(64, x + width)] = color
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                d = (x - cx) ** 2 + (y - cy) ** 2
+                if d <= radius * radius and (not hollow or d >= max(0, radius - 1) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def diamond(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for dy in range(-radius, radius + 1):
+            y = cy + dy
+            if not 0 <= y < 64:
+                continue
+            width = radius - abs(dy)
+            if hollow:
+                for x in (cx - width, cx + width):
+                    if 0 <= x < 64:
+                        frame[y, x] = color
+            else:
+                frame[y, max(0, cx - width):min(64, cx + width + 1)] = color
+
+    def curve(self, frame, a, b, color, dotted=False, limit=100):
+        ax, ay = a; bx, by = b; steps = max(abs(bx - ax), abs(by - ay), 12)
+        sag = min(6, max(2, abs(bx - ax) // 8))
+        last = min(steps, max(0, limit * steps // 100))
+        for step in range(last + 1):
+            if dotted and step % 4 in (1, 2):
+                continue
+            t = step / steps
+            x = round(ax + (bx - ax) * t)
+            y = round(ay + (by - ay) * t + 4 * sag * t * (1 - t))
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    def background(self, frame):
+        frame[:, :] = PEARL
+        for y in range(9, 55):
+            color = WHITE if y < 28 else ASH
+            frame[y, :] = color
+        # Warm sunrise, scalloped cloth canopy, and masonry footing.
+        self.disc(frame, (53, 15), 8, GOLD)
+        self.disc(frame, (53, 15), 5, PEARL)
+        for x in range(0, 64, 8):
+            self.line(frame, (x, 10), (x + 4, 13), ORANGE)
+            self.line(frame, (x + 4, 13), (x + 8, 10), ROSE)
+        frame[54:64, :] = BROWN
+        for y in range(55, 64, 4):
+            offset = 4 if y % 8 else 0
+            for x in range(-offset, 64, 9):
+                self.line(frame, (x, y), (x + 7, y), ORANGE)
+        for x in range(3, 64, 12):
+            self.line(frame, (x, 55), (x - 2, 63), RED, dotted=True)
+
+    def candidate(self, frame, edge_index):
+        level = self.game.level; a, b = level["edges"][edge_index]
+        start, finish = level["nodes"][a], level["nodes"][b]
+        role = level["roles"][edge_index]
+        if role == TENSION:
+            self.curve(frame, start, finish, VIOLET, dotted=True)
+        elif role == COMPRESSION:
+            self.line(frame, start, finish, SLATE, dotted=True)
+            midpoint = ((start[0] + finish[0]) // 2, (start[1] + finish[1]) // 2)
+            dx = 1 if abs(finish[1] - start[1]) > abs(finish[0] - start[0]) else 0
+            dy = 0 if dx else 1
+            self.line(frame, (midpoint[0] - dx * 2, midpoint[1] - dy * 2),
+                      (midpoint[0] + dx * 2, midpoint[1] + dy * 2), SLATE)
+        else:
+            self.line(frame, start, finish, ASH, dotted=True)
+        if edge_index in level["buckling"]:
+            mx, my = (start[0] + finish[0]) // 2, (start[1] + finish[1]) // 2
+            self.line(frame, (mx - 3, my - 2), (mx, my + 2), RED)
+            self.line(frame, (mx, my + 2), (mx + 3, my - 2), RED)
+
+    def member(self, frame, edge_index, material, limit=100, ghost=False):
+        level = self.game.level; a, b = level["edges"][edge_index]
+        start, finish = level["nodes"][a], level["nodes"][b]
+        if material == TIMBER:
+            self.line(frame, start, finish, BROWN, width=2, limit=limit)
+            self.line(frame, start, finish, GOLD, dotted=True, limit=limit)
+        elif material == CABLE:
+            self.curve(frame, start, finish, VIOLET if not ghost else ROSE,
+                       dotted=False, limit=limit)
+            self.curve(frame, (start[0], start[1] - 1), (finish[0], finish[1] - 1),
+                       MAGENTA, dotted=True, limit=limit)
+        else:
+            self.line(frame, start, finish, CYAN, width=2, limit=limit)
+            self.line(frame, start, finish, WHITE, dotted=True, limit=limit)
+        if limit >= 100:
+            for point in (start, finish):
+                self.disc(frame, point, 1, GOLD)
+
+    def brace_cloth(self, frame, state):
+        level = self.game.level
+        for brace in level["brace_sets"]:
+            if not all(member_capacity(level, edge, state[1][edge]) > 0 for edge in brace):
+                continue
+            vertices = sorted({node for edge in brace for node in level["edges"][edge]})
+            if len(vertices) != 3:
+                continue
+            points = [level["nodes"][node] for node in vertices]
+            center = (sum(point[0] for point in points) // 3,
+                      sum(point[1] for point in points) // 3)
+            for point in points:
+                midpoint = ((center[0] + point[0]) // 2, (center[1] + point[1]) // 2)
+                self.line(frame, center, midpoint, ORANGE, dotted=True)
+            self.diamond(frame, center, 2, GOLD, hollow=True)
+
+    def joint(self, frame, index, position):
+        level = self.game.level
+        is_source = any(source == index for source, _sink, _load in level["stress"])
+        sink_loads = [load for _source, sink, load in level["stress"] if sink == index]
+        x, y = position
+        if is_source:
+            self.line(frame, (x - 4, y + 4), (x - 4, y), BROWN)
+            self.line(frame, (x - 4, y), (x, y - 4), BROWN)
+            self.line(frame, (x, y - 4), (x + 4, y), BROWN)
+            self.line(frame, (x + 4, y), (x + 4, y + 4), BROWN)
+        self.disc(frame, position, 3, ORANGE)
+        self.disc(frame, position, 1, WHITE)
+        for case, load in enumerate(sink_loads):
+            for unit in range(load):
+                px = x + (unit - (load - 1) / 2) * 4
+                py = y + 5 + case * 4
+                self.line(frame, (round(px), y + 2), (round(px), round(py)), VIOLET)
+                self.diamond(frame, (round(px), round(py) + 2), 2, RED, hollow=True)
+
+    def stock_piece(self, frame, material, center, selected=False):
+        x, y = center
+        if material == TIMBER:
+            self.line(frame, (x - 4, y + 2), (x + 4, y - 2), BROWN, width=2)
+            self.line(frame, (x - 2, y + 1), (x, y), GOLD)
+        elif material == CABLE:
+            self.curve(frame, (x - 5, y - 1), (x + 5, y - 1), VIOLET)
+            self.disc(frame, (x - 5, y - 1), 1, MAGENTA)
+            self.disc(frame, (x + 5, y - 1), 1, MAGENTA)
+        else:
+            self.line(frame, (x - 4, y + 2), (x + 4, y - 2), CYAN, width=2)
+            self.disc(frame, (x, y), 1, WHITE)
+        if selected:
+            for dx, dy in ((-6, 0), (0, -5), (6, 0), (0, 5)):
+                self.diamond(frame, (x + dx, y + dy), 1, ORANGE)
+
+    def hud(self, frame):
+        game = self.game; state = game.state
+        shown = game.budget_left
+        if (game.anim_kind and game.pending_budget is not None
+                and game.anim_progress >= max(1, game.anim_total - 1)
+                and game.anim_kind != "success"):
+            shown = game.pending_budget
+        for unit in range(game.budget_max):
+            x = 3 + (unit % 14) * 3; y = 3 + (unit // 14) * 3
+            if unit < shown:
+                self.diamond(frame, (x, y), 1, ORANGE)
+            else:
+                frame[y, x - 1:x + 2] = ASH
+        for material, x in ((TIMBER, 34), (CABLE, 45), (STEEL, 56)):
+            self.stock_piece(frame, material, (x, 5), selected=material == state[0])
+            remaining = state[2][material - 1]
+            for piece in range(remaining):
+                self.diamond(frame, (x - 3 + piece * 3, 10), 1,
+                             (BROWN, VIOLET, CYAN)[material - 1])
+        for index, x in enumerate((57, 62)):
+            live = index < state[3]
+            self.disc(frame, (x, 59), 2, GREEN if live else RED, hollow=True)
+            if live:
+                self.line(frame, (x - 1, 59), (x + 1, 59), WHITE)
+            else:
+                self.line(frame, (x - 2, 57), (x + 2, 61), RED)
+
+    def structure(self, frame):
+        state = self.game.state; level = self.game.level
+        for edge in range(len(level["edges"])):
+            self.candidate(frame, edge)
+        self.brace_cloth(frame, state)
+        for edge, material in enumerate(state[1]):
+            if material:
+                self.member(frame, edge, material)
+        for index, position in enumerate(level["nodes"]):
+            self.joint(frame, index, position)
+        self.hud(frame)
+
+    def animation(self, frame):
+        game = self.game
+        if game.intro_mark:
+            for radius in (4, 8, 12):
+                self.disc(frame, (32, 34), radius, GOLD, hollow=True)
+        if not game.anim_kind:
+            return
+        p = game.anim_progress; span = max(1, game.anim_total - 1)
+        before, after = game.anim_before, game.pending_state
+        if game.anim_kind == "material" and p < span:
+            start_x = (TIMBER, CABLE, STEEL).index(before[0]) * 11 + 34
+            end_x = (TIMBER, CABLE, STEEL).index(after[0]) * 11 + 34
+            x = start_x + (end_x - start_x) * p // span
+            self.stock_piece(frame, after[0], (x, 13), selected=True)
+        elif game.anim_kind in ("place", "remove") and p < span:
+            changed = next(index for index, (a, b) in enumerate(zip(before[1], after[1])) if a != b)
+            if game.anim_kind == "place":
+                material = after[1][changed]; amount = p * 100 // span
+            else:
+                material = before[1][changed]; amount = 100 - p * 100 // span
+            self.member(frame, changed, material, limit=amount, ghost=game.anim_kind == "remove")
+            a, b = game.level["edges"][changed]
+            ax, ay = game.level["nodes"][a]; bx, by = game.level["nodes"][b]
+            event = (ax + (bx - ax) * max(0, amount) // 100,
+                     ay + (by - ay) * max(0, amount) // 100)
+            self.disc(frame, event, 2, WHITE, hollow=True)
+        elif game.anim_kind == "audit" and p < span:
+            amount = p * 100 // span
+            for edge, material in enumerate(before[1]):
+                if material and member_capacity(game.level, edge, material):
+                    self.member(frame, edge, material, limit=amount)
+            for _source, sink, load in game.level["stress"]:
+                x, y = game.level["nodes"][sink]
+                self.line(frame, (x - load * 2, y + 7), (x + load * 2, y + 7),
+                          GREEN if after[4] == 2 else RED, limit=amount)
+        elif game.anim_kind == "blocked" and p < span:
+            radius = 2 + min(p, span - p)
+            self.diamond(frame, (32, 33), radius, RED, hollow=True)
+        elif game.anim_kind == "success":
+            for edge, material in enumerate(before[1]):
+                if material and edge <= p:
+                    self.member(frame, edge, material)
+            for radius in range(5, min(30, 5 + p * 4), 5):
+                self.disc(frame, (32, 34), radius, GREEN, hollow=True)
+            for x in range(6, 61, 9):
+                if x // 9 <= p:
+                    self.diamond(frame, (x, 12), 2, ORANGE)
+        elif game.anim_kind == "loss" and p < span:
+            fall = 8 * p // span
+            for edge, material in enumerate(before[1]):
+                if not material:
+                    continue
+                a, b = game.level["edges"][edge]
+                start = game.level["nodes"][a]; finish = game.level["nodes"][b]
+                self.line(frame, (start[0], start[1] + fall),
+                          (finish[0] + fall // 2, finish[1] + fall), RED, dotted=True)
+            self.line(frame, (4 + fall, 53), (60 - fall, 53), CHARCOAL)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        game = self.game
+        preview = (game.anim_kind in ("material", "place", "remove", "audit", "blocked", "loss")
+                   and game.pending_state is not None
+                   and game.anim_progress >= max(1, game.anim_total - 1))
+        current = game.state
+        if preview:
+            game.state = game.pending_state
+        self.background(frame); self.structure(frame)
+        if preview:
+            game.state = current
+        self.animation(frame)
+        return frame
+
+
+class Q051(ARCBaseGame):
+    def __init__(self):
+        self.display = ScaffoldDisplay(self); self.level = LEVELS[0]
+        self.state = start_state(self.level); self.budget_left = self.budget_max = 0
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = None; self.pending_budget = None
+        self.pending_terminal = None; self.intro_mark = True
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(level), name=level["name"])
+                  for level in LEVELS]
+        super().__init__("q051", levels, Camera(0, 0, 64, 64, PEARL, PEARL, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = self.pending_budget = None
+        self.pending_terminal = None; self.intro_mark = True
+
+    def begin(self, kind, frames, before, after, budget, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames; self.anim_progress = 0
+        self.anim_before = before; self.pending_state = after; self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal; self.state = self.pending_state
+        self.budget_left = self.pending_budget; self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1; self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        action_id = self.action.id.value
+        if action_id == 0:
+            self.complete_action(); return
+        action = ((action_id, int(self.action.data.get("x", 0)), int(self.action.data.get("y", 0)))
+                  if action_id == 6 else action_id)
+        self.intro_mark = False; before = self.state
+        after = transition(self.level, before, action)
+        if after == before:
+            self.begin("blocked", 5, before, before, self.budget_left); return
+        cost = action_cost(before, after)
+        if cost > self.budget_left:
+            lost = before[:-1] + (3,)
+            self.begin("loss", 7, before, lost, self.budget_left, "loss"); return
+        budget = self.budget_left - cost
+        if after[4] == 2:
+            kind, frames, terminal = "success", 7, "win"
+        elif after[4] == 3:
+            kind, frames, terminal = "loss", 7, "loss"
+        elif action_id in (3, 4):
+            kind, frames, terminal = "material", 5, None
+        elif action_id == 6:
+            changed = next(index for index, (a, b) in enumerate(zip(before[1], after[1])) if a != b)
+            kind = "remove" if before[1][changed] else "place"
+            frames, terminal = 7, None
+        else:
+            kind, frames, terminal = "audit", 7, None
+        self.begin(kind, frames, before, after, budget, terminal)

--- a/data/community-games/sonpham/q052_v2_q052.py
+++ b/data/community-games/sonpham/q052_v2_q052.py
@@ -1,0 +1,407 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q052-v2 Chiral Caustic Forge -- tune a visible multi-ray optical instrument.
+
+Every faceted surface has a shape-coded local law. Convex and concave prisms
+turn rays in opposite directions, mirrors reverse handedness, fixed panes are
+bolted, and geared panes counter-rotate. Aperture marks show the required local
+ray state, so the target is functional geometry rather than a hidden checksum.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+WHITE, SILVER, ASH, CHARCOAL, BLACK = 0, 1, 2, 4, 5
+MAGENTA, ROSE, RED, BLUE, AQUA, GOLD, CORAL, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 14, 15
+LANE_Y = {0: 22, 1: 29, 2: 36, 3: 43}
+
+
+LEVELS = [
+    {"name": "First Caustic", "start": (0,), "kinds": ("p",), "fixed": (), "links": (),
+     "inputs": (0,), "ray_checks": ((0,),), "plan": (2,), "budget": 4},
+    {"name": "Serial Glass", "start": (0, 0, 0), "kinds": ("p", "p", "p"), "fixed": (), "links": (),
+     "inputs": (0,), "ray_checks": ((0, 1, 2),), "plan": (1, 1, 3, 1, 1, 3, 1, 1), "budget": 10},
+    {"name": "Opposed Curves", "start": (0, 1, 2), "kinds": ("p", "n", "p"), "fixed": (), "links": (),
+     "inputs": (0,), "ray_checks": ((0, 1, 2),), "plan": (2, 4, 1, 1, 4, 2, 2), "budget": 9},
+    {"name": "Bolted Compensation", "start": (3, 1, 0, 2), "kinds": ("p", "n", "p", "n"),
+     "fixed": (1,), "links": (), "inputs": (0,), "ray_checks": ((0, 1, 2, 3),),
+     "plan": (1, 1, 4, 1, 4, 2, 2, 4, 1), "budget": 11},
+    {"name": "Mirror Pair", "start": (0, 1, 2, 0), "kinds": ("p", "m", "n", "p"),
+     "fixed": (), "links": (), "inputs": (0, 1), "ray_checks": ((0, 1), (2, 3)),
+     "plan": (2, 2, 4, 1, 4, 2, 4, 1, 1), "budget": 11},
+    {"name": "Countergear", "start": (0, 1, 3, 2, 0), "kinds": ("p", "n", "p", "m", "n"),
+     "fixed": (), "links": ((0, 2),), "inputs": (0, 1), "ray_checks": ((0, 2, 4), (1, 3)),
+     "plan": (2, 2, 4, 1, 4, 4, 2, 4, 1, 1), "budget": 12},
+    {"name": "Spectral Gearbox", "start": (0, 1, 2, 0, 3, 1),
+     "kinds": ("p", "m", "n", "p", "n", "m"), "fixed": (), "links": ((0, 4),),
+     "inputs": (0, 1), "ray_checks": ((0, 1, 4), (3, 5)),
+     "plan": (2, 4, 2, 2, 4, 4, 1, 4, 4, 2), "budget": 12},
+    {"name": "Chiral Caustic Forge", "start": (0, 2, 1, 3, 2, 0),
+     "kinds": ("m", "n", "p", "m", "n", "p"), "fixed": (),
+     "links": ((0, 4), (1, 5)), "inputs": (0, 1, 2), "ray_checks": ((0, 3), (1, 4), (2, 5)),
+     "plan": (1, 1, 4, 2, 4, 1, 4, 1, 1), "budget": 11},
+]
+
+
+def start_state(level):
+    return tuple(level["start"]), 0, 0
+
+
+def transition(level, state, action):
+    angles, cursor, calibrated = state
+    size = len(angles)
+    if action == 3:
+        return angles, (cursor - 1) % size, calibrated
+    if action == 4:
+        return angles, (cursor + 1) % size, calibrated
+    if action not in (1, 2):
+        return state
+    if cursor in level.get("fixed", ()):
+        # The first tap grounds a bolted pane; later taps visibly recoil.
+        return angles, cursor, calibrated | (1 << cursor)
+    delta = -1 if action == 1 else 1
+    changed = list(angles)
+    changed[cursor] = (changed[cursor] + delta) % 4
+    for left, right in level.get("links", ()):
+        if cursor == left:
+            changed[right] = (changed[right] - delta) % 4
+        elif cursor == right:
+            changed[left] = (changed[left] - delta) % 4
+    return tuple(changed), cursor, calibrated
+
+
+def _surface(direction, angle, kind):
+    if kind == "p":
+        return (direction + angle) % 4
+    if kind == "n":
+        return (direction - angle) % 4
+    return (-direction + angle) % 4
+
+
+def ray_trace(level, angles, input_direction):
+    result = []
+    direction = input_direction
+    for angle, kind in zip(angles, level["kinds"]):
+        direction = _surface(direction, angle, kind)
+        result.append(direction)
+    return tuple(result)
+
+
+_TARGET_CACHE = {}
+
+
+def target_state(level):
+    key = level["name"]
+    if key not in _TARGET_CACHE:
+        state = start_state(level)
+        for action in level["plan"]:
+            state = transition(level, state, action)
+        _TARGET_CACHE[key] = state
+    return _TARGET_CACHE[key]
+
+
+def signature(level, angles):
+    return tuple(ray_trace(level, angles, input_direction)[index]
+                 for input_direction, checks in zip(level["inputs"], level["ray_checks"])
+                 for index in checks)
+
+
+def solved(level, state):
+    required = sum(1 << index for index in level.get("fixed", ()))
+    return (signature(level, state[0]) == signature(level, target_state(level)[0])
+            and state[2] & required == required)
+
+
+class ForgeDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def _disc(frame, center, radius, color):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                if (x - cx) ** 2 + (y - cy) ** 2 <= radius ** 2:
+                    frame[y, x] = color
+
+    @staticmethod
+    def _line(frame, a, b, color, dotted=False, width=1):
+        x0, y0 = a
+        x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            for offset in range(-(width // 2), width // 2 + 1):
+                if 0 <= x < 64 and 0 <= y + offset < 64:
+                    frame[y + offset, x] = color
+
+    def _positions(self):
+        size = len(self.game.state[0])
+        return tuple(12 + index * 40 // max(1, size - 1) for index in range(size))
+
+    def _background(self, frame):
+        frame[:, :] = BLACK
+        frame[8:55, 3:61] = CHARCOAL
+        for y in range(10, 54, 5):
+            frame[y, 5 + (y % 4):60:7] = ASH
+        frame[17:49, 5:59:4] = BLACK
+        frame[8, 8:56] = GOLD
+        frame[54, 8:56] = GOLD
+
+    def _wedge(self, frame, center, angle, kind, selected, fixed, calibrated=False):
+        cx, cy = center
+        color = SILVER if fixed else AQUA if kind == "p" else MAGENTA if kind == "n" else GOLD
+        # Four exact silhouettes: tip points in the stored orientation.
+        points = {
+            0: ((4, 0), (-3, -4), (-3, 4)),
+            1: ((0, -5), (-4, 3), (4, 3)),
+            2: ((-4, 0), (3, -4), (3, 4)),
+            3: ((0, 5), (-4, -3), (4, -3)),
+        }[angle]
+        a, b, c = tuple((cx + x, cy + y) for x, y in points)
+        self._line(frame, a, b, color)
+        self._line(frame, b, c, color)
+        self._line(frame, c, a, color)
+        self._disc(frame, center, 2, color)
+        if kind == "n":
+            self._disc(frame, center, 1, BLACK)
+        elif kind == "m":
+            self._line(frame, (cx - 4, cy + 4), (cx + 4, cy - 4), WHITE, dotted=True)
+        else:
+            frame[cy, cx] = WHITE
+        if fixed:
+            for dx, dy in ((-5, -5), (5, -5), (-5, 5), (5, 5)):
+                self._disc(frame, (cx + dx, cy + dy), 2 if calibrated else 1,
+                           GOLD if calibrated else SILVER)
+            if calibrated:
+                # Grounded bolts grow into four diamonds joined by a bottom bus.
+                frame[cy + 6, cx - 5:cx + 6] = GOLD
+        if selected:
+            frame[cy - 7, cx - 5:cx + 6:2] = CORAL
+            frame[cy + 7, cx - 5:cx + 6:2] = CORAL
+            frame[cy - 5:cy + 6:2, cx - 7] = CORAL
+            frame[cy - 5:cy + 6:2, cx + 7] = CORAL
+
+    @staticmethod
+    def _ray_style(index):
+        return ((AQUA, False, 1), (MAGENTA, True, 1), (GOLD, False, 2))[index]
+
+    def _aperture(self, frame, center, ray_index, current=False):
+        color, _, _ = self._ray_style(ray_index)
+        cx, cy = center
+        if ray_index == 0:
+            self._disc(frame, center, 2 if current else 3, color)
+            self._disc(frame, center, 1, BLACK)
+        elif ray_index == 1:
+            for row, width in ((-3, 1), (-2, 3), (-1, 5), (0, 7), (1, 5), (2, 3), (3, 1)):
+                frame[cy + row, cx - width // 2:cx + width // 2 + 1] = color
+            self._disc(frame, center, 1, BLACK)
+        else:
+            frame[cy - 3:cy + 4, cx - 3] = color
+            frame[cy - 3:cy + 4, cx + 3] = color
+            frame[cy - 3, cx - 3:cx + 4] = color
+            frame[cy + 3, cx - 3:cx + 4] = color
+            self._disc(frame, center, 1, BLACK)
+
+    def _rays(self, frame, bright=False, stages=None):
+        g = self.game
+        xs = self._positions()
+        target_angles = target_state(g.level)[0]
+        for ray_index, input_direction in enumerate(g.level["inputs"]):
+            color, dotted, width = self._ray_style(ray_index)
+            if not bright:
+                color = ASH
+                width = 1
+            trace = ray_trace(g.level, g.state[0], input_direction)
+            target_trace = ray_trace(g.level, target_angles, input_direction)
+            previous = (5, LANE_Y[input_direction])
+            checks = g.level["ray_checks"][ray_index]
+            for index, (x, direction) in enumerate(zip(xs, trace)):
+                point = (x, LANE_Y[direction])
+                if stages is None or index < stages:
+                    self._line(frame, previous, point, color, dotted=dotted, width=width)
+                if index in checks:
+                    self._aperture(frame, (x + 4, LANE_Y[target_trace[index]]), ray_index)
+                previous = point
+            if stages is None or len(xs) < stages:
+                self._line(frame, previous, (59, previous[1]), color, dotted=dotted, width=width)
+                self._aperture(frame, (59, LANE_Y[target_trace[-1]]), ray_index)
+
+    def _gears(self, frame):
+        xs = self._positions()
+        for left, right in self.game.level.get("links", ()):
+            self._line(frame, (xs[left], 13), (xs[right], 13), GOLD, dotted=True)
+            for index in (left, right):
+                self._disc(frame, (xs[index], 13), 3, GOLD)
+                self._disc(frame, (xs[index], 13), 1, BLACK)
+                frame[9:18:2, xs[index]] = SILVER
+
+    def _budget(self, frame):
+        g = self.game
+        for index in range(g.budget_max):
+            x = 5 + index * 54 // max(1, g.budget_max - 1)
+            if index < g.budget_left:
+                self._disc(frame, (x, 59), 1, GOLD)
+            else:
+                frame[59, x] = ASH
+
+    def _animation(self, frame):
+        g = self.game
+        if g.intro_mark:
+            frame[9:12, 8:57:3] = AQUA
+        if g.terminal_hold == "win":
+            frame[10:54, 4:60] = BLACK
+            for radius, color in ((18, AQUA), (13, VIOLET), (8, WHITE), (3, GOLD)):
+                self._disc(frame, (32, 32), radius, color)
+        elif g.terminal_hold == "loss":
+            frame[10:54:2, 4:60] = RED
+            frame[10:54, 4:60:5] = ASH
+        if not g.anim_kind:
+            return
+        p = g.anim_progress
+        xs = self._positions()
+        if g.anim_kind == "cursor":
+            a, b = xs[g.anim_from], xs[g.anim_to]
+            x = a + (b - a) * p // g.anim_total
+            frame[47:51, x - 3:x + 4:2] = CORAL
+        elif g.anim_kind == "rotate":
+            x = xs[g.state[1]]
+            radius = 4 + p
+            for dx, dy in ((radius, 0), (-radius, 0), (0, radius), (0, -radius)):
+                if 0 <= x + dx < 64 and 0 <= 32 + dy < 64:
+                    frame[32 + dy, x + dx] = WHITE
+            if g.pending_state is not None:
+                self._wedge(frame, (x, 32), g.pending_state[0][g.state[1]],
+                            g.level["kinds"][g.state[1]], True,
+                            g.state[1] in g.level.get("fixed", ()),
+                            bool(g.pending_state[2] & (1 << g.state[1])))
+                # A meshed partner visibly counter-rotates during the same beat.
+                for left, right in g.level.get("links", ()):
+                    partner = right if g.state[1] == left else left if g.state[1] == right else None
+                    if partner is not None:
+                        self._wedge(frame, (xs[partner], 32), g.pending_state[0][partner],
+                                    g.level["kinds"][partner], False, False)
+        elif g.anim_kind == "calibrate":
+            x = xs[g.state[1]]
+            radius = min(8, 2 + p)
+            for dx, dy in ((radius, radius), (radius, -radius), (-radius, radius), (-radius, -radius)):
+                self._disc(frame, (x + dx, 32 + dy), 1, GOLD)
+        elif g.anim_kind == "blocked":
+            x = xs[g.state[1]]
+            frame[24 + p:41 - p:2, x - 7:x + 8] = RED
+        elif g.anim_kind in ("fire", "success"):
+            self._rays(frame, bright=True, stages=min(len(xs) + 1, p + 1))
+            if g.anim_kind == "success" and p >= len(xs) // 2:
+                self._disc(frame, (59, 32), min(5, p), GREEN)
+        elif g.anim_kind == "miss":
+            self._rays(frame, bright=True, stages=min(len(xs) + 1, p + 1))
+            if p >= len(xs) // 2:
+                frame[18:47:3, 58:62] = RED
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        g = self.game
+        self._background(frame)
+        self._rays(frame)
+        self._gears(frame)
+        xs = self._positions()
+        for index, (x, angle, kind) in enumerate(zip(xs, g.state[0], g.level["kinds"])):
+            self._wedge(frame, (x, 32), angle, kind, index == g.state[1],
+                        index in g.level.get("fixed", ()), bool(g.state[2] & (1 << index)))
+        self._budget(frame)
+        self._animation(frame)
+        return frame
+
+
+class Q052(ARCBaseGame):
+    def __init__(self):
+        self.display = ForgeDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_from = self.anim_to = 0
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q052", levels, Camera(0, 0, 64, 64, BLACK, BLACK, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+
+    def _begin(self, kind, frames, *, next_state=None, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.pending_state = next_state
+        self.pending_terminal = terminal
+
+    def _finish(self):
+        terminal = self.pending_terminal
+        if self.pending_state is not None:
+            self.state = self.pending_state
+        self.anim_kind = None
+        self.pending_state = None
+        self.pending_terminal = None
+        if terminal == "win":
+            self.terminal_hold = "win"
+            self.next_level()
+        elif terminal == "loss" or self.budget_left <= 0:
+            self.terminal_hold = "loss"
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self._finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        self.intro_mark = False
+        if action == 5:
+            won = solved(self.level, self.state)
+            if not won:
+                self.budget_left -= 1
+            self._begin("success" if won else "miss", 7,
+                        terminal="win" if won else ("loss" if self.budget_left <= 0 else None))
+            return
+        after = transition(self.level, self.state, action)
+        if after == self.state:
+            self._begin("blocked", 4)
+            return
+        self.budget_left -= 1
+        self.anim_from, self.anim_to = self.state[1], after[1]
+        if action in (1, 2) and self.state[1] in self.level.get("fixed", ()):
+            kind = "calibrate"
+        else:
+            kind = "cursor" if action in (3, 4) else "rotate"
+        self._begin(kind, 5, next_state=after,
+                    terminal="loss" if self.budget_left <= 0 else None)

--- a/data/community-games/sonpham/q060_v2_q060.py
+++ b/data/community-games/sonpham/q060_v2_q060.py
@@ -1,0 +1,647 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q060-v2 Midnight Stampworks.
+
+The player assembles a serial stamping machine from four visibly distinct
+parts.  Cams stamp one of two marks, a delay advances the clock without a
+mark, and a feedback pawl repeats the preceding mark twice.  RUN executes the
+whole mechanism as a visible deterministic trace; success is judged only by
+that behavior, so output-equivalent machines are accepted.
+
+The accepted mx007 direct-mouse-navigation mechanic arrives in the late
+levels as wax-sealed sockets that keyboard navigation cannot enter.  Clicking
+their generous snapped targets is therefore necessary rather than a duplicate
+control.  Real-time strategy and hidden uncertainty were rejected: this is a
+fully observable, deliberate, serial machine.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+WHITE, PAPER, STEEL, IRON, COAL, VOID = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, CYAN, AMBER = 6, 7, 8, 9, 10, 11
+COPPER, CRIMSON, VERDIGRIS, VIOLET = 12, 13, 14, 15
+
+EMPTY, CAM_A, CAM_B, DELAY, FEEDBACK = 0, 1, 2, 3, 4
+TICK_DELAY, TICK_A, TICK_B, TICK_EMPTY = 0, 1, 2, 3
+ACTIVE, WIN, LOSS = 0, 2, 3
+TERMINAL_INDEX = 4
+SNAP_RADIUS = 8
+POINTER_ACTION = 6
+
+
+def run_sequence(program):
+    """Return the autonomous visible tick trace for a socket program.
+
+    Delay contributes a patterned silent tick. Feedback contributes two ticks
+    carrying the most recent stamp. Empty sockets contribute an unmistakable
+    broken tick and can never solve a level.
+    """
+    trace = []
+    previous = TICK_A
+    for part in program:
+        if part == CAM_A:
+            previous = TICK_A
+            trace.append(TICK_A)
+        elif part == CAM_B:
+            previous = TICK_B
+            trace.append(TICK_B)
+        elif part == DELAY:
+            trace.append(TICK_DELAY)
+        elif part == FEEDBACK:
+            trace.extend((previous, previous))
+        else:
+            trace.append(TICK_EMPTY)
+    return tuple(trace)
+
+
+def works(name, sockets, target_program, start, budget, witness,
+          pointer_only=()):
+    sockets = tuple(tuple(point) for point in sockets)
+    target_program = tuple(int(part) for part in target_program)
+    pointer_mask = sum(1 << int(index) for index in pointer_only)
+    assert len(sockets) == len(target_program)
+    assert 0 <= start < len(sockets)
+    assert not pointer_mask & (1 << start)
+    return {
+        "name": name,
+        "sockets": sockets,
+        "target_program": target_program,
+        "target": run_sequence(target_program),
+        "required_delays": target_program.count(DELAY),
+        "start": int(start),
+        "budget": int(budget),
+        "witness": tuple(witness),
+        "pointer_only": pointer_mask,
+    }
+
+
+LEVELS = (
+    works(
+        "Twin Dies",
+        ((23, 27), (41, 32)),
+        (CAM_A, CAM_B), 0, 5,
+        (1, 4, 1, 1, 5),
+    ),
+    works(
+        "Quiet Tooth",
+        ((18, 22), (32, 17), (45, 27), (36, 41)),
+        (CAM_B, CAM_A, DELAY, CAM_B), 1, 12,
+        (1, 3, 1, 1, 4, 4, 2, 2, 4, 1, 1, 5),
+    ),
+    works(
+        "Echo Pawl",
+        ((19, 19), (36, 16), (47, 31), (31, 43)),
+        (CAM_A, FEEDBACK, DELAY, CAM_B), 0, 10,
+        (1, 4, 2, 4, 2, 2, 4, 1, 1, 5),
+    ),
+    works(
+        "Spiral Register",
+        ((15, 27), (24, 15), (40, 17), (48, 31), (34, 43)),
+        (CAM_B, DELAY, CAM_A, FEEDBACK, CAM_B), 2, 15,
+        (1, 3, 2, 2, 3, 1, 1, 4, 4, 4, 2, 4, 1, 1, 5),
+    ),
+    works(
+        "Waxed Echo",
+        ((15, 26), (24, 14), (41, 16), (49, 31), (34, 44)),
+        (CAM_A, DELAY, CAM_B, FEEDBACK, CAM_A), 0, 12,
+        (1, (6, 1), 2, 2, (6, 2), 1, 1,
+         (6, 3), 2, (6, 4), 1, 5),
+        pointer_only=(3,),
+    ),
+    works(
+        "Double Seal",
+        ((14, 30), (21, 15), (38, 13), (49, 27), (37, 44)),
+        (CAM_B, FEEDBACK, DELAY, CAM_A, FEEDBACK), 0, 12,
+        (1, 1, (6, 1), 2, 4, 2, 2, 4, 1,
+         (6, 4), 2, 5),
+        pointer_only=(1, 4),
+    ),
+    works(
+        "Counterweight Choir",
+        ((13, 31), (20, 15), (37, 12), (49, 26), (37, 44)),
+        (CAM_A, DELAY, FEEDBACK, CAM_B, DELAY), 0, 13,
+        (1, 4, 2, 2, (6, 2), 2, 4, 1, 1,
+         (6, 4), 2, 2, 5),
+        pointer_only=(2, 4),
+    ),
+    works(
+        "Midnight Stampworks",
+        ((12, 31), (18, 15), (34, 10), (49, 22), (42, 43)),
+        (CAM_B, DELAY, FEEDBACK, CAM_A, DELAY), 0, 13,
+        (1, 1, (6, 1), 2, 2, (6, 2), 2, (6, 3), 1,
+         (6, 4), 2, 2, 5),
+        pointer_only=(1, 3, 4),
+    ),
+)
+
+
+def parse_action(action):
+    if isinstance(action, (tuple, list)):
+        return int(action[0]), int(action[1]) if len(action) > 1 else None
+    return int(action), None
+
+
+def action_tokens(level):
+    # Only wax-sealed sockets are mouse-actuated. Runtime snap_socket uses this
+    # same mask, so every effective direct click is represented exactly once.
+    return (1, 2, 3, 4, 5) + tuple(
+        (POINTER_ACTION, index) for index in range(len(level["sockets"]))
+        if level["pointer_only"] & (1 << index))
+
+
+def encode_action(level, action):
+    """Translate a semantic socket target to public pointer coordinates."""
+    aid, target = parse_action(action)
+    if aid == 6 and target is not None and 0 <= target < len(level["sockets"]):
+        x, y = level["sockets"][target]
+        return (6, x, y)
+    return (aid,)
+
+
+def start_state(level):
+    # socket parts, selected socket, cracked bad-run seals, visible last trace,
+    # terminal state.
+    return (tuple(EMPTY for _ in level["sockets"]), level["start"],
+            0, (), ACTIVE)
+
+
+def _keyboard_targets(level):
+    return tuple(index for index in range(len(level["sockets"]))
+                 if not level["pointer_only"] & (1 << index))
+
+
+def _navigate(level, cursor, direction):
+    allowed = _keyboard_targets(level)
+    if cursor not in allowed:
+        lower = tuple(index for index in allowed if index < cursor)
+        upper = tuple(index for index in allowed if index > cursor)
+        if direction < 0:
+            return lower[-1] if lower else allowed[0]
+        return upper[0] if upper else allowed[-1]
+    position = allowed.index(cursor)
+    return allowed[max(0, min(len(allowed) - 1, position + direction))]
+
+
+def ready(level, state):
+    return (EMPTY not in state[0]
+            and run_sequence(state[0]) == level["target"])
+
+
+def transition(level, state, action):
+    """Pure deterministic rules contract shared by search and runtime."""
+    if state[TERMINAL_INDEX] != ACTIVE:
+        return state
+    aid, target = parse_action(action)
+    program, cursor, strikes, _last_trace, _terminal = state
+    if aid in (1, 2):
+        updated = list(program)
+        delta = 1 if aid == 1 else -1
+        updated[cursor] = (updated[cursor] + delta) % 5
+        return (tuple(updated), cursor, strikes, (), ACTIVE)
+    if aid in (3, 4):
+        selected = _navigate(level, cursor, -1 if aid == 3 else 1)
+        if selected == cursor:
+            return state
+        return (program, selected, strikes, (), ACTIVE)
+    if aid == 6:
+        if target is None or not 0 <= target < len(program) or target == cursor:
+            return state
+        return (program, target, strikes, (), ACTIVE)
+    if aid != 5:
+        return state
+    trace = run_sequence(program)
+    if ready(level, state):
+        return (program, cursor, strikes, trace, WIN)
+    next_strikes = strikes + 1
+    return (program, cursor, next_strikes, trace,
+            LOSS if next_strikes >= 2 else ACTIVE)
+
+
+def action_cost(before, after):
+    if after == before:
+        return 0
+    # A first diagnostic run and terminal fracture consume no hidden budget.
+    # The visible spare beads fund an edit-after-run recovery.
+    if after[2] > before[2] or after[TERMINAL_INDEX] == LOSS:
+        return 0
+    return 1
+
+
+def solved(level, state):
+    return state[TERMINAL_INDEX] == WIN and ready(level, state)
+
+
+def _behavior_samples(program):
+    """Expose (held stamp value, advancing tick) samples for audit."""
+    samples = []
+    value = TICK_A
+    tick = 0
+    for part in program:
+        if part == CAM_A:
+            value = TICK_A
+            samples.append((value, tick)); tick += 1
+        elif part == CAM_B:
+            value = TICK_B
+            samples.append((value, tick)); tick += 1
+        elif part == DELAY:
+            samples.append((value, tick)); tick += 1
+        elif part == FEEDBACK:
+            samples.append((value, tick)); tick += 1
+            samples.append((value, tick)); tick += 1
+        else:
+            samples.append((TICK_EMPTY, tick)); tick += 1
+    return tuple(samples)
+
+
+def program_trace(level, plan):
+    """Derive the autonomous physical trace from an arbitrary action plan."""
+    state = start_state(level)
+    for action in plan:
+        state = transition(level, state, action)
+        if state[TERMINAL_INDEX]:
+            break
+    return _behavior_samples(state[0])
+
+
+def _mutant_run(level, state, action, trace):
+    """Shared audit-only mutation wrapper for a broken RUN action."""
+    aid, _target = parse_action(action)
+    if aid != 5 or state[TERMINAL_INDEX] != ACTIVE:
+        return transition(level, state, action)
+    program, cursor, strikes, _last_trace, _terminal = state
+    if EMPTY not in program and trace == level["target"]:
+        return (program, cursor, strikes, trace, WIN)
+    next_strikes = strikes + 1
+    return (program, cursor, next_strikes, trace,
+            LOSS if next_strikes >= 2 else ACTIVE)
+
+
+def without_delays(level, state, action):
+    """Counterfactual: delay teeth disappear instead of advancing time."""
+    program = state[0]
+    trace = tuple(tick for part in program if part != DELAY
+                  for tick in run_sequence((part,)))
+    return _mutant_run(level, state, action, trace)
+
+
+def without_autonomy(level, state, action):
+    """Counterfactual: RUN exposes only one manually advanced output tick."""
+    trace = run_sequence(state[0])[:1]
+    return _mutant_run(level, state, action, trace)
+
+
+def execute(level, actions):
+    state = start_state(level)
+    budget = level["budget"]
+    for action in actions:
+        after = transition(level, state, action)
+        budget -= action_cost(state, after)
+        state = after
+    return state, budget
+
+
+for _level in LEVELS:
+    _state, _left = execute(_level, _level["witness"])
+    assert solved(_level, _state) and _left >= 0, (
+        _level["name"], _state, _left)
+assert {parse_action(action)[0] for level in LEVELS
+        for action in level["witness"]} == {1, 2, 3, 4, 5, 6}
+
+
+class StampDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def line(frame, start, end, color, dotted=False, width=1):
+        x0, y0 = start; x1, y1 = end
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 4 in (1, 2):
+                continue
+            x = round(x0 + (x1 - x0) * step / steps)
+            y = round(y0 + (y1 - y0) * step / steps)
+            frame[max(0, y - width + 1):min(64, y + width),
+                  max(0, x - width + 1):min(64, x + width)] = color
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        yy, xx = np.ogrid[:64, :64]
+        d2 = (xx - cx) ** 2 + (yy - cy) ** 2
+        mask = d2 <= radius ** 2
+        if hollow:
+            mask &= d2 >= max(0, radius - 1) ** 2
+        frame[mask] = color
+
+    @staticmethod
+    def diamond(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        yy, xx = np.ogrid[:64, :64]
+        distance = abs(xx - cx) + abs(yy - cy)
+        mask = distance <= radius
+        if hollow:
+            mask &= distance >= max(0, radius - 1)
+        frame[mask] = color
+
+    def background(self, frame):
+        frame[:, :] = VOID
+        frame[2:62, 2:62] = COAL
+        frame[5:60, 5:59] = IRON
+        frame[7:58, 7:57] = VOID
+        for y in range(9, 56, 4):
+            for x in range(9 + (y // 4) % 2, 56, 5):
+                frame[y, x] = COAL if (x + y) % 3 else CRIMSON
+        self.disc(frame, (32, 29), 24, COAL, hollow=True)
+        self.disc(frame, (32, 29), 20, COPPER, hollow=True)
+        self.disc(frame, (32, 29), 18, VOID, hollow=True)
+        for spoke in range(12):
+            angle = 2 * math.pi * spoke / 12
+            a = (32 + round(18 * math.cos(angle)),
+                 29 + round(18 * math.sin(angle)))
+            b = (32 + round(21 * math.cos(angle)),
+                 29 + round(21 * math.sin(angle)))
+            self.line(frame, a, b, STEEL, width=1)
+
+    def part_glyph(self, frame, center, part, color=None):
+        cx, cy = center
+        color = color if color is not None else (
+            STEEL if part == EMPTY else AMBER if part == CAM_A
+            else CYAN if part == CAM_B else PAPER if part == DELAY
+            else VIOLET)
+        if part == EMPTY:
+            self.disc(frame, center, 3, color, hollow=True)
+            frame[cy, cx] = VOID
+            frame[cy - 2, cx] = frame[cy + 2, cx] = VOID
+        elif part == CAM_A:
+            self.diamond(frame, center, 4, color)
+            self.diamond(frame, center, 1, VOID)
+            frame[cy - 4:cy - 2, cx - 1:cx + 2] = COPPER
+        elif part == CAM_B:
+            self.disc(frame, (cx - 2, cy), 3, color)
+            self.disc(frame, (cx + 2, cy), 3, color)
+            frame[cy - 1:cy + 2, cx - 4:cx + 5:2] = VOID
+        elif part == DELAY:
+            self.line(frame, (cx - 3, cy - 4), (cx + 3, cy - 4), color)
+            self.line(frame, (cx - 3, cy + 4), (cx + 3, cy + 4), color)
+            self.line(frame, (cx - 3, cy - 3), (cx + 3, cy + 3), color)
+            self.line(frame, (cx + 3, cy - 3), (cx - 3, cy + 3), color)
+            frame[cy, cx] = RED
+        else:
+            self.disc(frame, center, 4, color, hollow=True)
+            self.disc(frame, center, 2, color, hollow=True)
+            self.line(frame, (cx, cy), (cx + 4, cy - 2), color)
+            frame[cy - 1:cy + 2, cx - 1:cx + 2] = VOID
+
+    def socket(self, frame, index, center, state):
+        program, cursor, _strikes, _trace, _terminal = state
+        pointer = bool(self.game.level["pointer_only"] & (1 << index))
+        self.disc(frame, center, 7, CRIMSON)
+        self.disc(frame, center, 6, COAL)
+        if pointer:
+            self.diamond(frame, center, 8, MAGENTA, hollow=True)
+            cx, cy = center
+            frame[cy - 6:cy - 4, cx - 1:cx + 2] = ROSE
+            frame[cy + 5:cy + 7, cx - 1:cx + 2] = ROSE
+        else:
+            self.disc(frame, center, 7, COPPER, hollow=True)
+        self.part_glyph(frame, center, program[index])
+        if index == cursor:
+            self.disc(frame, center, 9, WHITE, hollow=True)
+            cx, cy = center
+            self.diamond(frame, (cx, cy - 9), 1, AMBER)
+
+    def tick_glyph(self, frame, center, tick, target=False):
+        cx, cy = center
+        edge = PAPER if target else COPPER
+        frame[cy - 3:cy + 4, cx - 3:cx + 4] = COAL
+        if tick == TICK_DELAY:
+            self.diamond(frame, center, 3, edge, hollow=True)
+            frame[cy, cx - 2:cx + 3:2] = VOID
+        elif tick == TICK_A:
+            self.diamond(frame, center, 3, AMBER if not target else WHITE)
+            frame[cy, cx] = VOID
+        elif tick == TICK_B:
+            self.disc(frame, (cx - 1, cy), 2, CYAN if not target else PAPER)
+            self.disc(frame, (cx + 2, cy), 2, CYAN if not target else PAPER)
+            frame[cy, cx] = VOID
+        else:
+            self.line(frame, (cx - 3, cy - 3), (cx + 3, cy + 3), RED)
+            self.line(frame, (cx + 3, cy - 3), (cx - 3, cy + 3), RED)
+
+    def timeline(self, frame, y, trace, target=False, limit=None):
+        count = len(trace) if limit is None else min(len(trace), limit)
+        width = max(1, len(trace)) * 7
+        x0 = max(4, 32 - width // 2 + 3)
+        self.line(frame, (x0 - 3, y),
+                  (min(60, x0 + max(0, len(trace) - 1) * 7 + 3), y),
+                  STEEL, dotted=not target)
+        for index in range(count):
+            self.tick_glyph(frame, (x0 + index * 7, y), trace[index], target)
+
+    def instruments(self, frame, state):
+        _program, _cursor, strikes, trace, terminal = state
+        for bead in range(self.game.budget_max):
+            x = 5 + (bead % 18) * 3
+            y = 3 + (bead // 18) * 3
+            color = COPPER if bead < self.game.budget_left else COAL
+            self.diamond(frame, (x, y), 1, color)
+        for seal in range(2):
+            cx = 58; cy = 11 + seal * 7
+            self.disc(frame, (cx, cy), 3, RED if seal < strikes else VERDIGRIS,
+                      hollow=seal >= strikes)
+            if seal < strikes:
+                self.line(frame, (cx - 2, cy - 2), (cx + 2, cy + 2), WHITE)
+        self.timeline(frame, 55, self.game.level["target"], target=True)
+        if trace:
+            self.timeline(frame, 47, trace, target=False)
+        if terminal == LOSS:
+            self.line(frame, (7, 9), (56, 54), RED, width=2)
+            self.line(frame, (56, 9), (7, 54), CRIMSON, width=2)
+
+    def animation(self, frame, state):
+        g = self.game
+        if not g.anim_kind:
+            return
+        before, after = g.state, g.pending_state
+        p = g.anim_progress
+        span = max(1, g.anim_total - 1)
+        wave = min(p, span - p)
+        if g.anim_kind == "edit":
+            center = g.level["sockets"][before[1]]
+            self.disc(frame, center, 8 + wave, AMBER, hollow=True)
+            shown = before[0][before[1]] if p < span // 2 else after[0][after[1]]
+            self.part_glyph(frame, center, shown, WHITE)
+            angle = p * math.pi / 3
+            tip = (center[0] + round(10 * math.cos(angle)),
+                   center[1] + round(10 * math.sin(angle)))
+            self.line(frame, center, tip, COPPER)
+        elif g.anim_kind in ("navigate", "pointer"):
+            a = g.level["sockets"][before[1]]
+            b = g.level["sockets"][after[1]]
+            center = (round(a[0] + (b[0] - a[0]) * p / span),
+                      round(a[1] + (b[1] - a[1]) * p / span))
+            self.disc(frame, center, 8 + wave, MAGENTA if g.anim_kind == "pointer" else WHITE,
+                      hollow=True)
+            if g.anim_kind == "pointer":
+                self.diamond(frame, center, 2 + wave // 2, ROSE, hollow=True)
+        elif g.anim_kind in ("run", "success", "reject", "loss"):
+            trace = after[3]
+            shown = max(1, min(len(trace), 1 + p * max(1, len(trace)) // (span + 1)))
+            self.timeline(frame, 47, trace, target=False, limit=shown)
+            index = min(len(trace) - 1, shown - 1) if trace else 0
+            width = max(1, len(trace)) * 7
+            x0 = max(4, 32 - width // 2 + 3)
+            head_x = x0 + index * 7
+            self.line(frame, (head_x, 39 - wave), (head_x, 43),
+                      VERDIGRIS if g.anim_kind == "success" else RED,
+                      width=2)
+            self.disc(frame, (32, 29), 6 + p % 4, COPPER, hollow=True)
+            if g.anim_kind == "success":
+                self.disc(frame, (32, 29), 9 + p * 2, VERDIGRIS, hollow=True)
+            elif g.anim_kind == "loss":
+                inset = min(16, p * 2)
+                self.line(frame, (5 + inset, 8), (59 - inset, 54), RED, width=2)
+                self.line(frame, (59 - inset, 8), (5 + inset, 54), CRIMSON, width=2)
+            elif g.anim_kind == "reject":
+                offset = (-2, 2, -1, 1, 0, 1, 0, 0, 0)[min(p, 8)]
+                self.disc(frame, (32 + offset, 29), 10, RED, hollow=True)
+        else:
+            center = g.level["sockets"][before[1]]
+            offset = (-2, 2, -1, 1, 0)[min(p, 4)]
+            self.disc(frame, (center[0] + offset, center[1]), 9, RED, hollow=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        state = self.game.state
+        self.background(frame)
+        sockets = self.game.level["sockets"]
+        for index in range(len(sockets) - 1):
+            self.line(frame, sockets[index], sockets[index + 1], COPPER,
+                      dotted=index % 2 == 1, width=1)
+        if len(sockets) > 2:
+            self.line(frame, sockets[-1], sockets[0], STEEL, dotted=True)
+        for index, center in enumerate(sockets):
+            self.socket(frame, index, center, state)
+        self.instruments(frame, state)
+        self.animation(frame, state)
+        return frame
+
+
+class Q060(ARCBaseGame):
+    def __init__(self):
+        self.display = StampDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_total = self.anim_left = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        levels = [
+            Level(sprites=[], grid_size=(64, 64), data=deepcopy(level),
+                  name=level["name"])
+            for level in LEVELS
+        ]
+        super().__init__("q060", levels,
+                         Camera(0, 0, 64, 64, VOID, VOID, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_total = self.anim_left = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+
+    def snap_socket(self, x, y):
+        candidates = []
+        for index, (sx, sy) in enumerate(self.level["sockets"]):
+            if not self.level["pointer_only"] & (1 << index):
+                continue
+            distance = (sx - x) ** 2 + (sy - y) ** 2
+            if distance <= SNAP_RADIUS ** 2:
+                candidates.append((distance, index))
+        return min(candidates)[1] if candidates else None
+
+    def begin(self, kind, frames, after, budget, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.pending_state = after
+        self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state
+        self.budget_left = self.pending_budget
+        self.anim_kind = None
+        self.anim_total = self.anim_left = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        aid = self.action.id.value
+        if aid == 0:
+            self.complete_action()
+            return
+        token = aid
+        if aid == 6:
+            target = self.snap_socket(
+                int(self.action.data.get("x", -99)),
+                int(self.action.data.get("y", -99)),
+            )
+            token = aid if target is None else (aid, target)
+        before = self.state
+        after = transition(self.level, before, token)
+        if after == before:
+            self.begin("blocked", 5, before, self.budget_left)
+            return
+        cost = action_cost(before, after)
+        budget = self.budget_left - cost
+        won = after[TERMINAL_INDEX] == WIN
+        lost = after[TERMINAL_INDEX] == LOSS or (budget <= 0 and not won)
+        if lost and after[TERMINAL_INDEX] != LOSS:
+            after = after[:TERMINAL_INDEX] + (LOSS,)
+        if won:
+            # ARC level transitions append settlement frames; six authored
+            # poses keep both campaign and isolated replays within nine.
+            kind, frames, terminal = "success", 6, "win"
+        elif lost:
+            kind, frames, terminal = "loss", 6, "loss"
+        elif aid == 5:
+            kind, frames, terminal = "reject", 8, None
+        elif aid in (1, 2):
+            kind, frames, terminal = "edit", 6, None
+        elif aid == 6:
+            kind, frames, terminal = "pointer", 6, None
+        else:
+            kind, frames, terminal = "navigate", 6, None
+        self.begin(kind, frames, after, budget, terminal)
+
+
+if __name__ == "__main__":
+    for configured in LEVELS:
+        result, left = execute(configured, configured["witness"])
+        assert solved(configured, result) and left >= 0
+    print("q060-v2 ok")

--- a/data/community-games/sonpham/q061_v2_q061.py
+++ b/data/community-games/sonpham/q061_v2_q061.py
@@ -1,0 +1,566 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q061-v2 Split Couriers -- navigate one pane from warnings woven into the other.
+
+Two directly controlled couriers share a finite action skein but keep two separate
+safety ribbons.  Each pane renders the *other* pane's otherwise invisible thorns,
+sometimes through a mirror or half-turn.  Later dioramas add a two-step phase
+signal, persistent remote latches, hold plates, and one-way cloth folds.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, LINEN, MIST, CLAY, BARK, INK = 0, 1, 2, 3, 4, 5
+BERRY, ROSE, RED, BLUE, SKY, HONEY, APRICOT, GREEN, SAGE, LAVENDER = 6, 7, 8, 9, 10, 11, 12, 14, 14, 15
+WIDTH = HEIGHT = 6
+DIRS = {1: (0, -1), 2: (0, 1), 3: (-1, 0), 4: (1, 0)}
+ARROWS = {"^": (0, -1), "v": (0, 1), "<": (-1, 0), ">": (1, 0)}
+
+
+def idx(x, y):
+    return y * WIDTH + x
+
+
+def scene(name, left, right, hazards, budget, **rules):
+    base = {
+        "name": name,
+        "grids": (tuple(left), tuple(right)),
+        "hazards": tuple(tuple(tuple(idx(x, y) for x, y in pane) for pane in phase)
+                         for phase in hazards),
+        "budget": budget,
+        "transform": "identity",
+        "phases": len(hazards),
+        "goal_phase": None,
+    }
+    base.update(rules)
+    return base
+
+
+OPEN = (
+    "######",
+    "#S...#",
+    "#....#",
+    "#....#",
+    "#...G#",
+    "######",
+)
+
+
+LEVELS = [
+    scene("Borrowed Map", OPEN, OPEN,
+          ((((2, 1), (3, 3)), ((1, 2), (3, 2))),), 15),
+    scene("Folded Warning",
+          ("######", "#S...#", "#.##.#", "#....#", "#.#.G#", "######"),
+          ("######", "#S...#", "#.#..#", "#....#", "#.##G#", "######"),
+          ((((3, 1),), ((2, 1),)),), 17, transform="mirror"),
+    scene("Two-Breath Weather", OPEN, OPEN,
+          ((((2, 1), (2, 3)), ((1, 2), (3, 3))),
+           (((3, 1), (3, 2)), ((2, 2), (3, 1)))), 18,
+          transform="rotate", goal_phase=1),
+    scene("Stitched Latch",
+          ("######", "#SL..#", "#.####", "#..###", "#..DG#", "######"),
+          ("######", "#SLDG#", "#.####", "#....#", "#....#", "######"),
+          ((((3, 1),), ((2, 3),)),), 15),
+    scene("Held Hem",
+          ("######", "#S.P.#", "#.#..#", "#....#", "#...G#", "######"),
+          ("######", "#S.HG#", "#.####", "#....#", "#....#", "######"),
+          ((((2, 3),), ((3, 3),)),
+           (((2, 2),), ((2, 3),))), 19, transform="mirror", goal_phase=1),
+    scene("Arrow Weave",
+          ("######", "#SL>.#", "#.#v.#", "#....#", "#...G#", "######"),
+          ("######", "#S...#", "#v##.#", "#v.DG#", "######", "######"),
+          ((((3, 3),), ((2, 1),)),), 14),
+    scene("Changing Loom",
+          ("######", "#SL>.#", "#.#..#", "#....#", "#...G#", "######"),
+          ("######", "#S.DG#", "#.##.#", "#....#", "#....#", "######"),
+          ((((3, 1), (2, 3)), ((2, 3),)),
+           (((3, 2),), ((2, 1), (3, 3)))), 21,
+          transform="mirror", goal_phase=1),
+    scene("Split Couriers",
+          ("######", "#SLP.#", "#.#v.#", "#..###", "#..DG#", "######"),
+          ("######", "#SLHG#", "#.##.#", "#>...#", "#....#", "######"),
+          ((((2, 4), (4, 2)), ((2, 3), (3, 3))),
+           (((3, 2), (2, 3)), ((1, 3), (3, 1)))), 25,
+          transform="rotate", goal_phase=1),
+]
+
+
+def find_tile(grid, tile):
+    for y, row in enumerate(grid):
+        for x, value in enumerate(row):
+            if value == tile:
+                return idx(x, y)
+    return -1
+
+
+def point(index):
+    return index % WIDTH, index // WIDTH
+
+
+def tile_at(level, pane, index):
+    x, y = point(index)
+    return level["grids"][pane][y][x]
+
+
+def transform_point(level, index):
+    x, y = point(index)
+    if level["transform"] == "mirror":
+        x = WIDTH - 1 - x
+    elif level["transform"] == "rotate":
+        x, y = WIDTH - 1 - x, HEIGHT - 1 - y
+    return idx(x, y)
+
+
+def starts(level):
+    return tuple(find_tile(grid, "S") for grid in level["grids"])
+
+
+def goals(level):
+    return tuple(find_tile(grid, "G") for grid in level["grids"])
+
+
+def start_state(level):
+    # positions, active pane, persistent latch mask, pending signal, phase,
+    # remaining safety ribbons, terminal (0 play / 2 win / 3 loss)
+    return starts(level), 0, 0, 0, 0, 2, 0
+
+
+def hold_open(level, positions, gate_pane):
+    other = 1 - gate_pane
+    return tile_at(level, other, positions[other]) == "P"
+
+
+def configuration_solved(level, state):
+    positions, _active, _latches, _pending, phase, _safety, _terminal = state
+    phase_ok = level["goal_phase"] is None or phase == level["goal_phase"]
+    return positions == goals(level) and phase_ok
+
+
+def transition(level, state, action):
+    positions, active, latches, pending, phase, safety, terminal = state
+    if terminal or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    if action == 5:
+        after = positions, 1 - active, latches, pending, phase, safety, terminal
+        return after[:-1] + (2,) if configuration_solved(level, after) else after
+    if action == 6:
+        if level["phases"] < 2:
+            return state
+        if pending == 0:
+            return positions, active, latches, 1, phase, safety, terminal
+        phase = 1 - phase
+        pending = 0
+        occupied_thorn = any(positions[pane] in level["hazards"][phase][pane]
+                             for pane in (0, 1))
+        if occupied_thorn:
+            safety -= 1
+            terminal = 3 if safety <= 0 else 0
+        after = positions, active, latches, pending, phase, safety, terminal
+        return after[:-1] + (2,) if not terminal and configuration_solved(level, after) else after
+
+    dx, dy = DIRS[action]
+    x, y = point(positions[active])
+    nx, ny = x + dx, y + dy
+    if not (0 <= nx < WIDTH and 0 <= ny < HEIGHT):
+        return state
+    destination = idx(nx, ny)
+    tile = tile_at(level, active, destination)
+    if tile == "#":
+        return state
+    if tile == "D" and not (latches & (1 << (1 - active))):
+        return state
+    if tile == "H" and not hold_open(level, positions, active):
+        return state
+    if tile in ARROWS and ARROWS[tile] != (dx, dy):
+        return state
+    if destination in level["hazards"][phase][active]:
+        safety -= 1
+        return positions, active, latches, pending, phase, safety, 3 if safety <= 0 else 0
+    moved = list(positions)
+    moved[active] = destination
+    positions = tuple(moved)
+    if tile == "L":
+        latches |= 1 << active
+    after = positions, active, latches, pending, phase, safety, terminal
+    return after[:-1] + (2,) if configuration_solved(level, after) else after
+
+
+def action_cost(state, after):
+    if after == state:
+        return 0
+    # A direct thorn recoil spends only a safety ribbon.  A resolving weather
+    # signal still spends its action even if the new phase catches a courier.
+    if after[5] < state[5] and after[:5] == state[:5]:
+        return 0
+    return 1
+
+
+def solved(_level, state):
+    return state[-1] == 2
+
+
+class DioramaDisplay(RenderableUserDisplay):
+    CELL = 4
+    ORIGINS = ((3, 25), (37, 25))
+
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                d = (x - cx) ** 2 + (y - cy) ** 2
+                if d <= radius ** 2 and (not hollow or d >= max(0, radius - 1) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def line(frame, a, b, color, dotted=False):
+        x0, y0 = a; x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    def center(self, pane, index):
+        x, y = point(index); ox, oy = self.ORIGINS[pane]
+        return ox + x * self.CELL + 2, oy + y * self.CELL + 2
+
+    def background(self, frame):
+        frame[:, :] = PAPER
+        frame[2:55, 1:30] = LINEN
+        frame[2:55, 34:63] = MIST
+        for y in range(4, 55, 8):
+            frame[y, 3 + y % 5:29:9] = HONEY
+            frame[y + 3, 37 + y % 4:62:10] = SKY
+        # A bright braided seam, not a hard rectangular divider.
+        for y in range(3, 56, 4):
+            self.line(frame, (30, y), (33, y + 3), BERRY)
+            self.line(frame, (33, y), (30, y + 3), SKY)
+            self.disc(frame, (31 + (y // 4) % 2, y + 1), 1, HONEY)
+        for x in range(2, 63, 8):
+            self.disc(frame, (x, 54 + x % 3), 2, LINEN)
+
+    def courier(self, frame, center, pane, active, scale=1):
+        x, y = center
+        if pane == 0:
+            self.disc(frame, center, 2 + scale, SKY)
+            self.disc(frame, (x - 1, y - 1), 1, PAPER)
+            self.line(frame, (x - 3, y + 2), (x + 2, y + 3), BLUE)
+        else:
+            radius = 3 + scale
+            for dy in range(radius):
+                frame[max(0, y + 2 - dy), max(0, x - dy):min(64, x + dy + 1)] = ROSE
+            self.line(frame, (x, y - 3), (x, y + 3), BERRY)
+        if active:
+            self.disc(frame, center, 5, INK, hollow=True)
+            self.disc(frame, (x, y - 6), 1, INK)
+
+    def thorn(self, frame, center, phase):
+        x, y = center
+        self.disc(frame, center, 3, LAVENDER if phase else APRICOT, hollow=True)
+        if phase:
+            self.line(frame, (x - 3, y), (x + 3, y), INK, dotted=True)
+            self.line(frame, (x, y - 3), (x, y + 3), INK, dotted=True)
+        else:
+            self.line(frame, (x - 2, y - 2), (x + 2, y + 2), INK)
+            self.line(frame, (x + 2, y - 2), (x - 2, y + 2), INK)
+
+    def floor_tile(self, frame, pane, index, tile):
+        center = self.center(pane, index); x, y = center
+        self.disc(frame, center, 3, LINEN if pane == 0 else PAPER)
+        self.disc(frame, center, 3, CLAY, hollow=True)
+        if tile == "G":
+            self.disc(frame, center, 3, GREEN, hollow=True)
+            self.disc(frame, center, 1, HONEY)
+        elif tile == "L":
+            down = bool(self.game.state[2] & (1 << pane))
+            self.disc(frame, center, 2 if down else 3, SAGE)
+            self.disc(frame, center, 1, BARK, hollow=not down)
+        elif tile == "P":
+            held = tile_at(self.game.level, pane, self.game.state[0][pane]) == "P"
+            self.disc(frame, center, 3, APRICOT if held else HONEY, hollow=not held)
+            self.line(frame, (x - 2, y), (x + 2, y), BARK)
+        elif tile in ("D", "H"):
+            open_gate = ((tile == "D" and self.game.state[2] & (1 << (1 - pane)))
+                         or (tile == "H" and hold_open(self.game.level, self.game.state[0], pane)))
+            self.line(frame, (x - 3, y + 3), (x - 3, y - 3), SAGE)
+            self.line(frame, (x + 3, y + 3), (x + 3, y - 3), SAGE)
+            if open_gate:
+                self.line(frame, (x - 3, y - 3), (x - 5, y - 5), GREEN)
+                self.line(frame, (x + 3, y - 3), (x + 5, y - 5), GREEN)
+            else:
+                self.line(frame, (x - 3, y - 2), (x + 3, y + 2), BERRY)
+                self.line(frame, (x + 3, y - 2), (x - 3, y + 2), BERRY)
+        elif tile in ARROWS:
+            dx, dy = ARROWS[tile]
+            self.line(frame, (x - dx * 2, y - dy * 2), (x + dx * 2, y + dy * 2), BLUE)
+            self.line(frame, (x + dx * 2, y + dy * 2), (x + dx * 2 - dy * 2, y + dy * 2 + dx * 2), BLUE)
+            self.line(frame, (x + dx * 2, y + dy * 2), (x + dx * 2 + dy * 2, y + dy * 2 - dx * 2), BLUE)
+
+    def pane(self, frame, pane):
+        level = self.game.level; grid = level["grids"][pane]
+        # Scalloped paths are discs joined by stitches; walls remain negative space.
+        for y, row in enumerate(grid):
+            for x, tile in enumerate(row):
+                if tile != "#":
+                    index = idx(x, y)
+                    self.floor_tile(frame, pane, index, tile)
+                    for dx, dy in ((1, 0), (0, 1)):
+                        nx, ny = x + dx, y + dy
+                        if nx < WIDTH and ny < HEIGHT and grid[ny][nx] != "#":
+                            self.line(frame, self.center(pane, index), self.center(pane, idx(nx, ny)), CLAY, dotted=True)
+        # This pane carries a transformed projection of the opposite pane's thorns.
+        other = 1 - pane
+        for hazard in level["hazards"][self.game.state[4]][other]:
+            projected = transform_point(level, hazard)
+            self.thorn(frame, self.center(pane, projected), self.game.state[4])
+
+    def projected_thorn_overlay(self, frame, pane):
+        """Keep cross-pane warnings visible even beneath an occupying courier."""
+        level = self.game.level
+        other = 1 - pane
+        for hazard in level["hazards"][self.game.state[4]][other]:
+            projected = transform_point(level, hazard)
+            x, y = self.center(pane, projected)
+            if self.game.state[4]:
+                # Four compact cardinal ticks remain outside either courier silhouette.
+                frame[max(0, y - 1):min(64, y + 2), max(0, x - 4)] = LAVENDER
+                frame[max(0, y - 1):min(64, y + 2), min(63, x + 4)] = LAVENDER
+                frame[max(0, y - 4), max(0, x - 1):min(64, x + 2)] = LAVENDER
+                frame[min(63, y + 4), max(0, x - 1):min(64, x + 2)] = LAVENDER
+            else:
+                # Diagonal corner thorns encode the alternate phase without color.
+                for dx, dy in ((-4, -4), (4, -4), (-4, 4), (4, 4)):
+                    if 0 <= x + dx < 64 and 0 <= y + dy < 64:
+                        frame[y + dy, x + dx] = INK
+
+    def hud(self, frame):
+        g = self.game
+        # Two safety ribbons: leaf shields become hollow knots when spent.
+        for index in range(2):
+            center = (6 + index * 8, 8)
+            self.disc(frame, center, 3, SAGE if index < g.state[5] else CLAY, hollow=index >= g.state[5])
+            self.line(frame, (center[0], center[1] - 3), (center[0] + 3, center[1] - 5), BARK)
+        # Transform legend: opposed crescents for mirror, turning pinwheel for rotation.
+        if g.level["transform"] == "mirror":
+            self.disc(frame, (27, 9), 3, SKY, hollow=True); self.disc(frame, (37, 9), 3, ROSE, hollow=True)
+            self.line(frame, (30, 5), (34, 13), INK)
+        elif g.level["transform"] == "rotate":
+            for dx, dy in ((0, -4), (4, 0), (0, 4), (-4, 0)):
+                self.line(frame, (32, 9), (32 + dx, 9 + dy), LAVENDER)
+                self.disc(frame, (32 + dx, 9 + dy), 1, INK)
+        if g.level["phases"] > 1:
+            self.disc(frame, (50, 8), 4, SKY if g.state[4] == 0 else LAVENDER, hollow=g.state[4] == 1)
+            if g.state[4] == 0:
+                self.line(frame, (46, 8), (54, 8), HONEY)
+            else:
+                self.line(frame, (48, 5), (52, 11), INK)
+            if g.state[3]:
+                self.disc(frame, (43, 8), 2, BERRY)
+                self.line(frame, (43, 10), (32, 17), BERRY, dotted=True)
+        # Four actions form one flower knot; petals shrink to sockets when spent.
+        offsets = ((0, -2), (2, 0), (0, 2), (-2, 0))
+        for group in range((g.budget_max + 3) // 4):
+            cx = 4 + group * 8; cy = 60
+            self.disc(frame, (cx, cy), 1, BARK)
+            for petal, (dx, dy) in enumerate(offsets):
+                action = group * 4 + petal
+                if action >= g.budget_max:
+                    continue
+                if action < g.budget_left:
+                    self.disc(frame, (cx + dx, cy + dy), 1, SKY if group % 2 == 0 else ROSE)
+                else:
+                    frame[cy + dy, cx + dx] = CLAY
+
+    def animation(self, frame):
+        g = self.game
+        if g.intro_mark:
+            self.line(frame, (5, 18), (27, 15), HONEY, dotted=True)
+            self.line(frame, (37, 15), (59, 18), SKY, dotted=True)
+        if not g.anim_kind:
+            return
+        p = g.anim_progress
+        if g.anim_kind in ("move", "latch", "success"):
+            pane = g.anim_pane
+            a = self.center(pane, g.anim_from); b = self.center(pane, g.anim_to)
+            x = a[0] + (b[0] - a[0]) * p // g.anim_total
+            y = a[1] + (b[1] - a[1]) * p // g.anim_total - p * (g.anim_total - p) // max(2, g.anim_total)
+            self.courier(frame, (x, y), pane, True)
+            if g.anim_kind == "latch":
+                span = 28 * p // g.anim_total
+                self.line(frame, (32, 22), (32, 22 + span), SAGE, dotted=True)
+            elif g.anim_kind == "success":
+                # Both goals answer the final hop with growing petal wreaths and
+                # a rising seam stitch, making completion unlike ordinary travel.
+                for goal_pane, goal in enumerate(g.pending_state[0]):
+                    center = self.center(goal_pane, goal)
+                    radius = 3 + p
+                    self.disc(frame, center, radius, GREEN if goal_pane == 0 else BERRY,
+                              hollow=True)
+                    for dx, dy in ((0, -radius), (radius, 0), (0, radius), (-radius, 0)):
+                        self.disc(frame, (center[0] + dx, center[1] + dy), 1, HONEY)
+                self.line(frame, (32, 53), (32, max(17, 53 - p * 6)), GREEN, dotted=True)
+        elif g.anim_kind == "switch":
+            y = 18 + p * 5
+            self.disc(frame, (32, min(53, y)), 2, SKY if g.pending_state[1] == 0 else ROSE)
+        elif g.anim_kind == "signal":
+            y = 17 + p * 6
+            y = min(53, y)
+            self.disc(frame, (32, y), 2, BERRY)
+            self.disc(frame, (32, max(17, y - 4)), 1, HONEY)
+        elif g.anim_kind in ("hazard", "loss"):
+            pane = g.anim_pane
+            source = self.center(pane, g.anim_from)
+            impact = self.center(pane, g.anim_to)
+            half = max(1, g.anim_total // 2)
+            travel = p if p <= half else g.anim_total - p
+            x = source[0] + (impact[0] - source[0]) * travel // half
+            y = source[1] + (impact[1] - source[1]) * travel // half
+            self.thorn(frame, impact, g.pending_state[4])
+            if source == impact:
+                # A phase change can bloom a thorn under a stationary courier;
+                # pulse and recoil in place so that event is never a two-frame snap.
+                x += (-1) ** p * min(2, p)
+                self.disc(frame, impact, 3 + p // 2, RED, hollow=True)
+            self.courier(frame, (x, y), pane, True)
+            if g.anim_kind == "loss":
+                self.line(frame, (4 + p * 3, 20), (60 - p * 3, 53), RED)
+        elif g.anim_kind == "blocked":
+            pane = g.state[1]; center = self.center(pane, g.state[0][pane])
+            dx, dy = DIRS.get(g.anim_action, (0, 0))
+            self.courier(frame, (center[0] + dx * (p % 2), center[1] + dy * (p % 2)), pane, True)
+            self.line(frame, (center[0] + dx * 4 - dy * 2, center[1] + dy * 4 - dx * 2),
+                      (center[0] + dx * 4 + dy * 2, center[1] + dy * 4 + dx * 2), BERRY)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self.background(frame)
+        self.pane(frame, 0); self.pane(frame, 1)
+        moving = self.game.anim_kind in ("move", "latch", "success")
+        for pane, position in enumerate(self.game.state[0]):
+            if not (moving and pane == self.game.anim_pane):
+                self.courier(frame, self.center(pane, position), pane, pane == self.game.state[1])
+        # Critical cross-pane hazard evidence must survive avatar overlap.
+        self.projected_thorn_overlay(frame, 0)
+        self.projected_thorn_overlay(frame, 1)
+        self.hud(frame)
+        self.animation(frame)
+        return frame
+
+
+class Q061(ARCBaseGame):
+    def __init__(self):
+        self.display = DioramaDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_from = self.anim_to = 0
+        self.anim_pane = 0
+        self.anim_action = 0
+        self.pending_state = None
+        self.pending_budget = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q061", levels, Camera(0, 0, 64, 64, PAPER, PAPER, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_from = self.anim_to = 0
+        self.anim_pane = 0
+        self.anim_action = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        self.intro_mark = True
+
+    def begin(self, kind, frames, after, budget, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.pending_state = after
+        self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state
+        self.budget_left = self.pending_budget
+        self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        self.intro_mark = False
+        before = self.state
+        after = transition(self.level, before, action)
+        self.anim_action = action
+        self.anim_pane = before[1]
+        self.anim_from = before[0][before[1]]
+        self.anim_to = after[0][before[1]]
+        if action in DIRS:
+            x, y = point(self.anim_from)
+            dx, dy = DIRS[action]
+            if 0 <= x + dx < WIDTH and 0 <= y + dy < HEIGHT:
+                self.anim_to = idx(x + dx, y + dy)
+        if after == before:
+            self.begin("blocked", 4, before, self.budget_left)
+            return
+        budget = self.budget_left - action_cost(before, after)
+        won = solved(self.level, after)
+        lost = after[-1] == 3 or (budget <= 0 and not won)
+        if won:
+            kind, frames = "success", 7
+        elif lost:
+            kind, frames = "loss", 7
+        elif after[5] < before[5]:
+            if action == 6:
+                for pane in (0, 1):
+                    if before[0][pane] in self.level["hazards"][after[4]][pane]:
+                        self.anim_pane = pane
+                        self.anim_from = self.anim_to = before[0][pane]
+                        break
+            kind, frames = "hazard", 6
+        elif action == 5:
+            kind, frames = "switch", 5
+        elif action == 6:
+            kind, frames = "signal", 7
+        elif after[2] != before[2]:
+            kind, frames = "latch", 7
+        else:
+            kind, frames = "move", 5
+        self.begin(kind, frames, after, budget, "win" if won else "loss" if lost else None)

--- a/data/community-games/sonpham/q062_v3_q062.py
+++ b/data/community-games/sonpham/q062_v3_q062.py
@@ -1,0 +1,526 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q062-v3 Sunspool Parade -- align cut-paper bodies by projected shadows.
+
+The v3 presentation keeps the eight-level projection puzzle intact while
+making every moving paper body, selector, curtain, shadow, and HUD settlement
+spatially continuous.  Submission chances are independent of the physical
+swap/view budget, so one mistaken audit is honestly recoverable.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, PEARL, ASH, SLATE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, AQUA, GOLD, CORAL, EARTH, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+COLORS = (MAGENTA, BLUE, GOLD, GREEN, VIOLET, CORAL, AQUA)
+# Physical height/width coefficients are chosen so every exposed one-lamp
+# projection is unique at strengths 1, 2, and 3.  This removes invisible
+# identity-order tie breaking while preserving different orders by strength.
+HEIGHTS = (6, 9, 8, 10, 7, 4, 5)
+WIDTHS = (6, 2, 8, 3, 7, 4, 5)
+
+
+LEVELS = [
+    {"name": "Two Profiles", "n": 2, "order": (0, 1), "lights": (1,), "views": 1,
+     "attached": True, "require_views": False, "budget": 3},
+    {"name": "Shadow Balcony", "n": 4, "order": (3, 2, 1, 0), "lights": (1,), "views": 1,
+     "attached": False, "require_views": False, "budget": 11},
+    {"name": "High Sun", "n": 5, "order": (4, 3, 2, 1, 0), "lights": (2,), "views": 1,
+     "attached": False, "require_views": False, "budget": 18},
+    {"name": "Westward Light", "n": 5, "order": (0, 1, 2, 3, 4), "lights": (-2,), "views": 1,
+     "attached": False, "require_views": False, "budget": 15},
+    {"name": "Lace Curtain", "n": 6, "order": (5, 4, 3, 2, 1, 0), "lights": (2, 2), "views": 2,
+     "attached": False, "occluded": True, "require_views": True, "budget": 28},
+    {"name": "Twin Lamps", "n": 6, "order": (0, 5, 1, 4, 2, 3), "lights": (1, -3), "views": 2,
+     "attached": False, "occluded": True, "require_views": True, "budget": 14},
+    {"name": "Solstice Relay", "n": 7, "order": (6, 5, 4, 3, 2, 1, 0), "lights": (-2, -2), "views": 2,
+     "attached": False, "occluded": True, "require_views": True, "budget": 30},
+    {"name": "Sunspool Parade", "n": 7, "order": (0, 6, 1, 5, 2, 4, 3), "lights": (2, -3), "views": 2,
+     "attached": False, "occluded": True, "require_views": True, "budget": 16},
+]
+
+
+def projection(identity, light):
+    return HEIGHTS[identity] * abs(light) + WIDTHS[identity]
+
+
+def target_order(level):
+    identities = range(level["n"])
+    lights = level["lights"]
+    if len(set(lights)) > 1:
+        return tuple(sorted(identities, key=lambda identity: tuple(projection(identity, light) for light in lights)))
+    light = lights[0]
+    return tuple(sorted(identities, key=lambda identity: projection(identity, light), reverse=light < 0))
+
+
+def start_state(level):
+    return tuple(level["order"]), 0, 0, 1, 2
+
+
+def transition(level, state, action):
+    order, cursor, view, seen, chances = state
+    if chances <= 0:
+        return state
+    if action == 1 and level["views"] > 1:
+        view = (view + 1) % level["views"]
+        return order, cursor, view, seen | (1 << view), chances
+    if action == 3:
+        return order, (cursor - 1) % (len(order) - 1), view, seen, chances
+    if action == 4:
+        return order, (cursor + 1) % (len(order) - 1), view, seen, chances
+    if action == 5:
+        revised = list(order)
+        revised[cursor], revised[cursor + 1] = revised[cursor + 1], revised[cursor]
+        return tuple(revised), cursor, view, seen, chances
+    return state
+
+
+def solved(level, state):
+    order, _cursor, _view, seen, chances = state
+    all_views = (1 << level["views"]) - 1
+    return order == target_order(level) and (not level.get("require_views") or seen == all_views) and chances > 0
+
+
+def submit_transition(level, state):
+    if solved(level, state):
+        return state
+    order, cursor, view, seen, chances = state
+    return order, cursor, view, seen, chances - 1
+
+
+class ParadeDisplay(RenderableUserDisplay):
+    def __init__(self, game): self.game = game
+
+    @staticmethod
+    def _disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                d = (x - cx) ** 2 + (y - cy) ** 2
+                if d <= radius ** 2 and (not hollow or d >= max(0, radius - 2) ** 2): frame[y, x] = color
+
+    @staticmethod
+    def _line(frame, a, b, color, dotted=False):
+        x0, y0 = a; x1, y1 = b; steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for i in range(steps + 1):
+            if dotted and i % 3 == 1: continue
+            x = x0 + (x1 - x0) * i // steps; y = y0 + (y1 - y0) * i // steps
+            if 0 <= x < 64 and 0 <= y < 64: frame[y, x] = color
+
+    @staticmethod
+    def _xs(n):
+        # Seven-body scenes use compact silhouettes and wider slot spacing;
+        # live/target shadow endpoints are separately inset in _shadow.
+        if n >= 7:
+            xs = tuple(round(10 + 44 * i / (n - 1)) for i in range(n))
+        else:
+            xs = tuple(round(12 + 39 * i / (n - 1)) for i in range(n))
+        gap = min(b - a for a, b in zip(xs, xs[1:]))
+        return xs, gap
+
+    def _background(self, frame):
+        frame[:, :] = PAPER
+        frame[3:48, 3:61] = PEARL
+        for y in range(5, 47, 7): frame[y, 5 + y % 4:59:8] = ASH
+        frame[13:31, 4:60] = AQUA
+        frame[31:48, 4:60] = GOLD
+        # Scalloped paper proscenium and stitched footlights.
+        for x in range(5, 60, 6):
+            self._disc(frame, (x, 4), 3, CORAL)
+            self._disc(frame, (x, 47), 2, ROSE)
+        frame[49:63, 3:61] = PEARL
+        for x in range(5, 60, 5): frame[61:63, x:x + 2] = EARTH
+
+    def _profile(self, frame, identity, center, color=None, tiny=False, compact=False):
+        x, y = center; color = COLORS[identity] if color is None else color
+        kind = identity % 7
+        if tiny:
+            # Homologous endpoint miniatures fit inside a five-pixel box, even
+            # at the far-west and far-east shadow clamps.
+            if kind == 0:
+                self._disc(frame, (x, y - 2), 1, color)
+                frame[max(0, y - 1):min(64, y + 3), max(0, x - 1):min(64, x + 2)] = color
+            elif kind == 1:
+                for row in range(4):
+                    span = min(2, row)
+                    yy = y - 2 + row
+                    frame[yy, max(0, x - span):min(64, x + span + 1)] = color
+            elif kind == 2:
+                self._line(frame, (x, y - 2), (x, y + 2), color)
+                self._line(frame, (x - 2, y), (x + 2, y), color)
+            elif kind == 3:
+                self._disc(frame, (x, y), 2, color, hollow=True)
+            elif kind == 4:
+                self._line(frame, (x - 2, y + 2), (x, y - 2), color)
+                self._line(frame, (x, y - 2), (x + 2, y + 2), color)
+                self._line(frame, (x - 2, y + 2), (x + 2, y + 2), color)
+            elif kind == 5:
+                self._line(frame, (x - 2, y - 2), (x - 2, y + 2), color)
+                self._line(frame, (x + 2, y - 2), (x + 2, y + 2), color)
+                self._line(frame, (x - 2, y), (x + 2, y), color)
+            else:
+                self._disc(frame, (x, y), 2, color)
+                frame[max(0, y - 1):min(64, y + 1), x] = PEARL
+            return
+
+        if compact:
+            # The late seven-body parade retains all seven silhouette families
+            # in at most seven pixels, leaving visible air between neighbors.
+            if kind == 0:
+                self._disc(frame, (x, y - 3), 2, color)
+                frame[y - 1:y + 5, x - 1:x + 2] = color
+            elif kind == 1:
+                for row in range(7):
+                    span = min(2, row // 2)
+                    frame[y - 4 + row, x - span:x + span + 1] = color
+            elif kind == 2:
+                frame[y - 4:y + 5, x] = color; frame[y - 1:y + 1, x - 3:x + 4] = color
+                self._disc(frame, (x, y - 4), 1, color)
+            elif kind == 3:
+                self._disc(frame, (x, y - 2), 3, color, hollow=True); frame[y:y + 5, x] = color
+            elif kind == 4:
+                self._line(frame, (x - 3, y + 4), (x, y - 4), color)
+                self._line(frame, (x, y - 4), (x + 3, y + 4), color)
+                self._line(frame, (x - 3, y + 4), (x + 3, y + 4), color)
+            elif kind == 5:
+                frame[y - 4:y + 5, x - 2:x - 1] = color
+                frame[y - 4:y + 5, x + 1:x + 2] = color
+                frame[y - 1:y + 1, x - 2:x + 2] = color
+            else:
+                self._disc(frame, (x, y - 2), 3, color)
+                frame[y - 3:y - 1, x] = PEARL; frame[y:y + 5, x] = color
+            frame[y, max(0, x - 2):min(64, x + 3):2] = PAPER
+            return
+
+        r = 1 if tiny else 2
+        if kind == 0:
+            self._disc(frame, (x, y - 4), r + 1, color)
+            frame[y - 2:y + 5, x - 2:x + 3] = color
+        elif kind == 1:
+            for row in range(8):
+                span = min(row // 2, 3)
+                frame[y - 5 + row, x - span:x + span + 1] = color
+        elif kind == 2:
+            frame[y - 5:y + 5, x] = color; frame[y - 2:y, x - 4:x + 5] = color
+            self._disc(frame, (x, y - 5), r, color)
+        elif kind == 3:
+            self._disc(frame, (x, y - 3), 4, color, hollow=True); frame[y:y + 5, x - 1:x + 2] = color
+        elif kind == 4:
+            self._line(frame, (x - 4, y + 4), (x, y - 5), color)
+            self._line(frame, (x, y - 5), (x + 4, y + 4), color)
+            frame[y + 3:y + 5, x - 4:x + 5] = color
+        elif kind == 5:
+            frame[y - 5:y + 5, x - 3:x - 1] = color; frame[y - 5:y + 5, x + 1:x + 3] = color
+            frame[y - 1:y + 1, x - 3:x + 3] = color
+        else:
+            self._disc(frame, (x, y - 3), 4, color)
+            frame[y - 3:y, x - 1:x + 2] = PEARL
+            frame[y:y + 5, x - 1:x + 2] = color
+        # Fibrous cut-paper incision makes every body material legible.
+        frame[y, max(0, x - 3):min(64, x + 4):2] = PAPER
+
+    def _shadow(self, frame, identity, origin, light, target=False, faint=False):
+        x, y = origin; direction = 1 if light > 0 else -1
+        # Map physical projection to its per-view rank.  The seven possible
+        # lengths (4..10) fit every authored slot without edge clipping and are
+        # injective even when raw coefficients differ by only one unit.
+        ranked = sorted(range(self.game.level["n"]), key=lambda item: projection(item, light))
+        rank = ranked.index(identity)
+        length = 4 + rank
+        color = ASH if faint else CHARCOAL
+        # Three-pixel endpoint inset keeps both the neutral target socket and
+        # every five-pixel homologous miniature fully visible.
+        tip = (max(3, min(60, x + direction * length)), y + 4)
+        self._line(frame, (x, y), tip, color, dotted=faint)
+        # A perpendicular rank staff redundantly preserves magnitude when a
+        # profile overlaps the diagonal line or the shadow is shown faintly.
+        self._line(frame, (x, y), (x, y - 2 - rank), color, dotted=faint)
+        frame[max(0, y - 2 - rank), max(0, x - 1):min(64, x + 2)] = color
+        # Live shadows retain homologous endpoint silhouettes.  Target sockets
+        # deliberately do not: their neutral endpoint and projected length make
+        # lamp direction/strength the rule instead of giving away identity.
+        if not target:
+            self._profile(frame, identity, tip, color=color, tiny=True)
+        if target:
+            self._disc(frame, tip, 3, EARTH, hollow=True)
+            frame[tip[1], max(0, tip[0] - 2):min(64, tip[0] + 3)] = EARTH
+
+    def _sun(self, frame):
+        g = self.game; light = g.level["lights"][g.state[2]]
+        center = (7, 10) if light > 0 else (57, 10)
+        self._disc(frame, center, 5, GOLD)
+        for dx, dy in ((0, -7), (0, 7), (-7, 0), (7, 0), (-5, -5), (5, 5), (-5, 5), (5, -5)):
+            self._line(frame, center, (center[0] + dx, center[1] + dy), CORAL)
+        # Strength uses concentric geometry rather than hue.
+        for ring in range(max(0, abs(light) - 1)): self._disc(frame, center, 7 + ring * 2, CORAL, hollow=True)
+
+    def _selection(self, frame, left, right):
+        """A complete two-body sewing crown exposes the selected swap pair."""
+        self._line(frame, (left - 3, 17), (left - 3, 14), VIOLET)
+        self._line(frame, (left - 3, 14), (left + 3, 14), VIOLET)
+        self._line(frame, (right + 3, 17), (right + 3, 14), VIOLET)
+        self._line(frame, (right - 3, 14), (right + 3, 14), VIOLET)
+        self._line(frame, (left + 3, 15), (right - 3, 15), VIOLET, dotted=True)
+        self._disc(frame, ((left + right) // 2, 15), 2, GOLD, hollow=True)
+
+    def _curtain(self, frame, view, side=None):
+        if side is None:
+            side = 1 if view == 0 else 58
+        side = max(0, min(60, side))
+        frame[18:46, side:side + 4] = ROSE
+        for y in range(20 + view, 45, 5): self._disc(frame, (side + 1, y), 1, PAPER)
+
+    def _stage(self, frame, skip_slots=(), draw_cursor=True, draw_curtain=True):
+        g = self.game; order, cursor, view, _seen, _chances = g.state
+        xs, gap = self._xs(len(order)); light = g.level["lights"][view]
+        compact = len(order) >= 7
+        skipped = set(skip_slots)
+        for slot, identity in enumerate(order):
+            if slot not in skipped:
+                self._profile(frame, identity, (xs[slot], 26), compact=compact)
+                shadow_y = 31 if g.level.get("attached") else 38
+                visible = not g.level.get("occluded") or identity % g.level["views"] == view
+                if visible:
+                    self._shadow(frame, identity, (xs[slot], shadow_y), light)
+                else:
+                    # The lace pane withholds both identity endpoint and magnitude;
+                    # the other view is genuine evidence, not a cosmetic toggle.
+                    self._disc(frame, (xs[slot], shadow_y + 2), 3, ASH, hollow=True)
+                    frame[shadow_y + 1:shadow_y + 4, xs[slot] - 1:xs[slot] + 2] = PEARL
+        if draw_cursor:
+            self._selection(frame, xs[cursor], xs[cursor + 1])
+        wanted = target_order(g.level)
+        for slot, identity in enumerate(wanted):
+            visible = not g.level.get("occluded") or identity % g.level["views"] == view
+            if visible:
+                self._shadow(frame, identity, (xs[slot], 53), light, target=True)
+            else:
+                self._disc(frame, (xs[slot], 56), 3, ASH, hollow=True)
+                frame[55:58, xs[slot] - 1:xs[slot] + 2] = PEARL
+        # Lace view curtain has different holes in each pane.
+        if g.level["views"] > 1 and draw_curtain:
+            self._curtain(frame, view)
+
+    def _hud(self, frame):
+        g = self.game
+        # Exact physical budget: six possible five-stitch loom flowers.  Live
+        # stitches are larger diamonds; spent stitches remain as small ash
+        # pinholes, so count never depends on color alone or relocates at five.
+        stitch_positions = ((0, 0), (0, -2), (2, 0), (0, 2), (-2, 0))
+        for group in range((g.budget_max + 4) // 5):
+            cx, cy = 18 + group * 6, 7
+            self._disc(frame, (cx, cy), 3, ASH, hollow=True)
+            for stitch, (dx, dy) in enumerate(stitch_positions):
+                number = group * 5 + stitch
+                if number >= g.budget_max:
+                    continue
+                if number < g.budget_left:
+                    self._disc(frame, (cx + dx, cy + dy), 1, VIOLET)
+                else:
+                    frame[cy + dy, cx + dx] = ASH
+        for i in range(2):
+            x = 55 + i * 4
+            if i < g.state[4]: self._disc(frame, (x, 61), 2, ROSE, hollow=True)
+            else:
+                self._line(frame, (x - 2, 59), (x + 2, 63), RED)
+                self._line(frame, (x + 2, 59), (x - 2, 63), RED)
+        if g.level.get("require_views"):
+            for view in range(g.level["views"]):
+                x = 28 + view * 8
+                if g.state[3] & (1 << view):
+                    self._disc(frame, (x, 60), 3, GOLD, hollow=True)
+                    frame[60, x] = GOLD
+                else: frame[59:62, x - 2:x + 3] = ASH
+
+    def _loss_overlay(self, frame):
+        frame[18:46, 29:35] = RED
+        frame[24:40:4, 5:59] = RED
+
+    def _idle_overlay(self, frame):
+        g = self.game
+        if g.intro_mark:
+            # An opening thread arch makes reset distinct without covering the
+            # selected-pair crown or the first causal comparison.
+            self._line(frame, (19, 11), (45, 11), CORAL, dotted=True)
+            self._disc(frame, (19, 11), 2, GOLD, hollow=True)
+            self._disc(frame, (45, 11), 2, GOLD, hollow=True)
+            for x in (25, 32, 39):
+                self._line(frame, (x, 11), (x, 13), CORAL)
+        if g.terminal_hold == "loss":
+            self._loss_overlay(frame)
+        elif g.terminal_hold == "win":
+            for x in range(8, 58, 7):
+                self._disc(frame, (x, 20 + x % 5), 2, GREEN)
+
+    def _render_static(self, frame, skip_slots=(), draw_cursor=True, draw_curtain=True):
+        self._background(frame)
+        self._sun(frame)
+        self._stage(frame, skip_slots=skip_slots, draw_cursor=draw_cursor,
+                    draw_curtain=draw_curtain)
+        self._hud(frame)
+
+    def _moving_swap(self, frame, p, span):
+        g = self.game; before = g.anim_before
+        order, cursor, view, _seen, _chances = before
+        xs, _ = self._xs(len(order)); compact = len(order) >= 7
+        first, second = order[cursor], order[cursor + 1]
+        x1 = xs[cursor] + (xs[cursor + 1] - xs[cursor]) * p // span
+        x2 = xs[cursor + 1] + (xs[cursor] - xs[cursor + 1]) * p // span
+        lift = 16 * p * (span - p) // max(1, span * span)
+        self._profile(frame, first, (x1, 26 - lift), compact=compact)
+        self._profile(frame, second, (x2, 26 + lift // 2), compact=compact)
+        shadow_y = 31 if g.level.get("attached") else 38
+        light = g.level["lights"][view]
+        for identity, x in ((first, x1), (second, x2)):
+            visible = not g.level.get("occluded") or identity % g.level["views"] == view
+            if visible:
+                self._shadow(frame, identity, (x, shadow_y), light)
+            else:
+                self._disc(frame, (x, shadow_y + 2), 3, ASH, hollow=True)
+                frame[shadow_y + 1:shadow_y + 4, x - 1:x + 2] = PEARL
+
+    def _animation(self, frame, span):
+        g = self.game; p = g.anim_progress
+        before, after = g.anim_before, g.pending_state
+        if g.anim_kind == "cursor":
+            xs, _ = self._xs(len(before[0]))
+            left = xs[before[1]] + (xs[after[1]] - xs[before[1]]) * p // span
+            right = xs[before[1] + 1] + (xs[after[1] + 1] - xs[before[1] + 1]) * p // span
+            self._selection(frame, left, right)
+        elif g.anim_kind == "swap":
+            self._moving_swap(frame, p, span)
+        elif g.anim_kind == "miss":
+            # One continuous rejection seam grows toward the chance loops; no
+            # alternating fill, radius, or position is used as a flash.
+            reach = 2 + 10 * p // span
+            self._line(frame, (32 - reach, 30 - reach // 2),
+                       (32 + reach, 30 + reach // 2), RED)
+            self._line(frame, (32 + reach, 30 - reach // 2),
+                       (32 - reach, 30 + reach // 2), RED)
+        elif g.anim_kind == "success":
+            for radius in range(3, min(29, 3 + p * 4), 5):
+                self._disc(frame, (32, 34), radius, GREEN, hollow=True)
+
+    def _view_transition(self, frame, span):
+        """One lace curtain spatially replaces old evidence with new evidence."""
+        g = self.game; p = g.anim_progress
+        if p >= span:
+            current = g.state; g.state = g.pending_state
+            self._render_static(frame)
+            if g.pending_terminal == "loss":
+                self._loss_overlay(frame)
+            g.state = current
+            return
+
+        old_frame = np.zeros_like(frame); new_frame = np.zeros_like(frame)
+        current = g.state
+        g.state = g.anim_before
+        self._render_static(old_frame, draw_curtain=False)
+        g.state = g.pending_state
+        self._render_static(new_frame, draw_curtain=False)
+        g.state = current
+        after_view = g.pending_state[2]
+        if after_view:
+            side = 1 + 57 * p // span
+            frame[:, :] = old_frame
+            frame[:, :side] = new_frame[:, :side]
+        else:
+            side = 58 - 57 * p // span
+            frame[:, :] = old_frame
+            frame[:, side + 4:] = new_frame[:, side + 4:]
+        self._curtain(frame, after_view, side)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        g = self.game
+        if not g.anim_kind:
+            self._render_static(frame)
+            self._idle_overlay(frame)
+            return frame
+
+        span = max(1, g.anim_total - 1)
+        if g.anim_kind == "view":
+            self._view_transition(frame, span)
+            return frame
+
+        preview_settle = (g.pending_state is not None and g.anim_kind != "success"
+                          and g.anim_progress >= span)
+        current = g.state
+        if preview_settle:
+            g.state = g.pending_state
+        skip_slots = ()
+        draw_cursor = True
+        if not preview_settle and g.anim_kind == "swap":
+            cursor = g.anim_before[1]
+            skip_slots = (cursor, cursor + 1)
+        if not preview_settle and g.anim_kind == "cursor":
+            draw_cursor = False
+        self._render_static(frame, skip_slots=skip_slots, draw_cursor=draw_cursor)
+        if preview_settle:
+            if g.pending_terminal == "loss":
+                self._loss_overlay(frame)
+        else:
+            self._animation(frame, span)
+        if preview_settle:
+            g.state = current
+        return frame
+
+
+class Q062(ARCBaseGame):
+    def __init__(self):
+        self.display = ParadeDisplay(self); self.level = LEVELS[0]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0; self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0; self.anim_before = self.state
+        self.pending_state = None; self.pending_terminal = None; self.intro_mark = True; self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"]) for item in LEVELS]
+        super().__init__("q062", levels, Camera(0, 0, 64, 64, PAPER, PAPER, [self.display]), False, len(levels), [1, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = None; self.pending_terminal = None; self.intro_mark = True; self.terminal_hold = None
+
+    def _begin(self, kind, frames, state, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames; self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = state; self.pending_terminal = terminal
+
+    def _finish(self):
+        terminal = self.pending_terminal; self.state = self.pending_state
+        self.anim_kind = None; self.pending_state = None; self.pending_terminal = None
+        if terminal == "win": self.terminal_hold = "win"; self.next_level()
+        elif terminal == "loss" or self.budget_left <= 0: self.terminal_hold = "loss"; self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1; self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0: self._finish()
+            return
+        action = self.action.id.value
+        if action == 0: self.complete_action(); return
+        self.intro_mark = False
+        if action == 6:
+            won = solved(self.level, self.state); after = self.state if won else submit_transition(self.level, self.state)
+            # Wrong submissions still cost one action, preserving random-policy
+            # resistance.  L8 alone carries one explicit recovery stitch above
+            # its fourteen-action physical solution.
+            if not won:
+                self.budget_left -= 1
+            self._begin("success" if won else "miss", 7, after,
+                        "win" if won else "loss" if after[4] <= 0 or self.budget_left <= 0 else None)
+            return
+        after = transition(self.level, self.state, action)
+        if after == self.state:
+            self._begin("miss", 4, after); return
+        self.budget_left -= 1
+        kind = "view" if action == 1 else "cursor" if action in (3, 4) else "swap"
+        self._begin(kind, 5 if kind != "swap" else 7, after, "loss" if self.budget_left <= 0 else None)

--- a/data/community-games/sonpham/q070_v2_q070.py
+++ b/data/community-games/sonpham/q070_v2_q070.py
@@ -1,0 +1,741 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q070-v2 High Alpine Signal Survey.
+
+Triangulate one deterministic hidden route hypothesis by sending limited range
+sweeps from patterned mountain beacons.  Every observation visibly contracts
+the remaining family; target contact never reveals truth.  Later surveys add
+asymmetric baselines, climb-cost instruments, occluded bearings, a previewed
+beacon relocation, and deterministic target drift.
+
+The two-beacon opener is an ordered control tutorial. Every later level offers
+one more large patterned station than there are scan stones. Selecting a
+station previews its exact surviving family; only distinct informative scans
+consume a stone, while alias stations and repeats recoil at zero cost.
+
+Glow-up mechanic draw:
+* accepted mx003 uncertainty: every deterministic scan partitions and shrinks
+  an explicit hidden-state family before a fix can be attempted;
+* rejected mx004: a counter-combat layer would replace localization with type
+  matching rather than deepen evidence gathering;
+* rejected mx006: hex adjacency would decorate the relief map without changing
+  this game's range contours, so the survey retains irregular alpine terrain.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+SNOW, CLOUD, GRANITE, SHALE, INK, NIGHT = 0, 1, 2, 4, 5, 3
+MAGENTA, ROSE, RED, SKY, ICE, SUN, ALPINE, MAROON, MEADOW, VIOLET = range(6, 16)
+
+TERMINAL_INDEX = 10
+ACTIVE, WIN, LOSS = 0, 2, 3
+UNAVAILABLE = 255
+
+
+def beacon(position, metric="range", *, decoy=False):
+    return {
+        "position": tuple(position),
+        "metric": metric,
+        "decoy": bool(decoy),
+    }
+
+
+def static_tracks(sites):
+    return tuple((tuple(site),) for site in sites)
+
+
+def survey(
+    name,
+    sites,
+    target,
+    beacons,
+    scans,
+    budget,
+    *,
+    ridge=None,
+    relocation=None,
+    drift=False,
+    free_scan=False,
+    tracks=None,
+    fix_sites=None,
+):
+    tracks = tuple(tuple(tuple(point) for point in track) for track in (
+        tracks if tracks is not None else static_tracks(sites)))
+    authored_fix_sites = []
+    for point in fix_sites or ():
+        if tuple(point) not in authored_fix_sites:
+            authored_fix_sites.append(tuple(point))
+    for track in tracks:
+        for point in track:
+            if point not in authored_fix_sites:
+                authored_fix_sites.append(point)
+    return {
+        "name": name,
+        "tracks": tracks,
+        "fix_sites": tuple(authored_fix_sites),
+        "target": int(target),
+        "beacons": tuple(deepcopy(beacons)),
+        "scans": int(scans),
+        "budget": int(budget),
+        "ridge": ridge,
+        "relocation": deepcopy(relocation),
+        "drift": bool(drift),
+        # Level 1 teaches the beacon-selection control in a fixed order. Every
+        # later survey exposes one extra station and lets the player compare
+        # exact affected-family previews before choosing N informative scans.
+        "scan_order": () if free_scan else tuple(range(scans)),
+    }
+
+
+# The data are authored as hypothesis families, never generated from an answer
+# sequence.  Candidate order also defines the snapped diamond-fix route.
+LEVELS = [
+    survey(
+        "Snowline Ranges",
+        ((1, 3), (3, 2), (8, 3), (10, 4), (2, 3), (9, 8), (4, 9),
+         (5, 6), (7, 9), (10, 9), (1, 8), (6, 2), (11, 6), (3, 7)), 7,
+        (beacon((1, 1)), beacon((10, 1))), scans=2, budget=11,
+    ),
+    survey(
+        "Third Bearing",
+        ((4, 10), (2, 8), (4, 1), (4, 9), (9, 1), (9, 9), (5, 3),
+         (7, 3), (10, 7), (1, 7), (6, 9), (8, 4), (7, 1), (3, 5)), 7,
+        (beacon((1, 2)), beacon((6, 9), decoy=True),
+         beacon((5, 6)), beacon((9, 2))),
+        scans=3, budget=15, free_scan=True,
+    ),
+    survey(
+        "Asymmetric Cairns",
+        ((9, 2), (1, 4), (2, 3), (8, 4), (5, 6), (2, 7), (7, 8),
+         (2, 1), (9, 6), (4, 9), (10, 8), (6, 3), (3, 7), (8, 8)), 7,
+        (beacon((11, 2)), beacon((5, 4)),
+         beacon((9, 9), decoy=True), beacon((3, 10))),
+        scans=3, budget=15, free_scan=True,
+    ),
+    survey(
+        "Climb-Cost Dial",
+        ((10, 5), (2, 8), (4, 3), (4, 7), (6, 2), (6, 8), (8, 7),
+         (8, 3), (10, 2), (10, 8), (3, 5), (9, 5), (5, 9), (7, 1)), 7,
+        (beacon((6, 5), "climb"), beacon((3, 1), decoy=True),
+         beacon((1, 5)), beacon((11, 5))),
+        scans=3, budget=15, free_scan=True,
+    ),
+    survey(
+        "Ridge Shadow",
+        ((2, 2), (2, 8), (4, 3), (4, 7), (6, 8), (7, 7), (10, 4),
+         (8, 6), (10, 2), (10, 8), (3, 5), (6, 2), (9, 9), (5, 5)), 7,
+        (beacon((11, 1), decoy=True), beacon((1, 5)),
+         beacon((6, 1)), beacon((2, 2), "sight")),
+        scans=3, budget=16, free_scan=True,
+        ridge={"x": 7, "gap": (7, 8)},
+    ),
+    survey(
+        "Relocated Baseline",
+        ((2, 2), (2, 8), (4, 2), (4, 8), (6, 3), (6, 7), (8, 8),
+         (8, 2), (10, 3), (10, 7), (3, 5), (9, 5), (5, 9), (7, 1)), 7,
+        (beacon((7, 10)), beacon((10, 9), decoy=True),
+         beacon((1, 4)), beacon((6, 5))),
+        scans=3, budget=17, free_scan=True,
+        relocation={"beacon": 3, "to": (11, 3)},
+    ),
+    survey(
+        "Drifting Transponder",
+        (), 3,
+        (beacon((11, 10)), beacon((10, 9), decoy=True),
+         beacon((6, 1)), beacon((1, 7))),
+        scans=3, budget=17, drift=True, free_scan=True,
+        tracks=(
+            ((4, 3), (5, 4), (6, 5), (7, 6)),
+            ((4, 7), (5, 6), (6, 5), (7, 4)),
+            ((7, 3), (7, 4), (8, 5), (9, 6)),
+            ((7, 7), (7, 6), (8, 5), (9, 4)),
+            ((9, 2), (8, 3), (7, 4), (6, 5)),
+            ((9, 8), (8, 7), (7, 6), (6, 5)),
+            ((6, 8), (6, 5), (4, 4), (5, 5)),
+            ((8, 6), (8, 5), (8, 4), (8, 3)),
+        ),
+        fix_sites=((1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6),
+                   (7, 7), (8, 8), (9, 8), (9, 4), (10, 3), (8, 2),
+                   (6, 2), (4, 2), (2, 4), (3, 7), (7, 3), (10, 7)),
+    ),
+    survey(
+        "High Alpine Signal",
+        (), 5,
+        (beacon((1, 5)), beacon((10, 2)), beacon((3, 9), "climb"),
+         beacon((2, 1), "sight"), beacon((11, 8), decoy=True)),
+        scans=4, budget=21, drift=True, free_scan=True,
+        ridge={"x": 7, "gap": (5, 6)},
+        relocation={"beacon": 3, "to": (3, 9)},
+        tracks=(
+            ((3, 2), (4, 3), (5, 4), (6, 5), (8, 6)),
+            ((3, 8), (4, 7), (5, 6), (6, 5), (8, 4)),
+            ((5, 2), (6, 3), (7, 4), (8, 5), (9, 6)),
+            ((5, 8), (6, 7), (7, 6), (8, 5), (9, 4)),
+            ((8, 2), (8, 3), (9, 4), (9, 5), (10, 6)),
+            ((8, 8), (8, 7), (9, 6), (9, 5), (10, 4)),
+            ((10, 3), (9, 4), (8, 5), (7, 6), (6, 7)),
+            ((10, 7), (9, 6), (8, 5), (7, 4), (6, 3)),
+            ((9, 7), (7, 6), (7, 4), (8, 4), (9, 3)),
+            ((10, 6), (6, 5), (8, 5), (10, 1), (9, 2)),
+            # A high-route mirror agrees with any tempting three-station fix
+            # and with the final station's plain range, but its climb-cost
+            # signature diverges. It keeps both the fourth stone and typed
+            # altimeter evidence causally necessary in the finale.
+            ((8, 2), (8, 7), (9, 6), (1, 1), (1, 1)),
+        ),
+        fix_sites=((1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6),
+                   (7, 7), (8, 8), (9, 8), (10, 7), (10, 4), (9, 3),
+                   (8, 2), (7, 1), (5, 1), (3, 1), (2, 4), (2, 7),
+                   (4, 9), (7, 9)),
+    ),
+]
+
+
+# Scan-first witnesses are intentionally human-legible.  Independent BFS may
+# return an equal-length plan that parks the cursor before gathering evidence;
+# target contact still reveals nothing and both orders have the same cost.
+KNOWN_SOLUTIONS = (
+    (4, 3, 4, *(1,) * 7, 6),
+    (4, 3, 3, 4, 3, 4, *(1,) * 7, 6),
+    (4, 3, 4, 3, 3, 4, *(1,) * 7, 6),
+    (4, 3, 3, 4, 3, 4, *(1,) * 7, 6),
+    (3, 4, 3, 4, 3, 4, *(1,) * 7, 6),
+    (4, 3, 3, 4, 5, 5, 4, *(1,) * 7, 6),
+    (4, 3, 3, 4, 3, 4, *(2,) * 9, 6),
+    (4, 3, 4, 3, 4, 5, 5, 4, *(2,) * 10, 6),
+)
+for _level, _solution in zip(LEVELS, KNOWN_SOLUTIONS):
+    _level["known_solution"] = tuple(_solution)
+
+
+def elevation(point):
+    x, y = point
+    return (3 * x + 2 * y + x * y) % 6
+
+
+def current_position(level, hypothesis, phase):
+    track = level["tracks"][hypothesis]
+    return track[min(phase, len(track) - 1)]
+
+
+def beacon_position(level, relocated, index):
+    relocation = level["relocation"]
+    if relocated and relocation and index == relocation["beacon"]:
+        return tuple(relocation["to"])
+    return tuple(level["beacons"][index]["position"])
+
+
+def ridge_blocked(level, source, destination):
+    ridge = level["ridge"]
+    if not ridge:
+        return False
+    ridge_x = ridge["x"]
+    x0, y0 = source
+    x1, y1 = destination
+    if (x0 - ridge_x) * (x1 - ridge_x) >= 0 or x0 == x1:
+        return False
+    ratio = (ridge_x - x0) / (x1 - x0)
+    crossing_y = y0 + ratio * (y1 - y0)
+    low, high = ridge["gap"]
+    return not low <= crossing_y <= high
+
+
+def reading(level, beacon_index, hypothesis, phase, relocated=False):
+    if level["beacons"][beacon_index]["decoy"]:
+        return UNAVAILABLE
+    source = beacon_position(level, relocated, beacon_index)
+    destination = current_position(level, hypothesis, phase)
+    metric = level["beacons"][beacon_index]["metric"]
+    if metric == "sight" and ridge_blocked(level, source, destination):
+        return UNAVAILABLE
+    dx = abs(source[0] - destination[0])
+    dy = abs(source[1] - destination[1])
+    if metric == "climb":
+        return dx + dy + 2 * elevation(destination)
+    return dx + dy
+
+
+def scan_token(level, beacon_index, phase, relocated):
+    # A station may contribute at most one report per level. Drift changes the
+    # hypothesis family after an informative sweep; it never turns repeat
+    # clicking into a source of extra evidence.
+    del level, phase, relocated
+    return beacon_index
+
+
+def projected_candidates(level, state, beacon_index=None):
+    """Exact family preview for the currently selected survey station."""
+    beacon_index = state[1] if beacon_index is None else beacon_index
+    candidates = state[3]
+    actual = reading(level, beacon_index, level["target"], state[8], state[6])
+    projected = 0
+    for hypothesis in range(len(level["tracks"])):
+        if candidates & (1 << hypothesis) and reading(
+                level, beacon_index, hypothesis, state[8], state[6]) == actual:
+            projected |= 1 << hypothesis
+    return projected, actual
+
+
+def initial_candidates(level):
+    return (1 << len(level["tracks"])) - 1
+
+
+def start_state(level):
+    # cursor, beacon, scanned tokens, candidates, scans left, relocation
+    # preview, relocated, false-fix strikes, drift phase, last report, terminal.
+    return 0, 0, 0, initial_candidates(level), level["scans"], 0, 0, 0, 0, -1, ACTIVE
+
+
+def solved(_level, state):
+    return state[TERMINAL_INDEX] == WIN
+
+
+def singleton(mask):
+    return mask != 0 and mask & (mask - 1) == 0
+
+
+def transition(level, state, action):
+    if state[TERMINAL_INDEX] or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    cursor, selected, scanned, candidates, scans_left, preview, relocated, strikes, phase, report, _ = state
+    if action in (1, 2):
+        step = -1 if action == 1 else 1
+        cursor = (cursor + step) % len(level["fix_sites"])
+        return cursor, selected, scanned, candidates, scans_left, 0, relocated, strikes, phase, report, ACTIVE
+    if action == 3:
+        selected = (selected + 1) % len(level["beacons"])
+        return cursor, selected, scanned, candidates, scans_left, 0, relocated, strikes, phase, report, ACTIVE
+    if action == 4:
+        scan_index = level["scans"] - scans_left
+        if level["scan_order"]:
+            if scan_index >= len(level["scan_order"]):
+                return state
+            required_beacon = level["scan_order"][scan_index]
+            if selected != required_beacon:
+                return state
+        if (level["relocation"] and selected == level["relocation"]["beacon"]
+                and not relocated):
+            return state
+        token = scan_token(level, selected, phase, relocated)
+        if scans_left <= 0 or scanned & (1 << token):
+            return state
+        filtered, actual = projected_candidates(level, state, selected)
+        # A redundant station, or a station made redundant by earlier
+        # evidence, merely recoils: no scan stone or action budget is spent.
+        if filtered == candidates:
+            return state
+        next_phase = phase
+        if level["drift"]:
+            next_phase = min(
+                phase + 1,
+                max(len(track) for track in level["tracks"]) - 1,
+            )
+        return (cursor, selected, scanned | (1 << token), filtered,
+                scans_left - 1, 0, relocated, strikes, next_phase, actual, ACTIVE)
+    if action == 5:
+        relocation = level["relocation"]
+        if not relocation or relocated:
+            return state
+        if not preview:
+            return cursor, selected, scanned, candidates, scans_left, 1, relocated, strikes, phase, report, ACTIVE
+        selected = relocation["beacon"]
+        return cursor, selected, scanned, candidates, scans_left, 0, 1, strikes, phase, report, ACTIVE
+
+    target_point = current_position(level, level["target"], phase)
+    cursor_point = level["fix_sites"][cursor]
+    protocol_ready = scans_left == 0
+    if level["relocation"]:
+        protocol_ready = protocol_ready and bool(relocated)
+    if level["drift"]:
+        protocol_ready = protocol_ready and phase >= level["scans"]
+    if (protocol_ready and singleton(candidates)
+            and candidates & (1 << level["target"])
+            and cursor_point == target_point):
+        return state[:TERMINAL_INDEX] + (WIN,)
+    strikes += 1
+    return state[:7] + (strikes,) + state[8:TERMINAL_INDEX] + (
+        LOSS if strikes >= 2 else ACTIVE,
+    )
+
+
+def action_cost(before, after):
+    if after == before:
+        return 0
+    if after[7] > before[7]:
+        return 0
+    return 1
+
+
+def map_point(point):
+    x, y = point
+    return 7 + x * 4, 8 + y * 4
+
+
+class SurveyDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def line(frame, start, end, color, dotted=False, width=1):
+        x0, y0 = start; x1, y1 = end
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 4 in (1, 2):
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            for offset in range(width):
+                if 0 <= y + offset < 64 and 0 <= x < 64:
+                    frame[y + offset, x] = color
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        inner = max(0, radius - 1) ** 2
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius ** 2 and (not hollow or distance >= inner):
+                    frame[y, x] = color
+
+    @classmethod
+    def diamond(cls, frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for dy in range(-radius, radius + 1):
+            reach = radius - abs(dy)
+            if hollow:
+                frame[cy + dy, cx - reach] = color
+                frame[cy + dy, cx + reach] = color
+            else:
+                frame[cy + dy, cx - reach:cx + reach + 1] = color
+
+    @classmethod
+    def triangle(cls, frame, center, radius, color, pattern=0):
+        cx, cy = center
+        for row in range(radius + 1):
+            y = cy - radius // 2 + row
+            reach = row
+            cls.line(frame, (cx - reach, y), (cx + reach, y), color,
+                     dotted=bool(pattern and row % 2))
+        cls.line(frame, (cx - radius, cy + radius // 2),
+                 (cx + radius, cy + radius // 2), INK)
+        if pattern == 1:
+            cls.line(frame, (cx, cy - 1), (cx, cy + radius // 2), SNOW)
+        elif pattern == 2:
+            cls.diamond(frame, (cx, cy + 1), 1, SNOW)
+        elif pattern == 3:
+            cls.disc(frame, (cx, cy + 1), 1, SNOW, hollow=True)
+
+    def background(self, frame):
+        frame[:, :] = SNOW
+        # Layered relief contours and tree-line stipple: no rectangular board.
+        for band, color in ((0, CLOUD), (1, ICE), (2, GRANITE), (3, CLOUD)):
+            points = []
+            for x in range(2, 63, 2):
+                y = 11 + band * 11 + round(3 * math.sin((x + band * 7) / 8))
+                points.append((x, y))
+            for a, b in zip(points, points[1:]):
+                self.line(frame, a, b, color, dotted=band % 2 == 0)
+        for x in range(4, 62, 7):
+            y = 54 + ((x * 5) % 7) // 2
+            self.triangle(frame, (x, y), 2, MEADOW, pattern=x % 3)
+        for center, radius in (((11, 18), 7), ((50, 27), 9), ((30, 42), 6)):
+            self.disc(frame, center, radius, CLOUD, hollow=True)
+            self.disc(frame, (center[0] + 1, center[1] - 1), radius - 2,
+                      ICE, hollow=True)
+
+    def ridge(self, frame):
+        ridge = self.game.level["ridge"]
+        if not ridge:
+            return
+        x = map_point((ridge["x"], 0))[0]
+        low, high = ridge["gap"]
+        low_y = map_point((0, low))[1]; high_y = map_point((0, high))[1]
+        for y in list(range(8, low_y)) + list(range(high_y, 53)):
+            reach = 2 + (y % 3)
+            self.line(frame, (x - reach, y), (x + reach, y), SHALE,
+                      dotted=y % 4 == 0)
+        self.diamond(frame, (x, (low_y + high_y) // 2), 2, SUN, hollow=True)
+
+    def candidates(self, frame, state):
+        phase = state[8]
+        preview = None
+        if not self.game.level["scan_order"] and state[4] > 0:
+            preview, _report = projected_candidates(self.game.level, state)
+        occupied = {}
+        for hypothesis in range(len(self.game.level["tracks"])):
+            point = current_position(self.game.level, hypothesis, phase)
+            occupied.setdefault(point, []).append(hypothesis)
+        for point, hypotheses in occupied.items():
+            center = map_point(point)
+            live = any(state[3] & (1 << index) for index in hypotheses)
+            self.disc(frame, center, 2, SKY if live else GRANITE,
+                      hollow=live)
+            if live:
+                spokes = sum(bool(state[3] & (1 << index)) for index in hypotheses)
+                for index in range(spokes):
+                    self.line(frame, center,
+                              (center[0] + (index % 3) - 1, center[1] - 3),
+                              VIOLET)
+                if preview is not None:
+                    survives = any(
+                        state[3] & preview & (1 << index)
+                        for index in hypotheses)
+                    removed = any(
+                        state[3] & ~preview & (1 << index)
+                        for index in hypotheses)
+                    if survives:
+                        self.diamond(frame, center, 4, VIOLET, hollow=True)
+                    if removed:
+                        self.line(frame, (center[0] - 3, center[1] + 3),
+                                  (center[0] + 3, center[1] - 3), ROSE,
+                                  dotted=True)
+            else:
+                self.line(frame, (center[0] - 2, center[1] - 2),
+                          (center[0] + 2, center[1] + 2), GRANITE)
+
+    def beacons(self, frame, state):
+        scan_index = self.game.level["scans"] - state[4]
+        scan_order = self.game.level["scan_order"]
+        required = scan_order[scan_index] if scan_index < len(scan_order) else -1
+        for index, item in enumerate(self.game.level["beacons"]):
+            center = map_point(beacon_position(self.game.level, state[6], index))
+            color = ALPINE if index == state[1] else MAROON
+            if index == required:
+                self.disc(frame, center, 6, SUN, hollow=True)
+                self.diamond(frame, (center[0], center[1] - 7), 2, VIOLET)
+            self.triangle(frame, center, 4, color, pattern=index)
+            metric = item["metric"]
+            if metric == "climb":
+                self.line(frame, (center[0] - 3, center[1] + 5),
+                          (center[0] + 3, center[1] - 2), SUN, dotted=True)
+            elif metric == "sight":
+                self.disc(frame, (center[0], center[1] + 1), 2, ICE,
+                          hollow=True)
+
+    def instruments(self, frame, state):
+        # Countable scan stones, piton strikes, and a radial report dial.
+        for index in range(self.game.level["scans"]):
+            self.disc(frame, (5 + index * 4, 60), 1,
+                      SKY if index < state[4] else GRANITE,
+                      hollow=index >= state[4])
+        for index in range(2):
+            self.triangle(frame, (58, 56 + index * 4), 2,
+                          RED if index < state[7] else ALPINE,
+                          pattern=3 if index < state[7] else 0)
+        self.disc(frame, (57, 6), 5, ICE, hollow=True)
+        self.line(frame, (57, 1), (57, 11), GRANITE, dotted=True)
+        self.line(frame, (52, 6), (62, 6), GRANITE, dotted=True)
+        if state[9] == UNAVAILABLE:
+            self.line(frame, (53, 2), (61, 10), RED, width=2)
+            self.line(frame, (61, 2), (53, 10), RED, width=2)
+        elif state[9] >= 0:
+            ticks = 1 + state[9] % 8
+            for index in range(ticks):
+                angle = 2 * math.pi * index / ticks
+                x = 57 + round(4 * math.cos(angle))
+                y = 6 + round(4 * math.sin(angle))
+                frame[y, x] = VIOLET
+
+    def cursor(self, frame, state, center=None, color=INK):
+        center = center or map_point(self.game.level["fix_sites"][state[0]])
+        self.diamond(frame, center, 4, color, hollow=True)
+        self.disc(frame, center, 1, SUN)
+
+    def relocation_preview(self, frame, state):
+        relocation = self.game.level["relocation"]
+        if not relocation or not state[5]:
+            return
+        destination = map_point(relocation["to"])
+        self.triangle(frame, destination, 5, ROSE,
+                      pattern=relocation["beacon"])
+        for hypothesis in range(len(self.game.level["tracks"])):
+            old = reading(self.game.level, relocation["beacon"], hypothesis,
+                          state[8], False)
+            new = reading(self.game.level, relocation["beacon"], hypothesis,
+                          state[8], True)
+            if old != new and state[3] & (1 << hypothesis):
+                self.diamond(frame,
+                             map_point(current_position(self.game.level,
+                                                        hypothesis, state[8])),
+                             3, MAGENTA, hollow=True)
+
+    def animation(self, frame):
+        game = self.game
+        if not game.anim_kind:
+            if game.state[TERMINAL_INDEX] == LOSS:
+                self.line(frame, (7, 7), (56, 54), RED, dotted=True, width=2)
+            return
+        before = game.state; after = game.pending_state
+        progress = game.anim_progress; span = max(1, game.anim_total - 1)
+        wave = min(progress, span - progress)
+        if game.anim_kind == "cursor":
+            a = map_point(game.level["fix_sites"][before[0]])
+            b = map_point(game.level["fix_sites"][after[0]])
+            center = (a[0] + (b[0] - a[0]) * progress // span,
+                      a[1] + (b[1] - a[1]) * progress // span)
+            self.cursor(frame, before, center=center, color=VIOLET)
+        elif game.anim_kind == "beacon":
+            center = map_point(beacon_position(game.level, before[6], after[1]))
+            self.disc(frame, center, 5 + wave, SUN, hollow=True)
+            self.triangle(frame, center, 4, ALPINE, pattern=after[1])
+        elif game.anim_kind == "scan":
+            center = map_point(beacon_position(game.level, before[6], before[1]))
+            self.disc(frame, center, 3 + progress * 5, SKY, hollow=True)
+            self.disc(frame, center, 4 + progress * 3, VIOLET, hollow=True)
+            if progress > span // 2:
+                removed = before[3] & ~after[3]
+                for hypothesis in range(len(game.level["tracks"])):
+                    if removed & (1 << hypothesis):
+                        point = current_position(game.level, hypothesis, before[8])
+                        self.line(frame, (map_point(point)[0] - 2, map_point(point)[1] - 2),
+                                  (map_point(point)[0] + 2, map_point(point)[1] + 2), RED)
+        elif game.anim_kind == "preview":
+            destination = map_point(game.level["relocation"]["to"])
+            self.disc(frame, destination, 3 + wave, MAGENTA, hollow=True)
+            self.line(frame, map_point(beacon_position(game.level, False,
+                                                        game.level["relocation"]["beacon"])),
+                      destination, VIOLET, dotted=True)
+        elif game.anim_kind == "relocate":
+            index = game.level["relocation"]["beacon"]
+            a = map_point(beacon_position(game.level, False, index))
+            b = map_point(game.level["relocation"]["to"])
+            center = (a[0] + (b[0] - a[0]) * progress // span,
+                      a[1] + (b[1] - a[1]) * progress // span)
+            self.triangle(frame, center, 4, MAGENTA, pattern=index)
+        elif game.anim_kind == "reject":
+            center = map_point(game.level["fix_sites"][before[0]])
+            offset = (-2, 2, -1, 1, 0, 1, 0)[min(progress, 6)]
+            self.diamond(frame, (center[0] + offset, center[1]), 5,
+                         RED, hollow=True)
+        elif game.anim_kind == "success":
+            center = map_point(game.level["fix_sites"][before[0]])
+            self.disc(frame, center, 4 + progress * 3, MEADOW, hollow=True)
+            for index in range(5):
+                angle = 2 * math.pi * index / 5
+                point = (center[0] + round((3 + progress) * math.cos(angle)),
+                         center[1] + round((3 + progress) * math.sin(angle)))
+                self.diamond(frame, point, 1, SUN)
+        elif game.anim_kind == "loss":
+            inset = progress * 3
+            self.line(frame, (5 + inset, 5), (59 - inset, 58), RED,
+                      dotted=True, width=2)
+            self.line(frame, (59 - inset, 5), (5 + inset, 58), MAROON,
+                      dotted=True, width=2)
+        else:
+            center = map_point(game.level["fix_sites"][before[0]])
+            offset = (-2, 2, -1, 1, 0)[min(progress, 4)]
+            self.diamond(frame, (center[0] + offset, center[1]), 4,
+                         GRANITE, hollow=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        state = self.game.state
+        self.background(frame)
+        self.ridge(frame)
+        self.candidates(frame, state)
+        self.beacons(frame, state)
+        self.instruments(frame, state)
+        self.cursor(frame, state)
+        self.relocation_preview(frame, state)
+        self.animation(frame)
+        return frame
+
+
+class Q070(ARCBaseGame):
+    def __init__(self):
+        self.display = SurveyDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        levels = [
+            Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+            for item in LEVELS
+        ]
+        super().__init__(
+            "q070", levels,
+            Camera(0, 0, 64, 64, SNOW, SNOW, [self.display]),
+            False, len(levels), [1, 2, 3, 4, 5, 6],
+        )
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+
+    def begin(self, kind, frames, state, budget, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.pending_state = state
+        self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state
+        self.budget_left = self.pending_budget
+        self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        before = self.state
+        after = transition(self.level, before, action)
+        if after == before:
+            self.begin("blocked", 5, before, self.budget_left)
+            return
+        cost = action_cost(before, after)
+        budget = self.budget_left - cost
+        won = after[TERMINAL_INDEX] == WIN
+        lost = after[TERMINAL_INDEX] == LOSS or (budget <= 0 and not won)
+        if lost and after[TERMINAL_INDEX] != LOSS:
+            after = after[:TERMINAL_INDEX] + (LOSS,)
+        if won:
+            kind, frames, terminal = "success", 7, "win"
+        elif lost:
+            kind, frames, terminal = "loss", 8, "loss"
+        elif after[7] > before[7]:
+            kind, frames, terminal = "reject", 7, None
+        elif action in (1, 2):
+            kind, frames, terminal = "cursor", 6, None
+        elif action == 3:
+            kind, frames, terminal = "beacon", 5, None
+        elif action == 4:
+            kind, frames, terminal = "scan", 8, None
+        elif action == 5 and not before[5]:
+            kind, frames, terminal = "preview", 7, None
+        elif action == 5:
+            kind, frames, terminal = "relocate", 8, None
+        else:
+            kind, frames, terminal = "blocked", 5, None
+        self.begin(kind, frames, after, budget, terminal)

--- a/data/community-games/sonpham/q071_v3_q071.py
+++ b/data/community-games/sonpham/q071_v3_q071.py
@@ -1,0 +1,578 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q071-v3 Season Pilgrim -- walk a bright, living action-calendar.
+
+Each successful hop or deliberate wait advances one fully visible seasonal
+clock.  Flower and snowflake causeways alternate, faceted climate stones invert
+their meaning, brittle trail-stones fall behind the pilgrim, and spiral
+solstice wells restart the warm interval.  The puzzle is turn-based and exact:
+weather animation clarifies a transition but never supplies hidden state.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+WHITE, CREAM, STONE, SLATE, ASH, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, AQUA, SUN, CORAL, EARTH, LEAF, VIOLET = range(6, 16)
+CELL, OX, OY = 6, 8, 8
+DIRS = {1: (0, -1), 2: (0, 1), 3: (-1, 0), 4: (1, 0)}
+
+
+RAW_LEVELS = [
+    {"name": "First Bloom",
+     "map": ("########", "#SaaaG##", "########", "########",
+             "########", "########", "########", "########"),
+     "period": 6, "budget": 6,
+     "solution": (4, 4, 4, 4)},
+    {"name": "Frost Patience",
+     "map": ("########", "#SG#####", "#b######", "#bbbo###",
+             "########", "########", "########", "########"),
+     "period": 2, "budget": 20,
+     "solution": (4, 3, 2, 2, 5, 5, 4, 4, 4, 5, 3, 3, 5, 5, 3, 1, 1, 4)},
+    {"name": "Mixed Garden",
+     "map": ("########", "#SG#####", "#a######", "#aab####",
+             "###bo###", "########", "########", "########"),
+     "period": 2, "budget": 21,
+     "solution": (2, 2, 5, 5, 4, 5, 4, 2, 4, 5, 3, 1, 3, 3, 5, 5, 1, 1, 4)},
+    {"name": "Climate Mirror",
+     "map": ("########", "#SG#####", "#a######", "#aaM####",
+             "###bo###", "########", "########", "########"),
+     "period": 1, "budget": 17,
+     "solution": (2, 5, 2, 5, 4, 4, 2, 4, 3, 1, 3, 5, 3, 5, 1, 1, 4)},
+    {"name": "Brittle Return",
+     "map": ("########", "#SM!a###", "#o#ba###", "##Gbo###",
+             "########", "########", "########", "########"),
+     "period": 2, "budget": 10,
+     "solution": (2, 1, 4, 4, 2, 2, 4, 5, 3, 3)},
+    {"name": "Solstice Well",
+     "map": ("########", "#S.!W###", "#o##M###", "####b###",
+             "##Gao###", "########", "########", "########"),
+     "period": 3, "budget": 12,
+     "solution": (2, 1, 4, 4, 4, 2, 2, 2, 3, 3)},
+    {"name": "Falling Equinox",
+     "map": ("########", "#S.!b###", "#o##M###", "##G!ao##",
+             "########", "########", "########", "########"),
+     "period": 2, "budget": 19,
+     "solution": (2, 1, 2, 1, 4, 4, 4, 2, 5, 5, 2, 4, 5, 5, 3, 3, 3)},
+    {"name": "Season Pilgrim",
+     "map": ("########", "#S######", "#o.!a###", "####M###",
+             "#Woba###", "#a######", "#G######", "########"),
+     "period": 3, "budget": 22,
+     "solution": (2, 1, 2, 1, 2, 4, 4, 4, 2, 1, 2, 5, 2, 5, 5, 3, 3, 3, 2, 2)},
+]
+
+
+def locate(level, symbol):
+    for y, row in enumerate(level["map"]):
+        for x, value in enumerate(row):
+            if value == symbol:
+                return x, y
+    raise ValueError(symbol)
+
+
+def required_tiles(level, symbol):
+    mask = 0
+    for y, row in enumerate(level["map"]):
+        for x, value in enumerate(row):
+            if value == symbol:
+                mask |= 1 << (y * 8 + x)
+    return mask
+
+
+def start_state(level):
+    x, y = locate(level, "S")
+    # x, y, season, ticks, inversion, collapsed, seeds, wells, mirrors,
+    # two recoverable audit seals, terminal (0 live, 2 win, 3 loss)
+    return (x, y, 0, level["period"], 0, 0, 0, 0, 0, 2, 0)
+
+
+def _open(state, symbol):
+    phase, inverted = state[2], state[4]
+    return (symbol == "a") == (phase == (1 if inverted else 0))
+
+
+def _passable(level, state, x, y):
+    if not (0 <= x < 8 and 0 <= y < 8):
+        return False
+    symbol = level["map"][y][x]
+    if symbol == "#" or state[5] & (1 << (y * 8 + x)):
+        return False
+    return symbol not in "ab" or _open(state, symbol)
+
+
+def configuration_ready(level, state):
+    return (state[:2] == locate(level, "G")
+            and state[6] & required_tiles(level, "o") == required_tiles(level, "o")
+            and state[5] & required_tiles(level, "!") == required_tiles(level, "!")
+            and state[7] & required_tiles(level, "W") == required_tiles(level, "W")
+            and state[8] & required_tiles(level, "M") == required_tiles(level, "M"))
+
+
+def transition(level, state, action):
+    x, y, phase, until, inverted, collapsed, seeds, wells, mirrors, seals, terminal = state
+    if terminal or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    if action == 6:
+        if configuration_ready(level, state):
+            return state[:-1] + (2,)
+        if seals > 1:
+            return state[:9] + (seals - 1, 0)
+        return state[:9] + (0, 3)
+
+    moved = False
+    entered_well = False
+    if action in DIRS:
+        dx, dy = DIRS[action]
+        nx, ny = x + dx, y + dy
+        if not _passable(level, state, nx, ny):
+            return state
+        if level["map"][y][x] == "!":
+            collapsed |= 1 << (y * 8 + x)
+        x, y = nx, ny
+        moved = True
+        symbol = level["map"][y][x]
+        bit = 1 << (y * 8 + x)
+        if symbol == "M":
+            inverted = 1 - inverted
+            mirrors |= bit
+        elif symbol == "W":
+            phase, until = 0, level["period"]
+            wells |= bit
+            entered_well = True
+        elif symbol == "o":
+            seeds |= bit
+    # Wait is always causal; a successful hop is causal unless the well resets.
+    if not entered_well and (moved or action == 5):
+        until -= 1
+        if until <= 0:
+            phase = 1 - phase
+            until = level["period"]
+    return (x, y, phase, until, inverted, collapsed, seeds, wells, mirrors,
+            seals, terminal)
+
+
+def action_cost(before, after):
+    """Pure runtime cost: exploration/audits are recoverable; clock steps cost one."""
+    if before == after or before[9] != after[9] or after[10] in (2, 3):
+        return 0
+    return 1
+
+
+def solved(_level, state):
+    return state[10] == 2
+
+
+def _finalize_levels():
+    levels = []
+    for raw in RAW_LEVELS:
+        level = {key: deepcopy(value) for key, value in raw.items() if key != "solution"}
+        state = start_state(level)
+        for action in raw["solution"]:
+            before = state
+            state = transition(level, state, action)
+            assert state != before, (raw["name"], action, state)
+            assert not state[10]
+        assert configuration_ready(level, state), raw["name"]
+        level["solution"] = tuple(raw["solution"])
+        levels.append(level)
+    return levels
+
+
+LEVELS = _finalize_levels()
+
+
+class PilgrimDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for yy in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for xx in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                d = (xx - cx) ** 2 + (yy - cy) ** 2
+                if d <= radius ** 2 and (not hollow or d >= max(0, radius - 1) ** 2):
+                    frame[yy, xx] = color
+
+    @staticmethod
+    def line(frame, a, b, color, dotted=False, width=1):
+        x0, y0 = a; x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            for yy in range(y - width + 1, y + width):
+                for xx in range(x - width + 1, x + width):
+                    if 0 <= xx < 64 and 0 <= yy < 64:
+                        frame[yy, xx] = color
+
+    @staticmethod
+    def center(x, y):
+        return OX + x * CELL + CELL // 2, OY + y * CELL + CELL // 2
+
+    def petal(self, frame, center, radius, color, core=WHITE):
+        x, y = center
+        for dx, dy in ((0, -radius), (radius, 0), (0, radius), (-radius, 0)):
+            self.disc(frame, (x + dx, y + dy), max(1, radius // 2), color)
+        self.disc(frame, center, max(1, radius // 2), core)
+
+    def snowflake(self, frame, center, radius, color):
+        x, y = center
+        self.line(frame, (x - radius, y), (x + radius, y), color)
+        self.line(frame, (x, y - radius), (x, y + radius), color)
+        self.line(frame, (x - radius + 1, y - radius + 1),
+                  (x + radius - 1, y + radius - 1), color, dotted=True)
+        self.line(frame, (x + radius - 1, y - radius + 1),
+                  (x - radius + 1, y + radius - 1), color, dotted=True)
+
+    def diamond(self, frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for yy in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            span = radius - abs(yy - cy)
+            if hollow:
+                for xx in (cx - span, cx + span):
+                    if 0 <= xx < 64:
+                        frame[yy, xx] = color
+            else:
+                frame[yy, max(0, cx - span):min(64, cx + span + 1)] = color
+
+    def background(self, frame, state):
+        # High-key stitched paper landscape with large, stable landmarks.
+        warm = state[2] == 0
+        frame[:, :] = LEAF if warm else AQUA
+        frame[8:57, 4:60] = CREAM
+        for y in range(10, 57, 6):
+            color = SUN if warm else BLUE
+            start = 5 + ((y // 6) % 2) * 3
+            frame[y, start:60:6] = color
+        # Embroidered border: no words or numerals.
+        for x in range(4, 61, 4):
+            frame[8, x] = CORAL if warm else VIOLET
+            frame[56, x] = CORAL if warm else VIOLET
+        for y in range(8, 57, 4):
+            frame[y, 4] = EARTH
+            frame[y, 59] = EARTH
+        # Large sun-flower and snowy mountain establish scale and season.
+        self.disc(frame, (55, 13), 5, SUN if warm else CREAM)
+        if warm:
+            self.petal(frame, (55, 13), 4, CORAL, SUN)
+        else:
+            self.snowflake(frame, (55, 13), 5, BLUE)
+        self.line(frame, (5, 52), (13, 43), EARTH, width=2)
+        self.line(frame, (13, 43), (22, 52), EARTH, width=2)
+        self.line(frame, (9, 48), (13, 43), WHITE)
+        self.line(frame, (13, 43), (17, 48), WHITE)
+        for x, y in ((7, 15), (56, 34), (51, 50), (24, 12)):
+            self.line(frame, (x, y), (x + 2, y - 2), LEAF)
+            self.line(frame, (x, y), (x + 3, y + 1), LEAF)
+
+    def causeways(self, frame, state):
+        level = self.game.level
+        for y, row in enumerate(level["map"]):
+            for x, symbol in enumerate(row):
+                if symbol == "#":
+                    continue
+                bit = 1 << (y * 8 + x)
+                if state[5] & bit:
+                    continue
+                here = self.center(x, y)
+                for dx, dy in ((1, 0), (0, 1)):
+                    nx, ny = x + dx, y + dy
+                    if nx >= 8 or ny >= 8 or level["map"][ny][nx] == "#":
+                        continue
+                    nbit = 1 << (ny * 8 + nx)
+                    if state[5] & nbit:
+                        continue
+                    there = self.center(nx, ny)
+                    self.line(frame, here, there, EARTH, width=2)
+                    self.line(frame, here, there, CREAM, dotted=True)
+
+    def warm_bed(self, frame, center, opened):
+        if opened:
+            self.petal(frame, center, 3, CORAL, SUN)
+        else:
+            self.disc(frame, center, 3, STONE)
+            self.line(frame, (center[0] - 3, center[1]),
+                      (center[0] + 3, center[1]), INK, width=2)
+
+    def cold_bed(self, frame, center, opened):
+        if opened:
+            self.disc(frame, center, 3, BLUE)
+            self.snowflake(frame, center, 3, WHITE)
+        else:
+            self.diamond(frame, center, 3, STONE)
+            self.line(frame, (center[0], center[1] - 3),
+                      (center[0], center[1] + 3), INK, width=2)
+
+    def tile(self, frame, state, x, y, symbol):
+        if symbol == "#":
+            return
+        center = self.center(x, y); bit = 1 << (y * 8 + x)
+        self.disc(frame, center, 4, CREAM)
+        if symbol == "a":
+            self.warm_bed(frame, center, _open(state, "a"))
+        elif symbol == "b":
+            self.cold_bed(frame, center, _open(state, "b"))
+        elif symbol == "M":
+            self.diamond(frame, center, 4, VIOLET, hollow=True)
+            self.diamond(frame, center, 2, WHITE)
+            self.line(frame, (center[0] - 4, center[1] - 2),
+                      (center[0] + 4, center[1] + 2), MAGENTA, dotted=True)
+            if state[8] & bit:
+                self.diamond(frame, center, 4, SUN, hollow=True)
+        elif symbol == "!":
+            if state[5] & bit:
+                self.disc(frame, center, 4, EARTH)
+                self.diamond(frame, center, 2, INK)
+            else:
+                self.diamond(frame, center, 4, AQUA)
+                self.line(frame, (center[0] - 2, center[1] - 3),
+                          (center[0] + 2, center[1] + 3), BLUE)
+                self.line(frame, (center[0] + 2, center[1] - 3),
+                          center, BLUE)
+        elif symbol == "W":
+            awake = bool(state[7] & bit)
+            self.disc(frame, center, 4, AQUA if awake else BLUE)
+            for radius in (3, 2, 1):
+                angle = radius * math.pi / 2
+                point = (center[0] + round(radius * math.cos(angle)),
+                         center[1] + round(radius * math.sin(angle)))
+                self.disc(frame, point, 1, SUN if awake else WHITE)
+            if awake:
+                self.petal(frame, center, 4, SUN, WHITE)
+        elif symbol == "o":
+            if state[6] & bit:
+                self.disc(frame, center, 3, CREAM)
+                self.line(frame, (center[0] - 3, center[1]),
+                          (center[0] + 3, center[1]), STONE, dotted=True)
+            else:
+                self.petal(frame, center, 3, ROSE, SUN)
+                self.line(frame, (center[0], center[1] - 4),
+                          (center[0] + 2, center[1] - 6), LEAF)
+        elif symbol == "G":
+            ready = configuration_ready(self.game.level, state)
+            self.petal(frame, center, 4 if ready else 3,
+                       MAGENTA if ready else STONE, WHITE)
+            if not ready:
+                self.line(frame, (center[0] - 2, center[1]),
+                          (center[0] + 2, center[1]), INK, width=2)
+        elif symbol == ".":
+            self.disc(frame, center, 2, CREAM)
+            self.line(frame, (center[0] - 2, center[1] + 1),
+                      (center[0] + 2, center[1] - 1), LEAF)
+        else:  # S
+            self.disc(frame, center, 3, CREAM)
+            self.disc(frame, center, 2, CORAL, hollow=True)
+
+    def traveler(self, frame, center, color=CORAL, lift=0):
+        x, y = center; y -= lift
+        self.diamond(frame, (x, y - 1), 4, color)
+        self.diamond(frame, (x, y - 2), 2, SUN)
+        self.line(frame, (x - 4, y - 1), (x - 6, y - 3), MAGENTA)
+        self.line(frame, (x - 5, y - 2), (x - 7, y - 1), MAGENTA)
+        self.line(frame, (x - 2, y + 3), (x - 3, y + 5), INK)
+        self.line(frame, (x + 2, y + 3), (x + 3, y + 5), INK)
+
+    def hud(self, frame, state):
+        game = self.game
+        # Season and clock are shape-coded: petal vs snowflake plus live beads.
+        if state[2] == 0:
+            self.petal(frame, (7, 4), 3, CORAL, SUN)
+        else:
+            self.snowflake(frame, (7, 4), 3, BLUE)
+        for index in range(game.level["period"]):
+            x = 17 + index * 25 // max(1, game.level["period"] - 1)
+            if index < state[3]:
+                self.diamond(frame, (x, 4), 2,
+                             SUN if state[2] == 0 else BLUE)
+            else:
+                self.line(frame, (x - 1, 4), (x + 1, 4), STONE)
+        if state[4]:
+            self.diamond(frame, (49, 4), 3, VIOLET, hollow=True)
+            self.line(frame, (47, 2), (51, 6), MAGENTA)
+            self.line(frame, (51, 2), (47, 6), MAGENTA)
+        else:
+            self.disc(frame, (49, 4), 3, CREAM)
+            self.line(frame, (46, 4), (52, 4), LEAF)
+        # Two large wax seals support one recoverable mistaken audit.
+        for index, x in enumerate((56, 62)):
+            live = index < state[9]
+            self.diamond(frame, (x, 4), 2, ROSE if live else RED,
+                         hollow=not live)
+        shown = game.budget_left
+        if (game.anim_kind and game.pending_budget is not None
+                and game.anim_progress >= max(1, game.anim_total - 1)):
+            shown = game.pending_budget
+        for index in range(game.budget_max):
+            x = 5 + index * 54 // max(1, game.budget_max - 1)
+            if index < shown:
+                self.disc(frame, (x, 60), 1, CORAL)
+            else:
+                frame[60, x] = INK
+
+    def landscape(self, frame, state):
+        self.causeways(frame, state)
+        for y, row in enumerate(self.game.level["map"]):
+            for x, symbol in enumerate(row):
+                self.tile(frame, state, x, y, symbol)
+
+    def animation(self, frame, render_state):
+        game = self.game
+        if game.intro_mark:
+            for radius in (3, 6, 9):
+                self.disc(frame, (32, 33), radius, CORAL, hollow=True)
+        if not game.anim_kind:
+            return
+        p = game.anim_progress; span = max(1, game.anim_total - 1)
+        before, after = game.anim_before, game.pending_state
+        if game.anim_kind in ("move", "well") and p < span:
+            a = self.center(before[0], before[1]); b = self.center(after[0], after[1])
+            point = (a[0] + (b[0] - a[0]) * p // span,
+                     a[1] + (b[1] - a[1]) * p // span)
+            lift = (4 * min(p, span - p)) // max(1, span // 2)
+            self.traveler(frame, point, lift=lift)
+            self.line(frame, a, point, SUN, dotted=True)
+            if before[5] != after[5]:
+                radius = max(1, 5 - 4 * p // span)
+                self.diamond(frame, a, radius, AQUA, hollow=True)
+        elif game.anim_kind == "wait" and p < span:
+            center = self.center(before[0], before[1])
+            self.disc(frame, center, 2 + 4 * min(p, span - p) // max(1, span),
+                      ROSE, hollow=True)
+            for angle in range(0, 360, 90):
+                dx = round(5 * p * math.cos(math.radians(angle)) / span)
+                dy = round(5 * p * math.sin(math.radians(angle)) / span)
+                self.disc(frame, (center[0] + dx, center[1] + dy), 1, SUN)
+        elif game.anim_kind == "blocked" and p < span:
+            center = self.center(before[0], before[1])
+            fold = min(p, span - p)
+            self.diamond(frame, center, 5 + fold, RED, hollow=True)
+            self.line(frame, (center[0] - 4, center[1] - 4),
+                      (center[0] + 4, center[1] + 4), INK)
+        elif game.anim_kind == "audit" and p < span:
+            x = 5 + 54 * p // span
+            self.line(frame, (x, 9), (x, 55), SUN, dotted=True)
+            self.petal(frame, (x, 33), 2, ROSE, WHITE)
+        elif game.anim_kind == "success":
+            for radius in range(4, min(31, 5 + p * 4), 6):
+                self.disc(frame, (32, 33), radius, SUN, hollow=True)
+            for angle in range(0, 360, 45):
+                length = 6 + 2 * p
+                end = (32 + round(length * math.cos(math.radians(angle))),
+                       33 + round(length * math.sin(math.radians(angle))))
+                self.line(frame, (32, 33), end, CORAL, dotted=True)
+            self.petal(frame, (32, 33), min(8, 3 + p), MAGENTA, WHITE)
+        elif game.anim_kind == "loss" and p < span:
+            inset = 27 * p // span
+            self.line(frame, (3 + inset, 10), (3 + inset, 56), RED, width=2)
+            self.line(frame, (60 - inset, 10), (60 - inset, 56), RED, width=2)
+            for y in range(13, 55, 7):
+                self.line(frame, (4 + inset, y), (59 - inset, y + 3), EARTH,
+                          dotted=True)
+
+        if after is not None and after[2] != before[2] and p < span:
+            # One directional, nonflashing full-field weather front.
+            edge = 5 + 54 * p // span
+            color = BLUE if after[2] else SUN
+            for y in range(10, 56, 5):
+                self.line(frame, (5, y), (edge, y), color, dotted=True)
+        if after is not None and after[4] != before[4] and p < span:
+            center = self.center(after[0], after[1])
+            self.diamond(frame, center, 2 + 5 * p // span, VIOLET, hollow=True)
+        if game.anim_kind == "well" and p < span:
+            center = self.center(after[0], after[1])
+            for radius in range(2, 2 + p, 2):
+                self.disc(frame, center, min(8, radius), AQUA, hollow=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        game = self.game
+        span = max(1, game.anim_total - 1)
+        preview = (game.anim_kind is not None and game.pending_state is not None
+                   and game.anim_progress >= span)
+        render_state = game.pending_state if preview else game.state
+        self.background(frame, render_state)
+        self.landscape(frame, render_state)
+        moving = (game.anim_kind in ("move", "well") and not preview)
+        if not moving:
+            self.traveler(frame, self.center(render_state[0], render_state[1]))
+        self.hud(frame, render_state)
+        self.animation(frame, render_state)
+        return frame
+
+
+class Q071(ARCBaseGame):
+    def __init__(self):
+        self.display = PilgrimDisplay(self); self.level = LEVELS[0]
+        self.state = start_state(self.level); self.budget_left = self.budget_max = 0
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = None; self.pending_budget = None
+        self.pending_terminal = None; self.intro_mark = True
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(level), name=level["name"])
+                  for level in LEVELS]
+        super().__init__("q071", levels, Camera(0, 0, 64, 64, LEAF, LEAF, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = self.pending_budget = None
+        self.pending_terminal = None; self.intro_mark = True
+
+    def begin(self, kind, frames, before, after, budget, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames; self.anim_progress = 0
+        self.anim_before = before; self.pending_state = after; self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal; self.state = self.pending_state
+        self.budget_left = self.pending_budget; self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1; self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action(); return
+        self.intro_mark = False; before = self.state
+        after = transition(self.level, before, action)
+        if after == before:
+            self.begin("blocked", 5, before, before, self.budget_left); return
+        cost = action_cost(before, after)
+        if cost > self.budget_left:
+            lost = before[:-1] + (3,)
+            self.begin("loss", 7, before, lost, self.budget_left, "loss"); return
+        budget = self.budget_left - cost
+        if after[10] == 2:
+            kind, frames, terminal = "success", 7, "win"
+        elif after[10] == 3:
+            kind, frames, terminal = "loss", 7, "loss"
+        elif action == 6:
+            kind, frames, terminal = "audit", 6, None
+        elif action == 5:
+            kind, frames, terminal = "wait", 6, None
+        elif self.level["map"][after[1]][after[0]] == "W":
+            kind, frames, terminal = "well", 7, None
+        else:
+            kind, frames, terminal = "move", 7, None
+        self.begin(kind, frames, before, after, budget, terminal)

--- a/data/community-games/sonpham/q080_v3_q080.py
+++ b/data/community-games/sonpham/q080_v3_q080.py
@@ -1,0 +1,475 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q080-v3 Regime Cart -- carry a local physical law along a crystalline rail.
+
+The cart moves a modular height-changing field.  Eight levels compose polarity,
+radius, distance falloff, anchors, automatic switches, and a visibly bridged wrap
+topology.  Movement energy and the two audit seals are deliberately independent:
+an incorrect audit is recoverable without shortening the physical plan.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+WHITE, SILVER, SLATE, CHARCOAL, NIGHT = 0, 1, 2, 4, 5
+MAGENTA, ROSE, RED, BLUE, GLASS, AMBER, COPPER, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 14, 15
+
+
+LEVELS = [
+    {"name": "First Pulse", "start": (0, 0, 0), "target": (1, 1, 1),
+     "mod": 4, "radius": 0, "toggle": False, "goal_cart": 2, "goal_regime": 1,
+     "budget": 6},
+    {"name": "Inverse Glass", "start": (1, 0, 2, 0), "target": (0, 4, 3, 1),
+     "mod": 5, "radius": 0, "toggle": True, "goal_cart": 3, "goal_regime": 1,
+     "budget": 10},
+    {"name": "Wide Lantern", "start": (0, 1, 0, 2, 0), "target": (1, 1, 4, 2, 1),
+     "mod": 5, "radius": 1, "toggle": True, "goal_cart": 4, "goal_regime": 1,
+     "budget": 10},
+    {"name": "Tapered Law", "start": (2, 0, 1, 0, 3), "target": (0, 0, 2, 5, 0),
+     "mod": 7, "radius": 1, "kernel": "falloff", "toggle": True,
+     "goal_cart": 4, "goal_regime": -1, "budget": 12},
+    {"name": "Anchored Ridge", "start": (0, 2, 1, 3, 0, 1), "target": (2, 2, 1, 5, 3, 2),
+     "mod": 7, "radius": 1, "kernel": "falloff", "anchors": (2,), "toggle": True,
+     "goal_cart": 3, "goal_regime": 1, "budget": 12},
+    {"name": "Polarity Cairn", "start": (1, 0, 3, 2, 0, 4), "target": (6, 5, 0, 6, 0, 2),
+     "mod": 7, "radius": 1, "kernel": "falloff", "anchors": (4,), "switches": (2,),
+     "toggle": True, "goal_cart": 5, "goal_regime": -1, "budget": 12},
+    {"name": "Looped Horizon", "start": (0, 3, 1, 4, 2, 0), "target": (6, 3, 3, 4, 2, 0),
+     "mod": 7, "radius": 2, "kernel": "flat", "anchors": (3,), "switches": (5,),
+     "wrap": True, "toggle": True, "goal_cart": 5, "goal_regime": -1, "budget": 13},
+    {"name": "Regime Cart", "start": (2, 0, 4, 1, 3, 0, 5), "target": (6, 0, 1, 7, 2, 0, 2),
+     "mod": 8, "radius": 2, "kernel": "falloff", "anchors": (1, 5),
+     "switches": (3, 6), "wrap": True, "toggle": True,
+     "goal_cart": 5, "goal_regime": -1, "budget": 13},
+]
+
+
+def start_state(level):
+    """Return values, cart, polarity, remaining audit seals, terminal code."""
+    return tuple(level["start"]), 0, 1, 2, 0
+
+
+def field_distance(index, cart, size, wrap):
+    distance = abs(index - cart)
+    return min(distance, size - distance) if wrap else distance
+
+
+def configuration_solved(level, state):
+    values, cart, regime = state[:3]
+    return (tuple(values) == tuple(level["target"])
+            and cart == level["goal_cart"] and regime == level["goal_regime"])
+
+
+def transition(level, state, action):
+    """Pure deterministic transition used by the game and independent qualifier."""
+    values, cart, regime, audits, terminal = state
+    if terminal or action not in (1, 3, 4, 5, 6):
+        return state
+    size = len(values)
+    if action == 1:
+        if not level.get("toggle", True):
+            return state
+        return values, cart, -regime, audits, terminal
+    if action == 3:
+        next_cart = (cart - 1) % size if level.get("wrap") else max(0, cart - 1)
+        return values, next_cart, regime, audits, terminal
+    if action == 4:
+        next_cart = (cart + 1) % size if level.get("wrap") else min(size - 1, cart + 1)
+        return values, next_cart, regime, audits, terminal
+    if action == 6:
+        if configuration_solved(level, state):
+            return values, cart, regime, audits, 2
+        audits -= 1
+        return values, cart, regime, audits, 3 if audits <= 0 else 0
+
+    changed = list(values)
+    for index, value in enumerate(values):
+        distance = field_distance(index, cart, size, level.get("wrap", False))
+        if distance > level["radius"] or index in level.get("anchors", ()):
+            continue
+        strength = 1
+        if level.get("kernel", "flat") == "falloff":
+            strength = level["radius"] - distance + 1
+        changed[index] = (value + regime * strength) % level["mod"]
+    if cart in level.get("switches", ()):
+        regime = -regime
+    return tuple(changed), cart, regime, audits, terminal
+
+
+def action_cost(state, after):
+    """Only a changed physical configuration spends movement energy."""
+    return int(after[:3] != state[:3])
+
+
+def solved(_level, state):
+    return state[-1] == 2
+
+
+class RegimeDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def _disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius ** 2 and (not hollow or distance >= max(0, radius - 1) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def _line(frame, a, b, color, dotted=False):
+        x0, y0 = a
+        x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    @staticmethod
+    def _diamond(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for dy in range(-radius, radius + 1):
+            width = radius - abs(dy)
+            y = cy + dy
+            if not 0 <= y < 64:
+                continue
+            if hollow:
+                for x in (cx - width, cx + width):
+                    if 0 <= x < 64:
+                        frame[y, x] = color
+            else:
+                frame[y, max(0, cx - width):min(64, cx + width + 1)] = color
+
+    def _positions(self):
+        size = len(self.game.values)
+        if size == 1:
+            return (32,)
+        return tuple(8 + index * 48 // (size - 1) for index in range(size))
+
+    def _background(self, frame):
+        frame[:, :] = NIGHT
+        # Keep the play field quiet: sparse strata frame the high-contrast apparatus.
+        for y in (17, 27, 37):
+            frame[y, 4:61:6] = CHARCOAL
+        frame[14, 5:60:4] = SLATE
+        frame[56:59, 3:61] = CHARCOAL
+        frame[57, 4:60:3] = COPPER
+
+    def _tower(self, frame, index, x, value, target, current_height=None):
+        base = 45
+        height = value * 4 if current_height is None else current_height
+        current_top = base - height
+        target_top = base - target * 4
+        # Current is a filled crystal; target is a dotted outline on the same scale.
+        frame[max(15, target_top):base + 1:2, x - 4] = ROSE
+        frame[max(15, target_top):base + 1:2, x + 4] = ROSE
+        frame[max(15, target_top), x - 4:x + 5:2] = ROSE
+        if height > 0:
+            top = max(15, current_top)
+            if top + 2 < base:
+                frame[top + 2:base, x - 4:x + 5] = BLUE
+                frame[top + 2:base, x - 2:x + 3] = GLASS
+                frame[top + 2:base:3, x + 2:x + 4] = SILVER
+            frame[top, x] = WHITE
+            if top + 1 < 64:
+                frame[top + 1, x - 2:x + 3] = GLASS
+        frame[base:base + 3, x - 5:x + 6] = CHARCOAL
+        if index in self.game.level.get("anchors", ()):
+            frame[base - 5:base, x - 5:x + 6:2] = AMBER
+            frame[base - 4:base + 1:2, x - 5:x + 6] = AMBER
+        if index in self.game.level.get("switches", ()):
+            frame[base + 3:base + 7, x - 4:x + 5] = VIOLET
+            frame[base + 4:base + 6, x - 2:x + 3] = NIGHT
+            frame[base + 4, x] = WHITE
+
+    def _field(self, frame, cart, regime):
+        g = self.game
+        xs = self._positions()
+        size = len(xs)
+        for index, x in enumerate(xs):
+            distance = field_distance(index, cart, size, g.level.get("wrap", False))
+            if distance > g.level["radius"]:
+                continue
+            if g.level.get("kernel", "flat") == "falloff":
+                height = 3 + (g.level["radius"] - distance) * 2
+            else:
+                height = 3 + g.level["radius"] * 2
+            color = GLASS if regime > 0 else VIOLET
+            frame[47 - height:48, max(1, x - 5):min(63, x + 6):2] = color
+            if regime > 0:
+                frame[47 - height, max(1, x - 3):min(63, x + 4)] = GLASS
+                frame[45 - height:48 - height, x] = WHITE
+            else:
+                frame[46 - height:49 - height, max(1, x - 2):min(63, x + 3)] = NIGHT
+                frame[47 - height, x - 3:x + 4:2] = VIOLET
+
+    def _polarity(self, frame, center, regime, scale=3):
+        x, y = center
+        if scale <= 0:
+            self._disc(frame, center, 1, WHITE)
+            return
+        if regime > 0:
+            self._line(frame, (x, y - scale), (x, y + scale), WHITE)
+            self._line(frame, (x - scale, y), (x + scale, y), WHITE)
+        else:
+            self._line(frame, (x - scale, y - 2), (x + scale, y - 2), WHITE)
+            self._line(frame, (x - scale, y - 2), (x, y + scale), WHITE)
+            self._line(frame, (x + scale, y - 2), (x, y + scale), WHITE)
+
+    def _cart_at(self, frame, x, y, regime, morph_to=None, progress=0, total=1):
+        # The complete silhouette travels: dome, chassis, wheels, and polarity glyph.
+        self._disc(frame, (x, y - 1), 6, CHARCOAL)
+        dome_regime = morph_to if morph_to is not None and progress > total // 2 else regime
+        self._disc(frame, (x, y - 2), 5, GLASS if dome_regime > 0 else VIOLET)
+        frame[y - 1:y + 4, x - 6:x + 7] = COPPER
+        frame[y - 2:y + 1, x - 4:x + 5] = NIGHT
+        self._disc(frame, (x - 4, y + 5), 2, SILVER)
+        self._disc(frame, (x + 4, y + 5), 2, SILVER)
+        self._disc(frame, (x - 4, y + 5), 1, NIGHT)
+        self._disc(frame, (x + 4, y + 5), 1, NIGHT)
+        if morph_to is None:
+            self._polarity(frame, (x, y - 5), regime)
+        else:
+            half = max(1, total // 2)
+            if progress <= half:
+                scale = max(0, 3 * (half - progress) // half)
+                self._polarity(frame, (x, y - 5), regime, scale)
+            else:
+                scale = max(1, 3 * (progress - half) // max(1, total - half))
+                self._polarity(frame, (x, y - 5), morph_to, scale)
+
+    def _cart(self, frame, cart, regime):
+        self._cart_at(frame, self._positions()[cart], 49, regime)
+
+    def _goal(self, frame):
+        g = self.game
+        x = self._positions()[g.level["goal_cart"]]
+        frame[59:63, x - 5:x + 6:2] = GREEN
+        frame[60, x - 2:x + 3] = GREEN if g.level["goal_regime"] > 0 else MAGENTA
+        self._polarity(frame, (x, 59), g.level["goal_regime"], 2)
+
+    def _lamp(self, frame, center, filled, color):
+        # Five-pixel filled/hollow diamonds make every adjacent count distinct.
+        self._diamond(frame, center, 2, color if filled else SLATE, hollow=not filled)
+        if filled:
+            frame[center[1], center[0]] = WHITE
+
+    def _hud(self, frame):
+        g = self.game
+        for index in range(g.budget_max):
+            center = (7 + (index % 7) * 7, 4 + (index // 7) * 6)
+            self._lamp(frame, center, index < g.budget_left, AMBER)
+        for index in range(2):
+            self._lamp(frame, (57, 4 + index * 6), index < g.audits, COPPER)
+        # A neutral three-facet audit seal advertises action 6 but never readiness.
+        self._diamond(frame, (57, 18), 4, SILVER, hollow=True)
+        self._line(frame, (54, 18), (60, 18), SLATE)
+        self._line(frame, (57, 15), (57, 21), SLATE)
+        self._line(frame, (55, 20), (59, 16), SLATE)
+
+    @staticmethod
+    def _path_point(points, progress, total):
+        lengths = [abs(b[0] - a[0]) + abs(b[1] - a[1]) for a, b in zip(points, points[1:])]
+        distance = sum(lengths) * progress // max(1, total)
+        for (a, b), length in zip(zip(points, points[1:]), lengths):
+            if distance <= length:
+                if length == 0:
+                    return b
+                return (a[0] + (b[0] - a[0]) * distance // length,
+                        a[1] + (b[1] - a[1]) * distance // length)
+            distance -= length
+        return points[-1]
+
+    def _pulse_animation(self, frame):
+        g = self.game
+        xs = self._positions()
+        p = g.anim_progress
+        for index, x in enumerate(xs):
+            distance = field_distance(index, g.cart, len(xs), g.level.get("wrap", False))
+            if distance > g.level["radius"]:
+                continue
+            source = (xs[g.cart], 39)
+            destination = (x, 34)
+            marker = (source[0] + (destination[0] - source[0]) * p // g.anim_total,
+                      source[1] + (destination[1] - source[1]) * p // g.anim_total)
+            self._diamond(frame, marker, 1, GLASS if g.regime > 0 else VIOLET)
+            if index in g.level.get("anchors", ()):
+                # A stable X-brace rejects the arriving impulse; the tower never moves.
+                self._line(frame, (x - 4, 31), (x + 4, 37), AMBER)
+                self._line(frame, (x + 4, 31), (x - 4, 37), AMBER)
+
+    def _animation(self, frame):
+        g = self.game
+        if g.intro_mark:
+            frame[13, 6:55:3] = GLASS
+        if not g.anim_kind:
+            return
+        p = g.anim_progress
+        if g.anim_kind == "move":
+            xs = self._positions()
+            start_x = xs[g.anim_from_cart]
+            end_x = xs[g.anim_to_cart]
+            if abs(g.anim_to_cart - g.anim_from_cart) > 1:
+                points = ((start_x, 49), (start_x, 25), (end_x, 25), (end_x, 49))
+                x, y = self._path_point(points, p, g.anim_total)
+            else:
+                x = start_x + (end_x - start_x) * p // g.anim_total
+                y = 49 - (p * (g.anim_total - p) * 4 // (g.anim_total * g.anim_total))
+            self._cart_at(frame, x, y, g.regime)
+        elif g.anim_kind == "toggle":
+            self._cart_at(frame, self._positions()[g.cart], 49, g.regime,
+                          g.pending_state[2], p, g.anim_total)
+        elif g.anim_kind == "pulse":
+            self._pulse_animation(frame)
+        elif g.anim_kind == "blocked":
+            x = self._positions()[g.cart]
+            self._line(frame, (x - 6, 39 + p), (x + 6, 39 + p), RED, dotted=True)
+        elif g.anim_kind == "audit_reject":
+            self._diamond(frame, (57, 18), 4 + p, RED, hollow=True)
+            self._line(frame, (53 + p, 14), (61 - p, 22), RED)
+        elif g.anim_kind == "success":
+            frame[14 + p:25, 5 + p:60 - p:2] = GREEN
+        elif g.anim_kind == "loss":
+            frame[14:29, 6 + p:59 - p:3] = RED
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        g = self.game
+        self._background(frame)
+        xs = self._positions()
+        if g.level.get("wrap"):
+            self._line(frame, (xs[0], 39), (xs[0], 25), GLASS)
+            self._line(frame, (xs[0], 25), (xs[-1], 25), GLASS, dotted=True)
+            self._line(frame, (xs[-1], 25), (xs[-1], 39), GLASS)
+        for tick in range(g.level["mod"]):
+            frame[45 - tick * 4, 2:5] = SILVER if tick else COPPER
+        for index, (x, value, target) in enumerate(zip(xs, g.values, g.level["target"])):
+            height = None
+            if g.anim_kind == "pulse" and g.pending_state is not None:
+                new_value = g.pending_state[0][index]
+                height = (value * 4 * (g.anim_total - g.anim_progress)
+                          + new_value * 4 * g.anim_progress) // g.anim_total
+            self._tower(frame, index, x, value, target, height)
+        self._field(frame, g.cart, g.regime)
+        moving_or_morphing = g.anim_kind in ("move", "toggle")
+        switch_morph = (g.anim_kind == "pulse" and g.pending_state is not None
+                        and g.pending_state[2] != g.regime)
+        if not moving_or_morphing and not switch_morph:
+            self._cart(frame, g.cart, g.regime)
+        elif switch_morph:
+            self._cart_at(frame, xs[g.cart], 49, g.regime, g.pending_state[2],
+                          g.anim_progress, g.anim_total)
+        self._goal(frame)
+        self._hud(frame)
+        self._animation(frame)
+        return frame
+
+
+class Q080(ARCBaseGame):
+    def __init__(self):
+        self.display = RegimeDisplay(self)
+        self.level = LEVELS[0]
+        self.values = ()
+        self.cart = 0
+        self.regime = 1
+        self.audits = 2
+        self.terminal = 0
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_from_cart = self.anim_to_cart = 0
+        self.pending_state = None
+        self.pending_budget = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q080", levels, Camera(0, 0, 64, 64, NIGHT, NIGHT, [self.display]),
+                         False, len(levels), [1, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.values, self.cart, self.regime, self.audits, self.terminal = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_from_cart = self.anim_to_cart = self.cart
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        self.intro_mark = True
+
+    def state(self):
+        return self.values, self.cart, self.regime, self.audits, self.terminal
+
+    def _begin(self, kind, frames, next_state, budget, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.pending_state = next_state
+        self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def _finish(self):
+        terminal = self.pending_terminal
+        if self.pending_state is not None:
+            self.values, self.cart, self.regime, self.audits, self.terminal = self.pending_state
+        if self.pending_budget is not None:
+            self.budget_left = self.pending_budget
+        self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self._finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        self.intro_mark = False
+        before = self.state()
+        after = transition(self.level, before, action)
+        if after == before:
+            self._begin("blocked", 3, before, self.budget_left)
+            return
+        budget = self.budget_left - action_cost(before, after)
+        won = after[-1] == 2
+        # Zero energy is a valid resting state: the player may still use the
+        # separate audit reserve.  Only an attempted physical overdraft loses.
+        lost = after[-1] == 3 or (budget < 0 and not won)
+        if won:
+            kind = "success"
+        elif lost:
+            kind = "loss"
+        elif action == 6:
+            kind = "audit_reject"
+        elif action in (3, 4):
+            self.anim_from_cart = self.cart
+            self.anim_to_cart = after[1]
+            kind = "move"
+        elif action == 1:
+            kind = "toggle"
+        else:
+            kind = "pulse"
+        frames = 7 if kind in ("success", "loss") else 5 if kind != "blocked" else 3
+        self._begin(kind, frames, after, budget, "win" if won else "loss" if lost else None)

--- a/data/community-games/sonpham/q081_v2_q081.py
+++ b/data/community-games/sonpham/q081_v2_q081.py
@@ -1,0 +1,384 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q081-v2 Night-Clock Masquerade -- track identity through a mechanical revue."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, SILVER, ASH, STEEL, SMOKE, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, AQUA, GOLD, COPPER, WINE, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+
+
+def ev(kind, a=0, b=0):
+    return kind, a, b
+
+
+LEVELS = [
+    {"name": "First Crossing", "n": 3, "events": (ev("pos", 0, 2),), "adjacent": False, "ring": False, "budget": 7},
+    {"name": "Borrowed Faces", "n": 4, "events": (ev("pos", 0, 3), ev("costume", 1, 2), ev("pos", 0, 1)), "adjacent": False, "ring": False, "budget": 11},
+    {"name": "Badge and Body", "n": 4, "events": (ev("badge", 0, 2), ev("pos", 1, 3), ev("costume", 0, 3), ev("pos", 0, 2)), "adjacent": False, "ring": False, "budget": 16},
+    {"name": "Coupled Footlights", "n": 5, "events": (ev("pos", 0, 4), ev("costume", 1, 3), ev("badge", 0, 2), ev("pos", 1, 2)), "adjacent": True, "ring": False, "budget": 13},
+    {"name": "Wound Carousel", "n": 5, "events": (ev("rotate", 1), ev("costume", 0, 3), ev("pos", 1, 4), ev("badge", 2, 3)), "adjacent": True, "ring": True, "budget": 18},
+    {"name": "Traveling Sockets", "n": 5, "events": (ev("goal", 2), ev("pos", 0, 3), ev("badge", 1, 4), ev("rotate", 1), ev("costume", 0, 2)), "adjacent": True, "ring": True, "budget": 19},
+    {"name": "Mirror Revue", "n": 6, "events": (ev("mirror"), ev("costume", 0, 5), ev("badge", 1, 4), ev("pos", 2, 5), ev("goal", 1), ev("rotate", 2)), "adjacent": True, "ring": True, "budget": 18},
+    {"name": "Night-Clock Masquerade", "n": 6, "events": (ev("goal", 2), ev("pos", 0, 5), ev("costume", 1, 4), ev("badge", 0, 3), ev("rotate", 1), ev("mirror"), ev("pos", 2, 5)), "adjacent": True, "ring": True, "budget": 24},
+]
+
+
+def rotate(values, amount):
+    amount %= len(values)
+    return values[-amount:] + values[:-amount] if amount else values
+
+
+def target_order(level, state):
+    return rotate(tuple(range(level["n"])), state[7])
+
+
+def start_state(level):
+    values = tuple(range(level["n"]))
+    # phase, identities, costumes, badges, event, cursor, held, goal shift, chances, terminal
+    return 0, values, values, values, 0, 0, -1, 0, 2, 0
+
+
+def transition(level, state, action):
+    phase, identities, costumes, badges, event_index, cursor, held, goal_shift, chances, terminal = state
+    if terminal or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    n = level["n"]
+    if phase == 0:
+        if action != 5 or event_index >= len(level["events"]):
+            return state
+        kind, a, b = level["events"][event_index]
+        identities, costumes, badges = list(identities), list(costumes), list(badges)
+        if kind == "pos":
+            identities[a], identities[b] = identities[b], identities[a]
+            costumes[a], costumes[b] = costumes[b], costumes[a]
+            badges[a], badges[b] = badges[b], badges[a]
+        elif kind == "costume":
+            costumes[a], costumes[b] = costumes[b], costumes[a]
+        elif kind == "badge":
+            badges[a], badges[b] = badges[b], badges[a]
+        elif kind == "rotate":
+            identities = list(rotate(tuple(identities), a)); costumes = list(rotate(tuple(costumes), a)); badges = list(rotate(tuple(badges), a))
+        elif kind == "mirror":
+            identities.reverse(); costumes.reverse(); badges.reverse()
+        elif kind == "goal":
+            goal_shift = (goal_shift + a) % n
+        event_index += 1
+        phase = int(event_index == len(level["events"]))
+        return phase, tuple(identities), tuple(costumes), tuple(badges), event_index, cursor, -1, goal_shift, chances, terminal
+
+    if action == 1:
+        return phase, identities, costumes, badges, event_index, (cursor - 1) % n, held, goal_shift, chances, terminal
+    if action == 2:
+        return phase, identities, costumes, badges, event_index, (cursor + 1) % n, held, goal_shift, chances, terminal
+    if action == 3:
+        if held < 0:
+            return phase, identities, costumes, badges, event_index, cursor, cursor, goal_shift, chances, terminal
+        if held == cursor:
+            return phase, identities, costumes, badges, event_index, cursor, -1, goal_shift, chances, terminal
+        distance = min((held - cursor) % n, (cursor - held) % n)
+        if level["adjacent"] and distance != 1:
+            return state
+        identities, costumes, badges = list(identities), list(costumes), list(badges)
+        identities[held], identities[cursor] = identities[cursor], identities[held]
+        costumes[held], costumes[cursor] = costumes[cursor], costumes[held]
+        badges[held], badges[cursor] = badges[cursor], badges[held]
+        return phase, tuple(identities), tuple(costumes), tuple(badges), event_index, cursor, -1, goal_shift, chances, terminal
+    if action == 4:
+        if not level["ring"]:
+            return state
+        return phase, rotate(identities, 1), rotate(costumes, 1), rotate(badges, 1), event_index, cursor, held, goal_shift, chances, terminal
+    if action == 6:
+        if identities == target_order(level, state):
+            return phase, identities, costumes, badges, event_index, cursor, held, goal_shift, chances, 2
+        chances -= 1
+        return phase, identities, costumes, badges, event_index, cursor, -1, goal_shift, chances, 3 if chances <= 0 else 0
+    return state
+
+
+def action_cost(state, after):
+    # A rejected curtain check spends a brass retry, not a spring tooth.
+    return 0 if after[8] < state[8] else 1
+
+
+def solved(_level, state):
+    return state[-1] == 2
+
+
+class MasqueradeDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def line(frame, a, b, color, dotted=False):
+        x0, y0 = a; x1, y1 = b; steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for i in range(steps + 1):
+            if dotted and i % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * i // steps; y = y0 + (y1 - y0) * i // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                d = (x - cx) ** 2 + (y - cy) ** 2
+                if d <= radius ** 2 and (not hollow or d >= max(0, radius - 1) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def center(index, n, y=31):
+        return 7 + index * (50 // max(1, n - 1)), y
+
+    def background(self, frame):
+        frame[:, :] = INK
+        frame[11:51, 3:61] = SMOKE
+        for x in range(5, 61, 6):
+            frame[12:50:4, x] = STEEL
+        self.line(frame, (3, 10), (60, 10), GOLD)
+        self.line(frame, (3, 51), (60, 51), COPPER)
+        for x in range(5, 61, 8):
+            self.disc(frame, (x, 9), 2, GOLD)
+
+    def sigil(self, frame, center, identity, color=SILVER, small=False):
+        x, y = center; r = 2 if small else 3; kind = identity % 6
+        if kind == 0:
+            self.disc(frame, center, r, color, hollow=True); frame[y, x] = color
+        elif kind == 1:
+            self.line(frame, (x, y - r), (x + r, y + r), color); self.line(frame, (x + r, y + r), (x - r, y + r), color); self.line(frame, (x - r, y + r), (x, y - r), color)
+        elif kind == 2:
+            self.line(frame, (x, y - r), (x + r, y), color); self.line(frame, (x + r, y), (x, y + r), color); self.line(frame, (x, y + r), (x - r, y), color); self.line(frame, (x - r, y), (x, y - r), color)
+        elif kind == 3:
+            self.line(frame, (x - r, y), (x + r, y), color); self.line(frame, (x, y - r), (x, y + r), color)
+        elif kind == 4:
+            self.line(frame, (x - r, y - r), (x + r, y + r), color); self.line(frame, (x + r, y - r), (x - r, y + r), color)
+        else:
+            for dx, dy in ((0, -r), (r, 0), (0, r), (-r, 0)):
+                self.disc(frame, (x + dx, y + dy), 1, color)
+
+    def mask(self, frame, center, costume, badge, identity=None):
+        x, y = center; color = (MAGENTA, AQUA, GOLD, COPPER, GREEN, VIOLET)[costume % 6]
+        kind = costume % 3
+        if kind == 0:
+            self.disc(frame, (x, y), 7, color)
+            frame[y - 2:y + 3, x - 6:x + 7:3] = INK
+        elif kind == 1:
+            self.line(frame, (x, y - 8), (x + 7, y + 5), color); self.line(frame, (x + 7, y + 5), (x - 7, y + 5), color); self.line(frame, (x - 7, y + 5), (x, y - 8), color)
+            frame[y + 2:y + 5, x - 4:x + 5] = color
+        else:
+            frame[y - 6:y + 7, x - 6:x + 7] = color
+            frame[y - 8:y - 5, x - 3:x + 4] = color
+            frame[y - 2:y + 3, x - 4:x + 5] = INK
+        # Badge vocabulary is pattern/shape redundant, never hue-only.
+        by = y - 10
+        if badge % 3 == 0:
+            self.disc(frame, (x, by), 2, SILVER, hollow=True)
+        elif badge % 3 == 1:
+            self.line(frame, (x - 2, by + 2), (x, by - 2), SILVER); self.line(frame, (x, by - 2), (x + 2, by + 2), SILVER)
+        else:
+            frame[by - 1:by + 2, x - 1:x + 2] = SILVER
+        if identity is not None:
+            self.disc(frame, center, 4, INK)
+            self.sigil(frame, center, identity, SILVER)
+
+    def footlight(self, frame, center, identity):
+        x, y = center
+        self.disc(frame, center, 6, STEEL, hollow=True)
+        self.sigil(frame, (x, y), identity, GOLD, small=True)
+        frame[y + 5:y + 7, x - 4:x + 5] = COPPER
+
+    def event_glyph(self, frame, kind, center, done=False):
+        x, y = center; color = ASH if done else GOLD
+        if kind == "pos":
+            self.line(frame, (x - 3, y - 1), (x + 3, y + 1), color); self.disc(frame, (x - 3, y - 1), 1, color); self.disc(frame, (x + 3, y + 1), 1, color)
+        elif kind == "costume":
+            self.line(frame, (x - 3, y + 2), (x, y - 2), color); self.line(frame, (x, y - 2), (x + 3, y + 2), color)
+        elif kind == "badge":
+            self.disc(frame, center, 2, color, hollow=True); frame[y, x] = color
+        elif kind == "rotate":
+            self.disc(frame, center, 3, color, hollow=True); frame[y - 3:y, x + 2:x + 4] = color
+        elif kind == "mirror":
+            self.line(frame, (x, y - 3), (x, y + 3), color); self.line(frame, (x - 3, y), (x - 1, y - 2), color); self.line(frame, (x + 3, y), (x + 1, y + 2), color)
+        else:
+            self.disc(frame, center, 3, color, hollow=True); self.sigil(frame, center, 0, color, small=True)
+
+    def moving_positions(self):
+        g = self.game
+        if not g.anim_kind or not g.pending_state:
+            return None
+        if g.anim_kind not in ("event_pos", "event_rotate", "event_mirror", "repair_swap", "ring"):
+            return None
+        old_ids = g.state[1]; new_ids = g.pending_state[1]
+        return {i: new_ids.index(identity) for i, identity in enumerate(old_ids)}
+
+    def stage(self, frame):
+        g = self.game; state = g.state; n = g.level["n"]; movers = self.moving_positions()
+        if movers:
+            p = g.anim_progress
+            for old_pos, new_pos in movers.items():
+                a = self.center(old_pos, n); b = self.center(new_pos, n)
+                x = a[0] + (b[0] - a[0]) * p // g.anim_total
+                arch = abs(b[0] - a[0]) // 6
+                y = a[1] - (arch * p * (g.anim_total - p) * 4 // max(1, g.anim_total * g.anim_total))
+                self.mask(frame, (x, y), state[2][old_pos], state[3][old_pos])
+        else:
+            reveal = state[0] == 0 and state[4] == 0
+            for i in range(n):
+                self.mask(frame, self.center(i, n), state[2][i], state[3][i], state[1][i] if reveal else None)
+        goals = target_order(g.level, state)
+        if g.anim_kind == "event_goal" and g.pending_state:
+            new_goals = target_order(g.level, g.pending_state); p = g.anim_progress
+            for old_pos, identity in enumerate(goals):
+                new_pos = new_goals.index(identity)
+                before = self.center(old_pos, n, 57); after = self.center(new_pos, n, 57)
+                center = (before[0] + (after[0] - before[0]) * p // g.anim_total,
+                          before[1] - p * (g.anim_total - p) // max(1, g.anim_total))
+                self.footlight(frame, center, identity)
+        else:
+            for i, identity in enumerate(goals):
+                self.footlight(frame, self.center(i, n, 57), identity)
+        # A toothed floor coupling advertises adjacent-only repair.
+        if g.level["adjacent"]:
+            for i in range(n - 1):
+                a = self.center(i, n, 46); b = self.center(i + 1, n, 46)
+                self.line(frame, a, b, SILVER, dotted=True)
+            # Coupling is a closed rail: a low U-shaped return makes the legal
+            # first-to-last edge as explicit as every neighboring segment.
+            first = self.center(0, n, 46); last = self.center(n - 1, n, 46)
+            self.line(frame, first, (first[0], 50), SILVER, dotted=True)
+            self.line(frame, (first[0], 50), (last[0], 50), SILVER, dotted=True)
+            self.line(frame, (last[0], 50), last, SILVER, dotted=True)
+            self.disc(frame, (first[0], 48), 1, GOLD); self.disc(frame, (last[0], 48), 1, GOLD)
+        if g.level["ring"]:
+            # The winding handle anticipates the whole-carousel repair verb.
+            self.disc(frame, (32, 48), 3, COPPER, hollow=True)
+            frame[45:48, 34:37] = COPPER
+        if state[0] == 1:
+            cx, _ = self.center(state[5], n)
+            self.disc(frame, (cx, 31), 10, GOLD, hollow=True)
+            frame[43:47, max(0, cx - 5):min(64, cx + 6)] = GOLD
+            if state[6] >= 0:
+                hx, _ = self.center(state[6], n)
+                self.disc(frame, (hx, 31), 12, AQUA, hollow=True)
+
+    def hud(self, frame):
+        g = self.game; state = g.state
+        for i, item in enumerate(g.level["events"]):
+            self.event_glyph(frame, item[0], (8 + i * 7, 5), i < state[4])
+            # Endpoint/amount pinholes make the settled event ledger an exact
+            # record rather than asking animation memory to carry the rule.
+            if item[0] in ("pos", "costume", "badge"):
+                color = ASH if i < state[4] else GOLD
+                # Two height-coded brass posts remain readable when six slot
+                # indices cannot fit as tiny horizontal pinholes.
+                left = 5 + i * 7; right = left + 5
+                frame[11 - (item[1] + 1):11, left:left + 2] = color
+                frame[11 - (item[2] + 1):11, right:right + 2] = color
+            elif item[0] in ("rotate", "goal"):
+                frame[9, 5 + i * 7:5 + i * 7 + min(6, item[1])] = ASH if i < state[4] else GOLD
+        # Remaining spring teeth are broad; spent teeth collapse to pins.
+        for i in range(g.budget_max):
+            y = 13 + i
+            if i < g.budget_left:
+                frame[y, 1:4] = GOLD
+            else:
+                frame[y, 1] = ASH
+        for i in range(state[8]):
+            self.disc(frame, (56 + i * 5, 5), 2, COPPER, hollow=True)
+
+    def animation(self, frame):
+        g = self.game
+        if not g.anim_kind:
+            if g.intro_mark:
+                self.line(frame, (4, 50), (60, 50), GOLD)
+            if g.terminal_hold == "loss":
+                frame[12:51, 29:35] = RED
+            return
+        p = g.anim_progress; n = g.level["n"]
+        if g.anim_kind in ("event_costume", "event_badge"):
+            kind, a, b = g.active_event
+            ca, cb = self.center(a, n), self.center(b, n)
+            color = VIOLET if kind == "costume" else SILVER
+            for source, dest in ((ca, cb), (cb, ca)):
+                mid = (source[0] + (dest[0] - source[0]) * p // g.anim_total,
+                       source[1] - 9 - (p * (g.anim_total - p) // max(1, g.anim_total)))
+                self.disc(frame, mid, 3 if kind == "costume" else 2, color, hollow=True)
+        elif g.anim_kind == "event_goal":
+            self.disc(frame, (32, 57), 5 + p * 4, GOLD, hollow=True)
+        elif g.anim_kind in ("cursor", "pick"):
+            self.disc(frame, self.center(g.pending_state[5], n), 9 + p, AQUA if g.anim_kind == "pick" else GOLD, hollow=True)
+        elif g.anim_kind == "recoil":
+            cx, _ = self.center(g.state[5], n)
+            self.disc(frame, (cx + (-1) ** p * 2, 31), 9 + p, RED, hollow=True)
+        elif g.anim_kind == "success":
+            frame[11:11 + min(40, p * 7), 3:8] = WINE
+            frame[11:11 + min(40, p * 7), 56:61] = WINE
+            for x in range(7, 59, 7):
+                self.disc(frame, (x, 9), 2 + p // 2, GOLD, hollow=True)
+        elif g.anim_kind == "loss":
+            frame[11:51, 3:3 + min(29, p * 5)] = WINE
+            frame[11:51, 61 - min(29, p * 5):61] = WINE
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self.background(frame); self.stage(frame); self.hud(frame); self.animation(frame); return frame
+
+
+class Q081(ARCBaseGame):
+    def __init__(self):
+        self.display = MasqueradeDisplay(self); self.level = LEVELS[0]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0; self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None; self.active_event = None; self.intro_mark = True; self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"]) for item in LEVELS]
+        super().__init__("q081", levels, Camera(0, 0, 64, 64, INK, INK, [self.display]), False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]; self.state = start_state(self.level); self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None; self.active_event = None; self.intro_mark = True; self.terminal_hold = None
+
+    def begin(self, kind, frames, state, budget, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames; self.anim_progress = 0
+        self.pending_state = state; self.pending_budget = budget; self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal; self.state = self.pending_state; self.budget_left = self.pending_budget
+        self.anim_kind = None; self.pending_state = self.pending_budget = self.pending_terminal = None; self.active_event = None
+        if terminal == "win": self.terminal_hold = "win"; self.next_level()
+        elif terminal == "loss": self.terminal_hold = "loss"; self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1; self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0: self.finish()
+            return
+        action = self.action.id.value
+        if action == 0: self.complete_action(); return
+        self.intro_mark = False; before = self.state; after = transition(self.level, before, action)
+        if after == before:
+            self.begin("recoil", 4, before, self.budget_left); return
+        budget = self.budget_left - action_cost(before, after); won = after[-1] == 2; lost = after[-1] == 3 or (budget <= 0 and not won)
+        if won: kind = "success"
+        elif lost: kind = "loss"
+        elif before[0] == 0:
+            self.active_event = self.level["events"][before[4]]
+            kind = "event_" + self.active_event[0]
+        elif after[8] < before[8]: kind = "recoil"
+        elif action in (1, 2): kind = "cursor"
+        elif action == 3 and before[6] < 0: kind = "pick"
+        elif action == 3: kind = "repair_swap"
+        elif action == 4: kind = "ring"
+        else: kind = "recoil"
+        frames = 7 if kind in ("success", "loss", "event_rotate", "event_mirror", "event_goal") else 5
+        self.begin(kind, frames, after, budget, "win" if won else "loss" if lost else None)

--- a/data/community-games/sonpham/q088_v2_q088.py
+++ b/data/community-games/sonpham/q088_v2_q088.py
@@ -1,0 +1,596 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q088-v2 Iron Porters -- spatial identity debt in an industrial relay.
+
+Two differently shaped porters share one capability helmet across aligned
+transfer rails.  Work adds brass weight tags to the identity that performed
+it, never to the helmet; scales remove those tags.  Helmet gates, capacity
+limits, debt passages, and witness plates make repayment timing change which
+routes and services remain possible.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+WHITE, PEARL, IRON, STEEL, CHARCOAL, BLACK = 0, 1, 2, 3, 4, 5
+HAZARD, RED, BRASS, RUST, GREEN, VIOLET = 6, 8, 11, 12, 14, 15
+
+
+def depot(name, length, start, tasks, transfers, scales, goal, budget, **rules):
+    item = {
+        "name": name,
+        "length": length,
+        "start": tuple(start),            # pos A, pos B, active, helmet
+        "tasks": tuple(tuple(task) for task in tasks),  # owner, position, weight
+        "transfers": tuple(transfers),
+        "scales": tuple(tuple(row) for row in scales),
+        "goal": tuple(goal),              # pos A, pos B, active, helmet
+        "budget": budget,
+        "capacity": (3, 3),
+        "helmet_gates": (),               # owner, edge-left-index
+        "debt_gates": (),                 # owner, edge-left-index, maximum debt
+        "witness": tuple(-1 for _ in tasks),
+    }
+    item.update(rules)
+    item["helmet_gates"] = tuple(tuple(gate) for gate in item["helmet_gates"])
+    item["debt_gates"] = tuple(tuple(gate) for gate in item["debt_gates"])
+    item["witness"] = tuple(item["witness"])
+    return item
+
+
+LEVELS = [
+    depot("First Weight", 5, (0, 0, 0, 0), ((0, 2, 1),), (), ((1,), (1,)),
+          (0, 0, 0, 0), 7),
+    depot("Aligned Handoff", 6, (2, 0, 1, 0), ((1, 4, 1),), (2,), ((1,), (3,)),
+          (2, 2, 0, 0), 14),
+    depot("Helmet Gate", 7, (2, 2, 0, 0), ((1, 5, 1),), (2,), ((1,), (4,)),
+          (2, 2, 0, 0), 13, helmet_gates=((1, 3),)),
+    depot("Weight Limit", 7, (2, 2, 0, 0), ((1, 4, 2), (1, 5, 2)), (2,),
+          ((1,), (3,)), (2, 2, 0, 0), 19, capacity=(3, 2),
+          helmet_gates=((1, 3),)),
+    depot("Debt Passage", 7, (2, 2, 0, 0), ((1, 4, 1), (1, 6, 1)), (2,),
+          ((1,), (3, 6)), (2, 2, 0, 0), 17, capacity=(3, 2),
+          helmet_gates=((1, 3),), debt_gates=((1, 4, 0),)),
+    depot("Witness Bay", 7, (2, 0, 1, 0), ((0, 5, 1),), (2,), ((4,), (1,)),
+          (2, 4, 0, 0), 14, helmet_gates=((0, 3),), witness=(4,)),
+    depot("Double Customs", 7, (2, 2, 0, 0),
+          ((0, 4, 1), (1, 4, 1), (1, 6, 1)), (2,), ((3,), (3, 6)),
+          (2, 2, 0, 0), 23, capacity=(2, 1),
+          helmet_gates=((0, 3), (1, 3)), debt_gates=((1, 4, 0),)),
+    depot("Iron Porters", 7, (2, 0, 1, 0),
+          ((0, 5, 1), (1, 5, 1), (1, 6, 1)), (4,), ((4,), (4, 6)),
+          (4, 4, 0, 0), 24, capacity=(1, 1),
+          helmet_gates=((0, 3),), debt_gates=((1, 5, 1),),
+          witness=(4, 4, 4)),
+]
+
+
+def start_state(level):
+    pa, pb, active, helmet = level["start"]
+    # positions, selected identity, helmet identity, serviced-mask,
+    # identity-bound debts, two audit seals, terminal (0 play / 2 win / 3 loss)
+    return pa, pb, active, helmet, 0, 0, 0, 2, 0
+
+
+def _position(state, owner):
+    return state[owner]
+
+
+def _debt(state, owner):
+    return state[5 + owner]
+
+
+def _movement_allowed(level, state, owner, old, new):
+    edge = min(old, new)
+    if (owner, edge) in level["helmet_gates"] and state[3] != owner:
+        return False
+    for gate_owner, gate_edge, maximum in level["debt_gates"]:
+        if owner == gate_owner and edge == gate_edge and _debt(state, owner) > maximum:
+            return False
+    return True
+
+
+def configuration_solved(level, state):
+    done = (1 << len(level["tasks"])) - 1
+    return (state[4] == done and state[5] == 0 and state[6] == 0
+            and state[:4] == level["goal"])
+
+
+def transition(level, state, action):
+    pa, pb, active, helmet, done, debt_a, debt_b, audits, terminal = state
+    if terminal or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    values = [pa, pb]
+    debts = [debt_a, debt_b]
+    if action in (1, 2):
+        old = values[active]
+        new = old + (-1 if action == 1 else 1)
+        if not 0 <= new < level["length"]:
+            return state
+        if not _movement_allowed(level, state, active, old, new):
+            return state
+        values[active] = new
+        return values[0], values[1], active, helmet, done, debts[0], debts[1], audits, 0
+    if action == 3:
+        return pa, pb, 1 - active, helmet, done, debt_a, debt_b, audits, 0
+    if action == 4:
+        if active != helmet or pa != pb or pa not in level["transfers"]:
+            return state
+        return pa, pb, active, 1 - helmet, done, debt_a, debt_b, audits, 0
+    if action == 6:
+        if configuration_solved(level, state):
+            return pa, pb, active, helmet, done, debt_a, debt_b, audits, 2
+        audits -= 1
+        return pa, pb, active, helmet, done, debt_a, debt_b, audits, 3 if audits <= 0 else 0
+
+    # Context service: the selected porter must fit the station and wear the helmet.
+    # If a task is capacity-blocked at a scale, the same action honestly removes one
+    # tethered tag instead; the player can then retry the service.
+    other = 1 - active
+    for index, (owner, position, weight) in enumerate(level["tasks"]):
+        if done & (1 << index) or owner != active or position != values[active]:
+            continue
+        witness = level["witness"][index]
+        witnessed = witness < 0 or values[other] == witness
+        if helmet == active and witnessed and debts[active] + weight <= level["capacity"][active]:
+            done |= 1 << index
+            debts[active] += weight
+            return pa, pb, active, helmet, done, debts[0], debts[1], audits, 0
+        break
+    if debts[active] and values[active] in level["scales"][active]:
+        debts[active] -= 1
+        return pa, pb, active, helmet, done, debts[0], debts[1], audits, 0
+    return state
+
+
+def action_cost(before, after):
+    if after == before or after[7] < before[7] or after[-1] in (2, 3):
+        return 0
+    return 1
+
+
+def solved(_level, state):
+    return state[-1] == 2
+
+
+class DepotDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def line(frame, a, b, color, dotted=False):
+        x0, y0 = a; x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    @staticmethod
+    def diamond(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for dy in range(-radius, radius + 1):
+            y = cy + dy
+            if not 0 <= y < 64:
+                continue
+            width = radius - abs(dy)
+            if hollow:
+                for x in (cx - width, cx + width):
+                    if 0 <= x < 64:
+                        frame[y, x] = color
+            else:
+                left, right = max(0, cx - width), min(64, cx + width + 1)
+                frame[y, left:right] = color
+
+    @staticmethod
+    def rect(frame, x0, y0, x1, y1, color, hollow=False):
+        x0, x1 = max(0, x0), min(63, x1); y0, y1 = max(0, y0), min(63, y1)
+        if hollow:
+            frame[y0, x0:x1 + 1] = color; frame[y1, x0:x1 + 1] = color
+            frame[y0:y1 + 1, x0] = color; frame[y0:y1 + 1, x1] = color
+        else:
+            frame[y0:y1 + 1, x0:x1 + 1] = color
+
+    def xs(self):
+        n = self.game.level["length"]
+        return tuple(7 + index * 50 // max(1, n - 1) for index in range(n))
+
+    @staticmethod
+    def tag_direction(owner, x):
+        direction = -1 if owner == 0 else 1
+        if x < 17:
+            direction = 1
+        elif x > 47:
+            direction = -1
+        return direction
+
+    def background(self, frame):
+        frame[:, :] = BLACK
+        self.rect(frame, 2, 3, 61, 55, CHARCOAL, hollow=True)
+        for x in range(5, 61, 8):
+            self.rect(frame, x, 5, x + 3, 52, STEEL, hollow=True)
+        for y in (17, 27, 39, 50):
+            frame[y, 3:61] = IRON
+            frame[y + 1, 4:60:4] = RUST
+        for y in range(6, 54, 7):
+            frame[y, 6 + y % 5:59:11] = STEEL
+        for x, y in ((4, 4), (59, 4), (4, 54), (59, 54)):
+            self.diamond(frame, (x, y), 1, BRASS)
+
+    def porter(self, frame, owner, x, selected, helmet, debts, offset=(0, 0)):
+        x += offset[0]; y = (21, 44)[owner] + offset[1]
+        if owner == 0:
+            # Wedge porter: triangular shoulders, central striped spine.
+            for row in range(6):
+                frame[y - 4 + row, max(0, x - row):min(64, x + row + 1)] = RUST
+            self.line(frame, (x, y - 4), (x, y + 5), WHITE)
+            frame[y + 2:y + 5, max(0, x - 3):min(64, x + 4):2] = IRON
+        else:
+            # Fork porter: twin prongs and a notched crossbar.
+            self.rect(frame, x - 4, y - 4, x - 2, y + 4, STEEL)
+            self.rect(frame, x + 2, y - 4, x + 4, y + 4, STEEL)
+            self.rect(frame, x - 4, y, x + 4, y + 2, RUST)
+            frame[y - 2:y, x - 2:x + 3:2] = WHITE
+        if selected:
+            self.rect(frame, x - 6, y - 6, x + 6, y + 6, WHITE, hollow=True)
+            frame[y - 7, x - 3:x + 4:2] = BRASS
+        if helmet:
+            self.helmet(frame, x, y - 6)
+        # Large filled weights show debt; smaller hollow notches expose capacity.
+        capacity = self.game.level["capacity"][owner]
+        direction = self.tag_direction(owner, x)
+        anchor = (x + direction * 4, y + 4)
+        self.line(frame, anchor, (x + direction * (6 + capacity * 3), y + 6),
+                  BRASS if debts else STEEL, dotted=True)
+        for index in range(capacity):
+            tx = x + direction * (7 + index * 3)
+            filled = index < debts
+            self.diamond(frame, (tx, y + 6), 2 if filled else 1,
+                         BRASS if filled else STEEL, hollow=True)
+            if filled:
+                frame[y + 6, tx] = RUST
+
+    def helmet(self, frame, x, y):
+        self.rect(frame, x - 4, y - 2, x + 4, y, BRASS)
+        frame[y - 4:y - 1, x - 2:x + 3] = IRON
+        frame[y - 3, x] = WHITE
+
+    def static_geometry(self, frame):
+        g = self.game; xs = self.xs(); level = g.level
+        # Overhead crane rail and transfer posts.
+        frame[10, xs[0]:xs[-1] + 1] = IRON
+        frame[11, xs[0]:xs[-1] + 1:3] = BRASS
+        for position in level["transfers"]:
+            x = xs[position]
+            self.rect(frame, x - 2, 13, x + 2, 51, STEEL, hollow=True)
+            frame[15:50:4, x] = WHITE
+            if g.state[0] == position and g.state[1] == position:
+                self.diamond(frame, (x, 32), 3, BRASS, hollow=True)
+        # Helmet and debt passages are physically different closures.
+        for owner, edge in level["helmet_gates"]:
+            x = (xs[edge] + xs[edge + 1]) // 2; y = (21, 44)[owner]
+            open_gate = g.state[3] == owner
+            color = WHITE if open_gate else HAZARD
+            if open_gate:
+                self.rect(frame, x - 4, y - 7, x - 2, y + 7, color, hollow=True)
+                self.rect(frame, x + 2, y - 7, x + 4, y + 7, color, hollow=True)
+            else:
+                self.rect(frame, x - 1, y - 7, x + 1, y + 7, color, hollow=True)
+                frame[y, x - 4:x + 5] = color
+            self.helmet(frame, x, y - 7)
+        for owner, edge, maximum in level["debt_gates"]:
+            x = (xs[edge] + xs[edge + 1]) // 2; y = (21, 44)[owner]
+            open_gate = _debt(g.state, owner) <= maximum
+            color = WHITE if open_gate else RED
+            if open_gate:
+                self.line(frame, (x - 5, y - 6), (x - 2, y - 2), color)
+                self.line(frame, (x + 5, y + 6), (x + 2, y + 2), color)
+            else:
+                self.line(frame, (x - 3, y - 6), (x + 3, y + 6), color)
+                self.line(frame, (x + 3, y - 6), (x - 3, y + 6), color)
+            for notch in range(maximum + 1):
+                self.diamond(frame, (x - 2 + notch * 4, y), 1, BRASS, hollow=True)
+        # Scales are toothed anvils; witness plates are cross-hatched bays.
+        for owner, positions in enumerate(level["scales"]):
+            y = (29, 52)[owner]
+            for position in positions:
+                x = xs[position]
+                frame[y, x - 4:x + 5] = BRASS
+                frame[y + 1:y + 3, x - 3:x + 4:2] = IRON
+        for index, witness in enumerate(level["witness"]):
+            if witness < 0:
+                continue
+            owner = level["tasks"][index][0]; other = 1 - owner
+            x, y = xs[witness], (21, 44)[other]
+            self.rect(frame, x - 5, y + 7, x + 5, y + 9, WHITE, hollow=True)
+            frame[y + 8, x - 4:x + 5:2] = RUST
+            if _position(g.state, other) == witness:
+                self.diamond(frame, (x, y + 8), 2, WHITE)
+
+    def station(self, frame, index, owner, position, done):
+        x = self.xs()[position]; y = (14, 36)[owner]
+        color = STEEL if done else BRASS
+        if owner == 0:
+            self.line(frame, (x - 5, y + 3), (x, y - 3), color)
+            self.line(frame, (x, y - 3), (x + 5, y + 3), color)
+            self.line(frame, (x + 5, y + 3), (x - 5, y + 3), color)
+        else:
+            self.rect(frame, x - 5, y - 3, x - 3, y + 3, color)
+            self.rect(frame, x + 3, y - 3, x + 5, y + 3, color)
+            frame[y + 1:y + 3, x - 5:x + 6] = color
+        # Rivet count redundantly exposes task weight.
+        weight = self.game.level["tasks"][index][2]
+        for rivet in range(weight):
+            self.diamond(frame, (x - 2 + rivet * 4, y), 1, WHITE if not done else IRON)
+        if done:
+            self.line(frame, (x - 5, y - 4), (x + 5, y + 4), GREEN)
+            self.line(frame, (x + 5, y - 4), (x - 5, y + 4), GREEN)
+
+    def goals(self, frame):
+        g = self.game; xs = self.xs(); pa, pb, active, helmet = g.level["goal"]
+        for owner, position in enumerate((pa, pb)):
+            x, y = xs[position], (21, 44)[owner]
+            color = WHITE if owner == active else IRON
+            self.line(frame, (x - 7, y - 7), (x - 7, y - 3), color)
+            self.line(frame, (x - 7, y - 7), (x - 3, y - 7), color)
+            self.line(frame, (x + 7, y + 7), (x + 7, y + 3), color)
+            self.line(frame, (x + 7, y + 7), (x + 3, y + 7), color)
+            if owner == active:
+                # Twin inward inspection teeth mark the required final selection;
+                # the other goal remains a plain four-corner dock.
+                if x < 16:
+                    targets = ((x + 8, y - 3), (x + 8, y + 3))
+                elif x > 48:
+                    targets = ((x - 8, y - 3), (x - 8, y + 3))
+                else:
+                    targets = ((x - 8, y), (x + 8, y))
+                for target in targets:
+                    self.diamond(frame, target, 2, WHITE, hollow=True)
+            if owner == helmet:
+                self.rect(frame, x - 3, y - 10, x + 3, y - 9, BRASS, hollow=True)
+
+    def audits(self, frame):
+        g = self.game
+        audit_count = g.state[7]
+        if (g.anim_kind == "audit_reject" and g.pending_state is not None
+                and g.anim_progress >= max(1, g.anim_total - 1)):
+            audit_count = g.pending_state[7]
+        for index, center in enumerate(((8, 7), (56, 7))):
+            active = index < audit_count
+            if index == 0:
+                self.rect(frame, center[0] - 3, center[1] - 3,
+                          center[0] + 3, center[1] + 3,
+                          BRASS if active else STEEL, hollow=not active)
+                frame[center[1], center[0] - 4:center[0] + 5:2] = WHITE if active else IRON
+            else:
+                self.diamond(frame, center, 4, BRASS if active else STEEL, hollow=not active)
+                self.line(frame, (center[0] - 3, center[1]),
+                          (center[0] + 3, center[1]), WHITE if active else IRON)
+
+    def energy(self, frame):
+        g = self.game
+        budget_left = g.budget_left
+        if (g.anim_kind and g.pending_budget is not None
+                and g.anim_progress >= max(1, g.anim_total - 1)
+                and g.anim_kind != "success"):
+            budget_left = g.pending_budget
+        for group in range((g.budget_max + 3) // 4):
+            cx = 7 + group * 8; cy = 60
+            self.diamond(frame, (cx, cy), 1, IRON)
+            for tooth, (dx, dy) in enumerate(((0, -2), (2, 0), (0, 2), (-2, 0))):
+                number = group * 4 + tooth
+                if number >= g.budget_max:
+                    continue
+                self.diamond(frame, (cx + dx, cy + dy), 1,
+                             BRASS if number < budget_left else STEEL)
+
+    def animation(self, frame):
+        g = self.game
+        if g.intro_mark:
+            self.line(frame, (5, 13), (59, 13), WHITE, dotted=True)
+            self.line(frame, (5, 54), (59, 54), RUST, dotted=True)
+        if not g.anim_kind:
+            return
+        p, total = g.anim_progress, max(1, g.anim_total)
+        # The engine renders progress 0..total-1 and then commits.  Interpolate
+        # across that rendered span so the last animated pose exactly meets the
+        # pending settled pose instead of jumping the final fraction.
+        span = max(1, total - 1)
+        xs = self.xs(); owner = g.state[2]
+        if g.anim_kind == "move":
+            start, end = xs[g.anim_from], xs[g.anim_to]
+            x = start + (end - start) * p // span
+            lift = 8 * p * (span - p) // max(1, span * span)
+            self.porter(frame, owner, x, True, g.state[3] == owner,
+                        _debt(g.state, owner), (0, -lift))
+        elif g.anim_kind == "switch":
+            old, new = g.state[2], g.pending_state[2]
+            x0, y0 = xs[g.state[old]], (21, 44)[old]
+            x1, y1 = xs[g.state[new]], (21, 44)[new]
+            x = x0 + (x1 - x0) * p // span; y = y0 + (y1 - y0) * p // span
+            if p >= span:
+                self.porter(frame, new, x1, True, g.pending_state[3] == new,
+                            _debt(g.pending_state, new))
+            else:
+                self.rect(frame, x - 6, y - 6, x + 6, y + 6, WHITE, hollow=True)
+                frame[y - 7, max(0, x - 3):min(64, x + 4):2] = BRASS
+        elif g.anim_kind == "transfer":
+            x = xs[g.state[0]]; old, new = g.state[3], g.pending_state[3]
+            y0, y1 = (15, 38)[old], (15, 38)[new]
+            y = y0 + (y1 - y0) * p // span
+            self.helmet(frame, x, y)
+            self.line(frame, (x, min(y0, y1)), (x, max(y0, y1)), BRASS, dotted=True)
+        elif g.anim_kind in ("service", "repay"):
+            x = xs[_position(g.state, owner)]; y = (21, 44)[owner]
+            station_y = (14, 36)[owner] if g.anim_kind == "service" else (29, 52)[owner]
+            direction = self.tag_direction(owner, x)
+            if g.anim_kind == "service":
+                old_debt = _debt(g.state, owner)
+                new_debt = _debt(g.pending_state, owner)
+                for index in range(old_debt, new_debt):
+                    target = (x + direction * (7 + index * 3), y + 6)
+                    tx = x + (target[0] - x) * p // span
+                    ty = station_y + (target[1] - station_y) * p // span
+                    self.diamond(frame, (tx, ty), 2, BRASS, hollow=True)
+                    self.line(frame, (x, station_y), (tx, ty), WHITE, dotted=True)
+            else:
+                debt_index = max(0, _debt(g.state, owner) - 1)
+                source = (x + direction * (7 + debt_index * 3), y + 6)
+                tx = source[0] + (x - source[0]) * p // span
+                ty = source[1] + (station_y - source[1]) * p // span
+                if p < span:  # the scale has fully absorbed the tag at settlement
+                    self.diamond(frame, (tx, ty), 2, BRASS, hollow=True)
+                    self.line(frame, source, (tx, ty), WHITE, dotted=True)
+        elif g.anim_kind == "blocked":
+            direction = -1 if g.anim_action == 1 else 1 if g.anim_action == 2 else 0
+            x = xs[_position(g.state, owner)]
+            folded = min(p, span - p)
+            recoil = (3 * folded + max(1, span // 4)) // max(1, span // 2)
+            offset = (-direction * recoil, 0) if direction else (0, -recoil)
+            self.porter(frame, owner, x, True, g.state[3] == owner,
+                        _debt(g.state, owner), offset)
+            if p < span:
+                cue = 6 * (span - p) // span
+                self.line(frame, (x - cue, (21, 44)[owner] - cue),
+                          (x + cue, (21, 44)[owner] + cue), RED)
+        elif g.anim_kind == "audit_reject":
+            seal = max(0, g.state[7] - 1); x = (8, 56)[seal]
+            radius = 2 * p // span
+            if p < span:
+                self.line(frame, (x - radius, 5 - radius), (x + radius, 5 + radius), RED)
+                self.line(frame, (x + radius, 5 - radius), (x - radius, 5 + radius), RED)
+        elif g.anim_kind == "success":
+            for owner, position in enumerate(g.level["goal"][:2]):
+                x, y = xs[position], (21, 44)[owner]
+                self.rect(frame, x - 5 - p, y - 5, x + 5 + p, y + 5,
+                          GREEN, hollow=True)
+            self.line(frame, (6, 32), (6 + p * 8, 32), BRASS)
+        elif g.anim_kind == "loss":
+            left = 4 + 11 * p // span; right = 60 - 11 * p // span
+            top = 14 + 4 * p // span; bottom = 53 - 4 * p // span
+            self.line(frame, (left, top), (right, bottom), RED)
+            self.line(frame, (right, top), (left, bottom), HAZARD)
+            if p >= span:
+                self.rect(frame, 24, 28, 40, 38, STEEL, hollow=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        g = self.game
+        preview_settle = (g.anim_kind in (
+            "move", "switch", "transfer", "service", "repay",
+            "blocked", "audit_reject", "loss")
+            and g.pending_state is not None
+            and g.anim_progress >= max(1, g.anim_total - 1))
+        current_state = g.state
+        if preview_settle:
+            g.state = g.pending_state
+        self.background(frame); self.static_geometry(frame)
+        for index, (owner, position, _weight) in enumerate(g.level["tasks"]):
+            self.station(frame, index, owner, position, bool(g.state[4] & (1 << index)))
+        self.goals(frame)
+        moving = g.anim_kind == "move"
+        transferring = g.anim_kind == "transfer"
+        switching = g.anim_kind == "switch"
+        blocked = g.anim_kind == "blocked"
+        xs = self.xs()
+        for owner in (0, 1):
+            if (moving or blocked) and owner == g.state[2]:
+                continue
+            visible_debt = _debt(g.state, owner)
+            if g.anim_kind == "repay" and owner == g.state[2] and not preview_settle:
+                visible_debt = max(0, visible_debt - 1)
+            self.porter(frame, owner, xs[_position(g.state, owner)],
+                        owner == g.state[2] and not switching,
+                        g.state[3] == owner and not transferring,
+                        visible_debt)
+        self.audits(frame); self.energy(frame); self.animation(frame)
+        if g.state[-1] == 3 and not g.anim_kind:
+            self.line(frame, (15, 18), (49, 49), RED)
+            self.line(frame, (49, 18), (15, 49), HAZARD)
+            self.rect(frame, 24, 28, 40, 38, STEEL, hollow=True)
+        if preview_settle:
+            g.state = current_state
+        return frame
+
+
+class Q088(ARCBaseGame):
+    def __init__(self):
+        self.display = DepotDisplay(self)
+        self.level = LEVELS[0]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_from = self.anim_to = self.anim_action = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        self.intro_mark = True
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q088", levels, Camera(0, 0, 64, 64, BLACK, BLACK, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_from = self.anim_to = self.anim_action = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        self.intro_mark = True
+
+    def begin(self, kind, frames, after, budget, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames; self.anim_progress = 0
+        self.pending_state = after; self.pending_budget = budget; self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state; self.budget_left = self.pending_budget
+        self.anim_kind = None; self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1; self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action(); return
+        self.intro_mark = False; self.anim_action = action
+        before = self.state; after = transition(self.level, before, action)
+        if after == before:
+            self.begin("blocked", 5, before, self.budget_left); return
+        cost = action_cost(before, after)
+        if cost > self.budget_left:
+            lost = before[:-1] + (3,)
+            self.begin("loss", 7, lost, self.budget_left, "loss"); return
+        budget = self.budget_left - cost
+        self.anim_from, self.anim_to = _position(before, before[2]), _position(after, before[2])
+        if after[-1] == 2:
+            kind, frames, terminal = "success", 7, "win"
+        elif after[-1] == 3:
+            kind, frames, terminal = "loss", 7, "loss"
+        elif action == 6:
+            kind, frames, terminal = "audit_reject", 5, None
+        elif action in (1, 2):
+            kind, frames, terminal = "move", 5, None
+        elif action == 3:
+            kind, frames, terminal = "switch", 4, None
+        elif action == 4:
+            kind, frames, terminal = "transfer", 6, None
+        else:
+            kind = "service" if after[4] != before[4] else "repay"
+            frames, terminal = 6, None
+        self.begin(kind, frames, after, budget, terminal)

--- a/data/community-games/sonpham/q091_v2_q091.py
+++ b/data/community-games/sonpham/q091_v2_q091.py
@@ -1,0 +1,460 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q091-v2 Hearthwork Atelier -- assemble keyed artifacts on a tactile bench.
+
+Parts expose shape-coded leaves and oriented ports.  The player moves a bench
+cursor, lifts two parts, chooses a persistent fixture, and presses.  Later work
+orders add rotation, unlike fixtures, and limited fixture faces.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+CREAM, PEARL, FELT, WOOD, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RUST, BLUE, TEAL, MUSTARD, CORAL, EARTH, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+DANGER = MAGENTA
+
+
+def R(a, b, tool, ra, rb, out, ro=0):
+    return (a, b, tool, ra, rb, out, ro)
+
+
+LEVELS = [
+    {"name": "First Snap", "parts": ((1, 0), (2, 0)), "target": 3,
+     "tools": (0,), "limits": (9,), "rotatable": False,
+     "recipes": (R(1, 2, 0, 0, 0, 3),), "budget": 6},
+    {"name": "Growing Key", "parts": ((1, 0), (2, 0), (4, 0), (8, 0)), "target": 15,
+     "tools": (0,), "limits": (9,), "rotatable": False,
+     "recipes": (R(1, 2, 0, 0, 0, 3), R(3, 4, 0, 0, 0, 7), R(7, 8, 0, 0, 0, 15)), "budget": 15},
+    {"name": "Turning Teeth", "parts": ((1, 0), (2, 0), (4, 0), (8, 0)), "target": 15,
+     "tools": (0,), "limits": (9,), "rotatable": True,
+     "recipes": (R(1, 2, 0, 1, 0, 3), R(3, 4, 0, 0, 2, 7), R(7, 8, 0, 0, 1, 15)), "budget": 18},
+    {"name": "Brass Clamp", "parts": ((1, 0), (2, 0), (4, 0), (8, 0)), "target": 15,
+     "tools": (0, 1), "limits": (9, 9), "rotatable": False,
+     "recipes": (R(1, 2, 1, 0, 0, 3), R(4, 8, 0, 0, 0, 12), R(3, 12, 1, 0, 0, 15)), "budget": 17},
+    {"name": "Two Fixtures", "parts": ((1, 0), (2, 0), (4, 0), (8, 0)), "target": 15,
+     "tools": (0, 1, 2), "limits": (9, 9, 9), "rotatable": False,
+     "recipes": (R(1, 4, 1, 0, 0, 5), R(2, 8, 2, 0, 0, 10), R(5, 10, 0, 0, 0, 15)), "budget": 18},
+    {"name": "Finite Faces", "parts": ((1, 0), (2, 0), (4, 0), (8, 0), (16, 0)), "target": 31,
+     "tools": (0, 1, 2), "limits": (9, 1, 2), "rotatable": False,
+     "recipes": (R(1, 2, 2, 0, 0, 3), R(4, 8, 1, 0, 0, 12), R(3, 16, 2, 0, 0, 19), R(12, 19, 0, 0, 0, 31)), "budget": 25},
+    {"name": "Rose Engine", "parts": ((1, 0), (2, 0), (4, 0), (8, 0), (16, 0), (32, 0)), "target": 63,
+     "tools": (0, 1, 2), "limits": (9, 2, 2), "rotatable": True,
+     "recipes": (R(1, 16, 1, 1, 0, 17), R(2, 8, 2, 0, 2, 10), R(4, 32, 1, 3, 1, 36),
+                 R(10, 17, 2, 0, 0, 27), R(27, 36, 0, 0, 0, 63)), "budget": 39},
+    {"name": "Hearthwork Atelier", "parts": ((1, 0), (2, 0), (4, 0), (8, 0), (16, 0), (32, 0)), "target": 63,
+     "tools": (0, 1, 2), "limits": (9, 2, 2), "rotatable": True,
+     "recipes": (R(1, 32, 2, 1, 3, 33), R(2, 16, 1, 2, 0, 18), R(4, 8, 2, 0, 1, 12),
+                 R(18, 33, 1, 0, 0, 51), R(12, 51, 0, 0, 0, 63)), "budget": 40},
+]
+
+
+def start_state(level):
+    # ordered (mask, orientation) parts; cursor; selected indices; tool slot; uses; strikes
+    return tuple(level["parts"]), 0, (), 0, tuple(0 for _ in level["tools"]), 2
+
+
+def _recipe(level, left, right, tool):
+    for a, b, needed, ra, rb, out, ro in level["recipes"]:
+        if needed != tool:
+            continue
+        if left == (a, ra) and right == (b, rb):
+            return out, ro
+        if left == (b, rb) and right == (a, ra):
+            return out, ro
+    return None
+
+
+def keyed_orientation(level, mask):
+    """Return the single alternate detent authored for a loose part, if any."""
+    for a, b, _tool, ra, rb, _out, _ro in level["recipes"]:
+        if a == mask and ra:
+            return ra
+        if b == mask and rb:
+            return rb
+    return 0
+
+
+def transition(level, state, action):
+    parts, cursor, selected, tool_slot, uses, strikes = state
+    if strikes <= 0 or any(mask == level["target"] for mask, _ in parts):
+        return state
+    n = len(parts)
+    if action == 1:
+        return parts, (cursor - 1) % n, selected, tool_slot, uses, strikes
+    if action == 2:
+        return parts, (cursor + 1) % n, selected, tool_slot, uses, strikes
+    if action == 3:
+        chosen = list(selected)
+        if cursor in chosen:
+            chosen.remove(cursor)
+        elif len(chosen) < 2:
+            chosen.append(cursor)
+        return parts, cursor, tuple(chosen), tool_slot, uses, strikes
+    if action == 4:
+        if not level.get("rotatable"):
+            return state
+        revised = list(parts)
+        mask, orient = revised[cursor]
+        detent = keyed_orientation(level, mask)
+        if not detent:
+            return state
+        revised[cursor] = (mask, detent if orient == 0 else 0)
+        return tuple(revised), cursor, selected, tool_slot, uses, strikes
+    if action == 5:
+        if len(level["tools"]) < 2:
+            return state
+        return parts, cursor, selected, (tool_slot + 1) % len(level["tools"]), uses, strikes
+    if action != 6 or len(selected) != 2:
+        return state
+    i, j = sorted(selected)
+    tool = level["tools"][tool_slot]
+    result = _recipe(level, parts[i], parts[j], tool)
+    if result is None or uses[tool_slot] >= level["limits"][tool_slot]:
+        return parts, cursor, (), tool_slot, uses, strikes - 1
+    revised = list(parts)
+    revised.pop(j); revised.pop(i); revised.append(result)
+    use_list = list(uses); use_list[tool_slot] += 1
+    return tuple(revised), min(i, len(revised) - 1), (), tool_slot, tuple(use_list), strikes
+
+
+def solved(level, state):
+    return any(mask == level["target"] for mask, _ in state[0]) and state[5] > 0
+
+
+class AtelierDisplay(RenderableUserDisplay):
+    COLORS = (RUST, TEAL, MUSTARD, VIOLET, GREEN, ROSE, BLUE)
+
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def _disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                d = (x - cx) ** 2 + (y - cy) ** 2
+                if d <= radius ** 2 and (not hollow or d >= max(0, radius - 2) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def _line(frame, a, b, color, dotted=False):
+        x0, y0 = a; x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for i in range(steps + 1):
+            if dotted and i % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * i // steps
+            y = y0 + (y1 - y0) * i // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    @staticmethod
+    def _centers(n):
+        if n <= 4:
+            return ((14, 29), (28, 26), (42, 26), (52, 34))[:n]
+        return tuple((10 + (i % 4) * 14, 25 + (i // 4) * 17) for i in range(n))
+
+    def _background(self, frame):
+        frame[:, :] = CREAM
+        # Warm wooden apron with irregular grain; felt work island is rounded.
+        frame[10:59, 3:61] = WOOD
+        for y in range(12, 58, 6):
+            frame[y, 5 + y % 5:59:9] = EARTH
+        frame[16:54, 6:58] = PEARL
+        self._disc(frame, (16, 35), 14, FELT)
+        self._disc(frame, (43, 35), 14, FELT)
+        frame[22:49, 16:44] = FELT
+        for x in range(7, 58, 7):
+            frame[53:56, x:x + 3] = CHARCOAL
+
+    def _leaf(self, frame, bit, center, scale=1):
+        x, y = center; color = self.COLORS[bit % len(self.COLORS)]
+        kind = bit % 7
+        if kind == 0:
+            self._disc(frame, center, 2 * scale, color, hollow=True)
+        elif kind == 1:
+            for row in range(4 * scale + 1):
+                span = row if row <= 2 * scale else 4 * scale - row
+                frame[y - 2 * scale + row, x - span:x + span + 1] = color
+        elif kind == 2:
+            frame[y - 2 * scale:y + 3 * scale, x] = color
+            frame[y, x - 2 * scale:x + 3 * scale] = color
+        elif kind == 3:
+            self._line(frame, (x - 2 * scale, y - 2 * scale), (x + 2 * scale, y + 2 * scale), color)
+            self._line(frame, (x + 2 * scale, y - 2 * scale), (x - 2 * scale, y + 2 * scale), color)
+        elif kind == 4:
+            frame[y - 2 * scale:y + 3 * scale, x - 2 * scale] = color
+            frame[y - 2 * scale:y + 3 * scale, x + 2 * scale] = color
+            frame[y, x - 2 * scale:x + 3 * scale] = color
+        elif kind == 5:
+            self._disc(frame, center, 2 * scale, color)
+            frame[y - scale:y + scale + 1, x - scale:x + scale + 1] = PEARL
+        else:
+            frame[y - 2 * scale:y + 3 * scale, x] = color
+            frame[y - 2 * scale:y + 1, x - 2 * scale:x + 3 * scale] = color
+
+    @staticmethod
+    def _join_info(level, parts, index):
+        mask = parts[index][0]
+        present = {item[0] for item in parts}
+        for recipe_index, (a, b, tool, ra, rb, _out, _ro) in enumerate(level["recipes"]):
+            if mask == a and b in present:
+                return recipe_index, tool, ra
+            if mask == b and a in present:
+                return recipe_index, tool, rb
+        return None
+
+    def _part(self, frame, part, center, selected=False, cursor=False, tiny=False,
+              join_info=None, target=False):
+        mask, orient = part; x, y = center
+        radius = 4 if tiny else 7
+        # Irregular ceramic medallion and tooth direction encode orientation.
+        self._disc(frame, center, radius, CREAM)
+        self._disc(frame, center, radius, CHARCOAL, hollow=True)
+        port = ((0, -radius - 2), (radius + 2, 0), (0, radius + 2), (-radius - 2, 0))[orient]
+        px, py = x + port[0], y + port[1]
+        if target:
+            self._disc(frame, (px, py), 2 if not tiny else 1, MUSTARD)
+        elif join_info is None:
+            # A capped port has crossed geometry until its dependency exists.
+            self._disc(frame, (px, py), 2 if not tiny else 1, CHARCOAL, hollow=True)
+            self._line(frame, (px - 1, py - 1), (px + 1, py + 1), EARTH)
+            self._line(frame, (px + 1, py - 1), (px - 1, py + 1), EARTH)
+        else:
+            recipe_index, tool, _required_orientation = join_info
+            key = recipe_index % 3
+            if key == 0:
+                self._disc(frame, (px, py), 2 if not tiny else 1, MUSTARD, hollow=True)
+            elif key == 1:
+                for row in range(5):
+                    span = row if row <= 2 else 4 - row
+                    frame[py - 2 + row, px - span:px + span + 1] = MUSTARD
+            else:
+                frame[py - 2:py + 3, px] = MUSTARD
+                frame[py, px - 2:px + 3] = MUSTARD
+            # Fixture requirement is a second, non-color silhouette around the key.
+            if tool == 1:
+                frame[py - 3:py + 4, px - 4] = RUST
+                frame[py - 3:py + 4, px + 4] = RUST
+            elif tool == 2:
+                self._line(frame, (px - 3, py + 3), (px, py - 4), VIOLET)
+                self._line(frame, (px, py - 4), (px + 3, py + 3), VIOLET)
+        bits = [i for i in range(7) if mask & (1 << i)]
+        if len(bits) == 1:
+            self._leaf(frame, bits[0], center, 1)
+        else:
+            offsets = ((-3, -2), (3, -2), (-3, 3), (3, 3), (0, -4), (0, 4), (0, 0))
+            for bit, offset in zip(bits, offsets):
+                self._leaf(frame, bit, (x + offset[0], y + offset[1]), 1)
+        if selected:
+            frame[y - radius - 2:y - radius, x - radius:x + radius + 1] = TEAL
+            frame[y + radius + 1:y + radius + 3, x - radius:x + radius + 1] = TEAL
+            frame[y - radius:y + radius + 1, x - radius - 2:x - radius] = TEAL
+            frame[y - radius:y + radius + 1, x + radius + 1:x + radius + 3] = TEAL
+        if cursor:
+            self._disc(frame, (x, y + radius + 4), 2, RUST)
+            frame[y + radius + 3, x] = CREAM
+
+    def _target(self, frame):
+        target = (self.game.level["target"], 0)
+        self._part(frame, target, (32, 8), tiny=True, target=True)
+        frame[7:10, 21:24] = MUSTARD
+        frame[7:10, 40:43] = MUSTARD
+        self._line(frame, (24, 8), (27, 8), EARTH, dotted=True)
+        self._line(frame, (37, 8), (40, 8), EARTH, dotted=True)
+
+    def _tools(self, frame):
+        g = self.game; state = g.state
+        for slot, tool in enumerate(g.level["tools"]):
+            x = 10 + slot * 16; y = 59
+            active = slot == state[3]
+            color = RUST if active else CHARCOAL
+            if active:
+                # Raised U-bracket makes the active fixture legible without hue.
+                frame[y - 8:y - 6, x - 5:x + 6] = MUSTARD
+                frame[y - 8:y - 2, x - 5:x - 3] = MUSTARD
+                frame[y - 8:y - 2, x + 3:x + 5] = MUSTARD
+            if tool == 0:  # bare wooden press
+                frame[y - 4:y + 1, x - 3:x - 1] = color
+                frame[y - 4:y + 1, x + 1:x + 3] = color
+                frame[y - 1:y + 1, x - 3:x + 3] = color
+            elif tool == 1:  # clamp jaws
+                frame[y - 5:y + 1, x - 4:x - 2] = color
+                frame[y - 5:y + 1, x + 2:x + 4] = color
+                frame[y - 5:y - 3, x - 4:x + 4] = color
+            else:  # triangular punch
+                for row in range(6):
+                    frame[y - 5 + row, x - row // 2:x + row // 2 + 1] = color
+            remaining = g.level["limits"][slot] - state[4][slot]
+            for token in range(min(3, remaining)):
+                self._disc(frame, (x - 3 + token * 3, 62), 1, MUSTARD)
+
+    def _bench(self, frame):
+        g = self.game; parts, cursor, selected, _, _, _ = g.state
+        centers = self._centers(len(parts))
+        # A live exploded-order diagram links only currently compatible inputs.
+        positions = {part[0]: centers[i] for i, part in enumerate(parts)}
+        for recipe_index, (a, b, tool, _ra, _rb, _out, _ro) in enumerate(g.level["recipes"]):
+            if a not in positions or b not in positions:
+                continue
+            color = EARTH if tool == 0 else RUST if tool == 1 else VIOLET
+            self._line(frame, positions[a], positions[b], color, dotted=(tool == 1))
+            if tool == 2:
+                ax, ay = positions[a]; bx, by = positions[b]
+                self._line(frame, (ax, ay + 2), (bx, by + 2), color)
+        for i, part in enumerate(parts):
+            x, y = centers[i]
+            if i in selected:
+                y -= 2
+            self._part(frame, part, (x, y), selected=i in selected, cursor=i == cursor,
+                       join_info=self._join_info(g.level, parts, i))
+        # Press jaws are large, asymmetric, and physically separate from the pieces.
+        frame[31:45, 29:32] = RUST
+        frame[31:45, 35:38] = RUST
+        frame[31:34, 29:38] = MUSTARD
+        frame[42:45, 29:38] = CHARCOAL
+        groups, remainder = divmod(g.budget_left, 5)
+        for i in range(groups):
+            self._disc(frame, (8 + i * 5, 14), 2, GREEN, hollow=True)
+            frame[14, 8 + i * 5] = GREEN
+        for i in range(remainder):
+            frame[12:14, 49 + i * 2] = MUSTARD
+        for i in range(2):
+            x = 55 + i * 4
+            if i < g.state[5]:
+                self._disc(frame, (x, 13), 2, TEAL, hollow=True)
+            else:
+                self._line(frame, (x - 2, 11), (x + 2, 15), DANGER)
+                self._line(frame, (x + 2, 11), (x - 2, 15), DANGER)
+
+    def _animation(self, frame):
+        g = self.game
+        if not g.anim_kind:
+            if g.intro_mark:
+                self._disc(frame, (32, 37), 11, MUSTARD, hollow=True)
+            if g.terminal_hold == "loss":
+                frame[28:47, 28:30] = DANGER; frame[28:47, 37:39] = DANGER
+                frame[35:39, 28:39] = DANGER
+            elif g.terminal_hold == "win":
+                self._disc(frame, (32, 36), 14, GREEN, hollow=True)
+            return
+        p = g.anim_progress; total = max(1, g.anim_total)
+        if g.anim_kind == "cursor":
+            before = self._centers(len(g.anim_before[0]))[g.anim_before[1]]
+            after = self._centers(len(g.pending_state[0]))[g.pending_state[1]]
+            x = before[0] + (after[0] - before[0]) * p // total
+            y = before[1] + (after[1] - before[1]) * p // total
+            self._disc(frame, (x, y + 11 - p % 2), 2, RUST)
+        elif g.anim_kind == "select":
+            x, y = self._centers(len(g.state[0]))[g.state[1]]
+            self._disc(frame, (x, y), min(10, 4 + p), TEAL, hollow=True)
+        elif g.anim_kind == "rotate":
+            x, y = self._centers(len(g.state[0]))[g.state[1]]
+            self._disc(frame, (x, y), 9, MUSTARD, hollow=True)
+            self._line(frame, (x - 7 + p, y - 7), (x + 5, y - 5 + p), RUST)
+        elif g.anim_kind == "tool":
+            frame[50 - p:53 - p, 7:55] = MUSTARD
+        elif g.anim_kind == "press":
+            gap = max(0, 6 - p)
+            frame[31:45, 31 - gap:33 - gap] = RUST
+            frame[31:45, 34 + gap:36 + gap] = RUST
+            for d in range(-p, p + 1, 3):
+                self._disc(frame, (32 + d, 38 + (d % 3)), 1, MUSTARD)
+        elif g.anim_kind == "recoil":
+            gap = 2 + (p % 3)
+            frame[34:42, 27 - gap:30 - gap] = DANGER
+            frame[34:42, 35 + gap:38 + gap] = DANGER
+        elif g.anim_kind == "blocked":
+            self._disc(frame, (32, 38), 5 + p, EARTH, hollow=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self._background(frame)
+        self._target(frame)
+        self._bench(frame)
+        self._tools(frame)
+        self._animation(frame)
+        return frame
+
+
+class Q091(ARCBaseGame):
+    def __init__(self):
+        self.display = AtelierDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q091", levels, Camera(0, 0, 64, 64, CREAM, CREAM, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+
+    def _begin(self, kind, frames, next_state, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.anim_before = self.state
+        self.pending_state = next_state
+        self.pending_terminal = terminal
+
+    def _finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state
+        self.anim_kind = None
+        self.pending_state = None
+        self.pending_terminal = None
+        if terminal == "win":
+            self.terminal_hold = "win"; self.next_level()
+        elif terminal == "loss" or self.budget_left <= 0:
+            self.terminal_hold = "loss"; self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self._finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action(); return
+        self.intro_mark = False
+        after = transition(self.level, self.state, action)
+        if after == self.state:
+            self._begin("blocked", 4, after); return
+        self.budget_left -= 1
+        if action in (1, 2): kind = "cursor"
+        elif action == 3: kind = "select"
+        elif action == 4: kind = "rotate"
+        elif action == 5: kind = "tool"
+        elif after[5] < self.state[5]: kind = "recoil"
+        else: kind = "press"
+        terminal = "win" if solved(self.level, after) else "loss" if after[5] <= 0 or self.budget_left <= 0 else None
+        self._begin(kind, 5 if kind not in ("press", "recoil") else 7, after, terminal)

--- a/data/community-games/sonpham/q102_v2_q102.py
+++ b/data/community-games/sonpham/q102_v2_q102.py
@@ -1,0 +1,541 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q102-v2 Blacksite Carriage -- navigate a walker and its moving room.
+
+The diamond walker moves in chamber-local coordinates.  Throwing the clutch
+hands the same four direction controls to the entire chamber in world
+coordinates, without changing the walker's local position.  Later chambers
+add internal bulkheads, world rails, one-way shutters, and an induction plate
+that reverses the carrier controls.  Rule-relevant state is always redundant
+in silhouette, position, or pattern rather than color alone.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+WHITE, PEARL, ASH, STEEL, IRON, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, ICE, AMBER, CORAL, EARTH, GREEN, VIOLET = range(6, 16)
+
+WORLD, ROOM = 8, 3
+DIRS = {1: (0, -1), 2: (0, 1), 3: (-1, 0), 4: (1, 0)}
+
+
+def _path(*points):
+    """Expand axis-aligned corner points into a tuple of adjacent rail origins."""
+    result = [points[0]]
+    for end in points[1:]:
+        x, y = result[-1]
+        ex, ey = end
+        while (x, y) != (ex, ey):
+            x += (ex > x) - (ex < x)
+            y += (ey > y) - (ey < y)
+            if (x, y) not in result:
+                result.append((x, y))
+    return tuple(result)
+
+
+# Budgets are exactly one unit above the shortest physical plan.  That spare
+# unit is the first rejected audit; the second rejected audit breaks the
+# remaining unlike seal and loses.
+LEVELS = [
+    {"name": "Inside the Hull", "start": ((2, 2), (0, 1), 0),
+     "target": ((2, 2), (2, 1), 0), "carrier": False, "budget": 3},
+    {"name": "Throw the Clutch", "start": ((0, 0), (0, 0), 0),
+     "target": ((5, 5), (2, 2), 0), "carrier": True, "budget": 16},
+    {"name": "Internal Bulkheads", "start": ((0, 1), (0, 0), 0),
+     "target": ((4, 4), (2, 2), 0), "carrier": True,
+     "inside_walls": ((1, 0), (1, 1)), "budget": 13},
+    {"name": "Gantry Rail", "start": ((0, 0), (2, 0), 0),
+     "target": ((5, 5), (0, 2), 0), "carrier": True,
+     "rail": _path((0, 0), (2, 0), (2, 2), (4, 2), (4, 4), (5, 4), (5, 5)),
+     "budget": 16},
+    {"name": "One-Way Shutter", "start": ((0, 4), (2, 2), 0),
+     "target": ((5, 1), (0, 0), 0), "carrier": True,
+     "rail": tuple(dict.fromkeys(_path((0, 4), (5, 4), (5, 1))
+                                   + _path((3, 4), (3, 1), (5, 1)))),
+     "shutters": (((5, 3), (5, 2)),), "budget": 14},
+    {"name": "Reverse Induction", "start": ((5, 5), (0, 2), 0),
+     "target": ((0, 0), (2, 0), 1), "carrier": True,
+     "inside_walls": ((0, 1),), "flip": (1, 1), "budget": 16},
+    {"name": "Cold Junction", "start": ((4, 5), (0, 0), 0),
+     "target": ((5, 0), (2, 2), 1), "carrier": True,
+     "inside_walls": ((1, 0),), "flip": (1, 1),
+     "rail": tuple(dict.fromkeys(_path((4, 5), (4, 1), (5, 1), (5, 0))
+                                   + _path((4, 3), (2, 3), (2, 1), (4, 1)))),
+     "shutters": (((4, 3), (4, 2)),), "budget": 16},
+    {"name": "Blacksite Carriage", "start": ((5, 5), (0, 2), 0),
+     "target": ((0, 0), (2, 0), 1), "carrier": True,
+     "inside_walls": ((0, 1), (2, 1)), "flip": (1, 1),
+     "rail": tuple(dict.fromkeys(_path((5, 5), (3, 5), (3, 3), (5, 3), (5, 1),
+                                           (2, 1), (2, 3), (0, 3), (0, 0)))),
+     "shutters": (((5, 3), (5, 2)), ((2, 2), (2, 1))), "budget": 16},
+]
+
+
+# State: origin x/y, local x/y, control (0=walker, 1=carrier), induction
+# polarity, remaining audit seals, physical budget, terminal (0/1/2).
+def start_state(level):
+    origin, local, polarity = level["start"]
+    return origin[0], origin[1], local[0], local[1], 0, polarity, 2, level["budget"], 0
+
+
+def world_position(state):
+    return state[0] + state[2], state[1] + state[3]
+
+
+def ready(level, state):
+    origin, local, polarity = level["target"]
+    return (state[8] == 0 and (state[0], state[1]) == tuple(origin)
+            and (state[2], state[3]) == tuple(local) and state[5] == polarity)
+
+
+def solved(level, state):
+    return ready(level, state)
+
+
+def action_cost(before, after):
+    return max(0, before[7] - after[7])
+
+
+def _carrier_allowed(level, origin):
+    x, y = origin
+    if not (0 <= x <= WORLD - ROOM and 0 <= y <= WORLD - ROOM):
+        return False
+    return not level.get("rail") or origin in level["rail"]
+
+
+def _consume(level, values):
+    values[7] = max(0, values[7] - 1)
+    candidate = tuple(values)
+    if values[7] == 0 and not ready(level, candidate):
+        values[8] = 2
+    return tuple(values)
+
+
+def transition(level, state, action):
+    """Pure deterministic transition used by the runtime and exact solvers."""
+    if state[8] or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    values = list(state)
+
+    if action == 6:
+        if ready(level, state):
+            values[8] = 1
+            return tuple(values)
+        values[6] -= 1
+        values[7] = max(0, values[7] - 1)
+        if values[6] <= 0 or values[7] == 0:
+            values[8] = 2
+        return tuple(values)
+
+    if state[7] <= 0:
+        # With no bolts left the aligned rig may only be audited; trying to
+        # actuate an unpowered control hard-fails instead of creating a free
+        # self-loop in exact policy analysis.
+        values[8] = 2
+        return tuple(values)
+
+    if action == 5:
+        if not level.get("carrier"):
+            # The tutorial's sealed clutch is a true rejected control, not a
+            # silent bolt sink for a mechanic that has not been introduced.
+            return state
+        values[4] = 1 - state[4]
+        return _consume(level, values)
+
+    dx, dy = DIRS[action]
+    if state[4] == 0:
+        local = state[2] + dx, state[3] + dy
+        if (0 <= local[0] < ROOM and 0 <= local[1] < ROOM
+                and local not in level.get("inside_walls", ())):
+            values[2], values[3] = local
+            if level.get("flip") == local and local != (state[2], state[3]):
+                values[5] = 1 - state[5]
+    else:
+        if state[5]:
+            dx, dy = -dx, -dy
+        origin = state[0] + dx, state[1] + dy
+        edge = ((state[0], state[1]), origin)
+        if (_carrier_allowed(level, origin)
+                and edge not in level.get("shutters", ())):
+            values[0], values[1] = origin
+    return _consume(level, values)
+
+
+def transition_kind(level, before, after, action):
+    if after[8] == 1:
+        return "success"
+    if after[8] == 2:
+        return "loss"
+    if action == 6:
+        return "reject"
+    if action == 5 and before == after:
+        return "blocked"
+    if action == 5:
+        return "clutch"
+    moved_local = before[2:4] != after[2:4]
+    moved_room = before[:2] != after[:2]
+    if moved_local:
+        return "induction" if before[5] != after[5] else "walker"
+    if moved_room:
+        return "carrier"
+    return "blocked"
+
+
+class CarriageDisplay(RenderableUserDisplay):
+    OX, OY, CELL = 8, 6, 6
+
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def line(frame, start, end, color, dotted=False):
+        x0, y0 = start; x1, y1 = end
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for index in range(steps + 1):
+            if dotted and index % 3 == 1:
+                continue
+            x = round(x0 + (x1 - x0) * index / steps)
+            y = round(y0 + (y1 - y0) * index / steps)
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    @staticmethod
+    def diamond(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for dy in range(-radius, radius + 1):
+            y = cy + dy
+            if not 0 <= y < 64:
+                continue
+            width = radius - abs(dy)
+            if hollow:
+                for x in (cx - width, cx + width):
+                    if 0 <= x < 64:
+                        frame[y, x] = color
+            else:
+                frame[y, max(0, cx - width):min(64, cx + width + 1)] = color
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius * radius and (not hollow or distance >= (radius - 1) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def polygon(frame, points, color):
+        for start, end in zip(points, points[1:] + points[:1]):
+            CarriageDisplay.line(frame, start, end, color)
+
+    @classmethod
+    def cell_center(cls, cell):
+        return cls.OX + cell[0] * cls.CELL + 3, cls.OY + cell[1] * cls.CELL + 3
+
+    @classmethod
+    def chamber_bounds(cls, origin):
+        x = cls.OX + origin[0] * cls.CELL
+        y = cls.OY + origin[1] * cls.CELL
+        return x, y, x + ROOM * cls.CELL - 1, y + ROOM * cls.CELL - 1
+
+    @staticmethod
+    def interpolate(start, end, amount):
+        return (round(start[0] + (end[0] - start[0]) * amount),
+                round(start[1] + (end[1] - start[1]) * amount))
+
+    def background(self, frame):
+        frame[:, :] = INK
+        # Sparse brutalist seams and cold fixed pin-lights preserve negative space.
+        for y in (3, 55):
+            self.line(frame, (3, y), (60, y), STEEL, dotted=True)
+        for x, y in ((4, 9), (59, 12), (4, 47), (59, 50), (31, 3)):
+            self.diamond(frame, (x, y), 1, STEEL)
+        for x in range(self.OX + 3, self.OX + WORLD * self.CELL, self.CELL):
+            for y in range(self.OY + 3, self.OY + WORLD * self.CELL, self.CELL):
+                frame[y, x] = STEEL
+
+    def rail(self, frame, level):
+        rail = level.get("rail", ())
+        if not rail:
+            return
+        centers = {origin: self.cell_center((origin[0] + 1, origin[1] + 1)) for origin in rail}
+        for origin, center in centers.items():
+            for dx, dy in ((1, 0), (0, 1)):
+                other = (origin[0] + dx, origin[1] + dy)
+                if other in centers:
+                    self.line(frame, center, centers[other], STEEL, dotted=True)
+            self.diamond(frame, center, 1, ASH, hollow=True)
+        for source, target in level.get("shutters", ()):
+            start, end = centers[source], centers[target]
+            center = ((start[0] + end[0]) // 2, (start[1] + end[1]) // 2)
+            dx = (end[0] > start[0]) - (end[0] < start[0])
+            dy = (end[1] > start[1]) - (end[1] < start[1])
+            normal = (-dy, dx)
+            tip = (center[0] + dx * 2, center[1] + dy * 2)
+            points = [tip, (center[0] - dx * 2 + normal[0] * 2,
+                            center[1] - dy * 2 + normal[1] * 2),
+                      (center[0] - dx * 2 - normal[0] * 2,
+                       center[1] - dy * 2 - normal[1] * 2)]
+            self.polygon(frame, points, AMBER)
+            # A perpendicular white stop bar disambiguates this as the
+            # forbidden approach rather than a permissive direction arrow.
+            self.line(frame, (tip[0] - normal[0] * 2, tip[1] - normal[1] * 2),
+                      (tip[0] + normal[0] * 2, tip[1] + normal[1] * 2), WHITE)
+
+    def target_ghost(self, frame, level):
+        origin, local, _polarity = level["target"]
+        x0, y0, x1, y1 = self.chamber_bounds(origin)
+        points = [(x0 + 3, y0), (x1 - 3, y0), (x1, y0 + 3), (x1, y1 - 3),
+                  (x1 - 3, y1), (x0 + 3, y1), (x0, y1 - 3), (x0, y0 + 3)]
+        for start, end in zip(points, points[1:] + points[:1]):
+            self.line(frame, start, end, ASH, dotted=True)
+
+    def target_socket(self, frame, level):
+        origin, local, _polarity = level["target"]
+        socket = self.cell_center((origin[0] + local[0], origin[1] + local[1]))
+        self.diamond(frame, socket, 4, WHITE, hollow=True)
+        for dx, dy in ((-2, -2), (2, -2), (-2, 2), (2, 2)):
+            frame[socket[1] + dy, socket[0] + dx] = AMBER
+
+    def chamber(self, frame, state, offset=(0, 0), draw_walker=True):
+        origin = state[0], state[1]
+        x0, y0, x1, y1 = self.chamber_bounds(origin)
+        x0 += offset[0]; x1 += offset[0]; y0 += offset[1]; y1 += offset[1]
+        # Chamfered armored mass rather than a tiled rectangular board.
+        points = [(x0 + 3, y0), (x1 - 3, y0), (x1, y0 + 3), (x1, y1 - 3),
+                  (x1 - 3, y1), (x0 + 3, y1), (x0, y1 - 3), (x0, y0 + 3)]
+        for y in range(y0 + 1, y1):
+            inset = max(0, 3 - min(y - y0, y1 - y))
+            frame[y, max(0, x0 + inset):min(64, x1 - inset + 1)] = IRON
+        self.polygon(frame, points, ICE)
+        self.line(frame, (x0 + 3, y0 + 3), (x1 - 3, y1 - 3), STEEL)
+        self.line(frame, (x1 - 3, y0 + 3), (x0 + 3, y1 - 3), STEEL)
+        for lx in range(ROOM):
+            for ly in range(ROOM):
+                center = (x0 + lx * self.CELL + 3, y0 + ly * self.CELL + 3)
+                self.disc(frame, center, 2, ASH, hollow=True)
+                frame[center[1], center[0]] = STEEL
+        for lx, ly in self.game.level.get("inside_walls", ()):
+            cx, cy = x0 + lx * self.CELL + 3, y0 + ly * self.CELL + 3
+            self.polygon(frame, [(cx - 3, cy - 2), (cx + 2, cy - 2),
+                                 (cx + 3, cy + 2), (cx - 2, cy + 2)], ASH)
+            self.line(frame, (cx - 2, cy), (cx + 2, cy), AMBER)
+        flip = self.game.level.get("flip")
+        if flip:
+            cx, cy = x0 + flip[0] * self.CELL + 3, y0 + flip[1] * self.CELL + 3
+            self.diamond(frame, (cx, cy), 3, AMBER, hollow=True)
+            self.line(frame, (cx - 2, cy + 2), (cx + 2, cy - 2), WHITE)
+            self.line(frame, (cx - 2, cy - 1), (cx + 1, cy - 3), WHITE)
+        # Corner trusses and unlike rivets make orientation legible in mono.
+        for center in ((x0 + 3, y0 + 3), (x1 - 3, y0 + 3),
+                       (x0 + 3, y1 - 3), (x1 - 3, y1 - 3)):
+            self.diamond(frame, center, 1, PEARL)
+        if draw_walker:
+            center = (x0 + state[2] * self.CELL + 3, y0 + state[3] * self.CELL + 3)
+            self.walker(frame, center)
+
+    def walker(self, frame, center):
+        self.diamond(frame, center, 3, WHITE)
+        self.line(frame, (center[0] - 2, center[1]), (center[0] + 2, center[1]), INK)
+        self.line(frame, (center[0], center[1] - 2), (center[0], center[1] + 2), INK)
+
+    def clutch(self, frame, state, amount=None):
+        mode = state[4]
+        cx, cy = 32, 58
+        self.polygon(frame, [(cx - 6, cy - 3), (cx + 6, cy - 3),
+                             (cx + 4, cy + 3), (cx - 4, cy + 3)], STEEL)
+        if amount is None:
+            position = cx - 3 if mode == 0 else cx + 3
+        else:
+            position = round(cx - 3 + amount * 6)
+        self.diamond(frame, (position, cy), 2, WHITE)
+        # Vertical jaw = local body; horizontal jaws = world carrier.
+        if mode == 0:
+            self.line(frame, (cx - 8, cy - 3), (cx - 8, cy + 3), ICE)
+        else:
+            self.line(frame, (cx + 5, cy - 4), (cx + 11, cy - 4), ICE)
+            self.line(frame, (cx + 5, cy + 4), (cx + 11, cy + 4), ICE)
+
+    def polarity(self, frame, state):
+        cx, cy = 51, 60
+        reverse = state[5]
+        direction = -1 if reverse else 1
+        self.line(frame, (cx - 6, cy), (cx + 6, cy), STEEL)
+        tip = (cx + direction * 6, cy)
+        self.polygon(frame, [tip, (tip[0] - direction * 3, cy - 2),
+                             (tip[0] - direction * 3, cy + 2)], WHITE)
+        if reverse:
+            self.line(frame, (cx - 1, cy - 3), (cx + 1, cy + 3), AMBER)
+            self.line(frame, (cx + 1, cy - 3), (cx - 1, cy + 3), AMBER)
+        # An engraved open arrow above the live filled arrow shows the exact
+        # required polarity without relying on hue or a text legend.
+        target_reverse = self.game.level["target"][2]
+        target_direction = -1 if target_reverse else 1
+        target_tip = (cx + target_direction * 5, 56)
+        self.polygon(frame, [target_tip,
+                             (target_tip[0] - target_direction * 3, 54),
+                             (target_tip[0] - target_direction * 3, 58)], AMBER)
+
+    def budget(self, frame, state):
+        maximum = self.game.level["budget"]
+        for unit in range(maximum):
+            row, column = divmod(unit, 16)
+            x, y = 8 + column * 3, 1 + row * 3
+            if unit < state[7]:
+                self.diamond(frame, (x, y), 1, ICE)
+            else:
+                frame[y, x] = STEEL
+        # Two audit armors are unlike and fixed to opposite sides.
+        if state[6] >= 1:
+            self.disc(frame, (3, 58), 2, WHITE, hollow=True)
+        else:
+            self.line(frame, (1, 56), (5, 60), RED)
+        if state[6] >= 2:
+            self.diamond(frame, (61, 58), 2, WHITE, hollow=True)
+        else:
+            self.line(frame, (59, 56), (63, 60), RED)
+
+    def terminal(self, frame, state):
+        if state[8] == 1:
+            center = self.cell_center(world_position(state))
+            for radius in (3, 6, 9):
+                self.diamond(frame, center, radius, WHITE, hollow=True)
+        elif state[8] == 2:
+            self.line(frame, (8, 7), (55, 54), RED)
+            self.line(frame, (55, 7), (8, 54), ASH)
+
+    def scene(self, frame, state, *, chamber_offset=(0, 0), draw_chamber=True,
+              draw_walker=True, walker_override=None, clutch_amount=None):
+        self.background(frame); self.rail(frame, self.game.level)
+        self.target_ghost(frame, self.game.level)
+        if draw_chamber:
+            self.chamber(frame, state, chamber_offset, draw_walker=draw_walker)
+        if walker_override is not None:
+            self.walker(frame, walker_override)
+        self.target_socket(frame, self.game.level)
+        self.clutch(frame, state, clutch_amount)
+        self.polarity(frame, state); self.budget(frame, state); self.terminal(frame, state)
+
+    def animation(self, frame, before, after, kind, progress, total):
+        span = max(1, total - 1)
+        p = min(progress, span)
+        amount = p / span
+        preview = after if p * 2 >= span else before
+        if kind in ("walker", "induction"):
+            self.scene(frame, preview, draw_walker=False)
+            start = self.cell_center(world_position(before))
+            end = self.cell_center(world_position(after))
+            # Piston-like anticipation, then a hard glide and settle.
+            eased = 0.0 if p == 0 else min(1.0, max(0.0, (amount - .15) / .7))
+            point = self.interpolate(start, end, eased)
+            self.walker(frame, point)
+            if kind == "induction":
+                radius = 1 + 4 * min(p, span - p) // max(1, span // 2)
+                self.diamond(frame, end, radius, AMBER, hollow=True)
+        elif kind == "carrier":
+            self.scene(frame, preview, draw_chamber=False)
+            start = self.cell_center((before[0], before[1]))
+            end = self.cell_center((after[0], after[1]))
+            position = self.interpolate(start, end, amount)
+            offset = position[0] - start[0], position[1] - start[1]
+            # Hydraulic trail is sparse and directionally unlike body motion.
+            trail = self.interpolate(start, end, max(0.0, amount - .22))
+            self.diamond(frame, trail, 1, STEEL)
+            # The trail belongs behind the moving mass so it can never erase
+            # the carried walker's central cross or any chamber aperture.
+            self.chamber(frame, before, offset)
+        elif kind == "clutch":
+            self.scene(frame, preview, clutch_amount=(before[4] + (after[4] - before[4]) * amount))
+        else:
+            self.scene(frame, preview)
+            if kind == "blocked":
+                center = (32, 30); reach = 2 + 5 * min(p, span - p) // max(1, span // 2)
+                for dx, dy in ((-reach, -2), (-reach, 2), (reach, -2), (reach, 2)):
+                    self.line(frame, center, (center[0] + dx, center[1] + dy), AMBER, dotted=True)
+            elif kind == "reject":
+                center = (61, 58) if before[6] == 2 else (3, 58)
+                reach = 1 + 3 * p // span
+                self.line(frame, (center[0] - reach, center[1] - reach),
+                          (center[0] + reach, center[1] + reach), RED)
+            elif kind == "success":
+                center = self.cell_center(world_position(after))
+                for radius in range(2, min(12, 2 + p * 2), 3):
+                    self.diamond(frame, center, radius, WHITE, hollow=True)
+            elif kind == "loss":
+                inset = 4 * p // span
+                self.line(frame, (7 + inset, 6 + inset), (56 - inset, 55 - inset), RED)
+                self.line(frame, (56 - inset, 6 + inset), (7 + inset, 55 - inset), ASH)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        game = self.game
+        if game.anim_kind:
+            self.animation(frame, game.anim_before, game.pending_state, game.anim_kind,
+                           game.anim_progress, game.anim_total)
+        else:
+            self.scene(frame, game.state)
+            if game.intro_mark:
+                x0, y0, x1, y1 = self.chamber_bounds((game.state[0], game.state[1]))
+                self.polygon(frame, [(x0 + 3, y0 - 2), (x1 - 3, y0 - 2),
+                                     (x1 + 2, y0 + 3), (x1 + 2, y1 - 3),
+                                     (x1 - 3, y1 + 2), (x0 + 3, y1 + 2),
+                                     (x0 - 2, y1 - 3), (x0 - 2, y0 + 3)], AMBER)
+        return frame
+
+
+class Q102(ARCBaseGame):
+    def __init__(self):
+        self.display = CarriageDisplay(self); self.level = LEVELS[0]
+        self.state = start_state(self.level); self.budget_left = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = None; self.pending_terminal = None
+        self.intro_mark = True
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q102", levels, Camera(0, 0, 64, 64, INK, INK, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]; self.state = start_state(self.level)
+        self.budget_left = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = None; self.pending_terminal = None
+        self.intro_mark = True
+
+    def begin(self, kind, frames, after, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames; self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = after; self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal; self.state = self.pending_state
+        self.budget_left = self.state[7]; self.anim_kind = None
+        self.pending_state = None; self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1; self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action(); return
+        self.intro_mark = False
+        after = transition(self.level, self.state, action)
+        kind = transition_kind(self.level, self.state, after, action)
+        terminal = "win" if after[8] == 1 else "loss" if after[8] == 2 else None
+        frames = 7 if kind in ("carrier", "induction", "success", "loss") else 6
+        self.begin(kind, frames, after, terminal)

--- a/data/community-games/sonpham/q107_v2_q107.py
+++ b/data/community-games/sonpham/q107_v2_q107.py
@@ -1,0 +1,395 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q107-v2 Atlas Loom -- fold a nailed survey ribbon into a target atlas.
+
+The map is a physical ordered strip.  A hinge folds either side, reversing its
+order and turning every lifted panel over.  Later atlases require both faces,
+broken wax seals, and a brass survey nail that keeps its side on the table.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, PEARL, ASH, SLATE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, AQUA, GOLD, CORAL, EARTH, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+
+
+LEVELS = [
+    {"name": "First Pleat", "n": 3, "plan": (5,), "budget": 3,
+     "hinge_control": False, "side_control": False, "faces": False, "one_use": False, "required": (), "anchor": None},
+    {"name": "Traveling Hinge", "n": 5, "plan": (4, 4, 5, 3, 3, 5, 4, 5), "budget": 10,
+     "hinge_control": True, "side_control": False, "faces": False, "one_use": False, "required": (), "anchor": None},
+    {"name": "Two Hands", "n": 5, "plan": (1, 4, 5, 1, 3, 5, 1, 4, 5, 4, 5), "budget": 13,
+     "side_control": True, "faces": False, "one_use": False, "required": (), "anchor": None},
+    {"name": "Night Printing", "n": 5, "plan": (4, 5, 1, 4, 5, 3, 3, 5, 1, 4, 5), "budget": 13,
+     "side_control": True, "faces": True, "one_use": False, "required": (), "anchor": None},
+    {"name": "Wax Memory", "n": 6, "plan": (4, 5, 4, 4, 5, 1, 3, 5, 3, 3, 5), "budget": 13,
+     "side_control": True, "faces": True, "one_use": True, "required": (0, 1, 2, 3), "anchor": None},
+    {"name": "Survey Nail", "n": 6, "plan": (3, 3, 5, 3, 5, 3, 3, 5, 3, 5, 3, 5), "budget": 14,
+     "side_control": True, "faces": True, "one_use": False, "required": (), "anchor": 3,
+     "require_anchor": True},
+    {"name": "Sealed Archipelago", "n": 6,
+     "plan": (3, 5, 3, 3, 5, 3, 3, 5, 4, 5, 4, 4, 5), "budget": 15,
+     "side_control": True, "faces": True, "one_use": True, "required": (1, 2, 3), "anchor": 4,
+     "require_anchor": True},
+    {"name": "Atlas Loom", "n": 7,
+     "plan": (3, 3, 5, 3, 3, 5, 3, 3, 5, 3, 5, 3, 3, 5, 3, 3, 5), "budget": 19,
+     "side_control": True, "faces": True, "one_use": True, "required": (1, 2, 3), "anchor": 4,
+     "require_anchor": True},
+]
+
+
+def start_state(level):
+    return tuple((index, 0) for index in range(level["n"])), 0, 1, 0, 0
+
+
+def fold_side(level, state):
+    panels, hinge, side, spent, anchor_used = state
+    selected = range(hinge + 1) if side == 0 else range(hinge + 1, len(panels))
+    effective = side
+    anchor = level.get("anchor")
+    if anchor is not None and any(panels[index][0] == anchor for index in selected):
+        effective = 1 - side
+        anchor_used = 1
+    if level.get("one_use") and spent & (1 << hinge):
+        return state
+    lifted = list(panels[:hinge + 1] if effective == 0 else panels[hinge + 1:])
+    grounded = list(panels[hinge + 1:] if effective == 0 else panels[:hinge + 1])
+    lifted = [(identity, 1 - face) for identity, face in reversed(lifted)]
+    result = tuple(lifted + grounded if effective == 0 else grounded + lifted)
+    return result, hinge, side, spent | (1 << hinge), anchor_used
+
+
+def transition(level, state, action):
+    panels, hinge, side, spent, anchor_used = state
+    if action == 1 and level.get("side_control"):
+        return panels, hinge, 1 - side, spent, anchor_used
+    if action == 3 and level.get("hinge_control", True):
+        return panels, (hinge - 1) % (len(panels) - 1), side, spent, anchor_used
+    if action == 4 and level.get("hinge_control", True):
+        return panels, (hinge + 1) % (len(panels) - 1), side, spent, anchor_used
+    if action == 5:
+        return fold_side(level, state)
+    return state
+
+
+_TARGET_CACHE = {}
+
+
+def target_state(level):
+    if level["name"] not in _TARGET_CACHE:
+        state = start_state(level)
+        for action in level["plan"]:
+            state = transition(level, state, action)
+        _TARGET_CACHE[level["name"]] = state
+    return _TARGET_CACHE[level["name"]]
+
+
+def solved(level, state):
+    target = target_state(level)
+    current_panels, _, _, spent, anchor_used = state
+    if level.get("faces"):
+        panel_match = current_panels == target[0]
+    else:
+        panel_match = tuple(x for x, _ in current_panels) == tuple(x for x, _ in target[0])
+    required = sum(1 << hinge for hinge in level.get("required", ()))
+    return (panel_match and spent & required == required
+            and (not level.get("require_anchor") or anchor_used))
+
+
+class AtlasDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def _disc(frame, center, radius, color):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                if (x - cx) ** 2 + (y - cy) ** 2 <= radius ** 2:
+                    frame[y, x] = color
+
+    @staticmethod
+    def _line(frame, a, b, color, dotted=False):
+        x0, y0 = a
+        x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    def _background(self, frame):
+        frame[:, :] = INK
+        frame[5:59, 3:61] = CHARCOAL
+        for y in range(7, 58, 6):
+            frame[y, 5 + y % 4:60:8] = SLATE
+        for x in range(6, 60, 9):
+            frame[8 + x % 3:58:8, x] = EARTH
+        frame[17:51, 4:60] = ASH
+
+    @staticmethod
+    def _xs(n):
+        width = max(6, 48 // n)
+        start = (64 - n * width) // 2
+        return tuple(start + index * width for index in range(n)), width
+
+    def _glyph(self, frame, identity, face, center, scale=1):
+        x, y = center
+        color = (AQUA, GOLD, CORAL, GREEN, VIOLET, ROSE, BLUE)[identity % 7]
+        if identity % 7 == 0:
+            self._disc(frame, center, 2 * scale, color)
+            self._disc(frame, center, max(0, scale - 1), INK)
+        elif identity % 7 == 1:
+            for d in range(-2 * scale, 2 * scale + 1):
+                span = 2 * scale - abs(d)
+                frame[y + d, x - span:x + span + 1] = color
+        elif identity % 7 == 2:
+            for row in range(4 * scale + 1):
+                span = row if face == 0 else 4 * scale - row
+                yy = y - 2 * scale + row
+                frame[yy, x - span // 2:x + span // 2 + 1] = color
+        elif identity % 7 == 3:
+            frame[y - 2 * scale:y + 2 * scale + 1, x] = color
+            frame[y, x - 2 * scale:x + 2 * scale + 1] = color
+        elif identity % 7 == 4:
+            self._line(frame, (x - 2 * scale, y - 2 * scale), (x + 2 * scale, y + 2 * scale), color)
+            self._line(frame, (x + 2 * scale, y - 2 * scale), (x - 2 * scale, y + 2 * scale), color)
+        elif identity % 7 == 5:
+            frame[y - scale:y + scale + 1, x - 2 * scale:x + 2 * scale + 1] = color
+        else:
+            frame[y - 2 * scale:y + 2 * scale + 1, x - 2 * scale] = color
+            frame[y - 2 * scale:y + 2 * scale + 1, x + 2 * scale] = color
+            frame[y - 2 * scale, x - 2 * scale:x + 2 * scale + 1] = color
+            frame[y + 2 * scale, x - 2 * scale:x + 2 * scale + 1] = color
+        # Face is additionally encoded by a top pennant versus a bottom root.
+        if face:
+            frame[y + 3 * scale:y + 4 * scale + 1, x - scale:x + scale + 1] = PAPER
+        else:
+            frame[y - 4 * scale:y - 2 * scale, x - scale:x + scale + 1] = PAPER
+
+    def _panel(self, frame, left, width, panel, anchor=False, tiny=False):
+        identity, face = panel
+        top, bottom = (20, 43) if not tiny else (8, 15)
+        color = PEARL if face == 0 else SLATE
+        inset = 1 if not tiny else 0
+        frame[top + inset:bottom - inset, left + 1:left + width - 1] = color
+        frame[top, left + 2:left + width - 2] = PAPER
+        frame[bottom - 1, left + 2:left + width - 2] = EARTH
+        if not tiny:
+            self._glyph(frame, identity, face, (left + width // 2, 31))
+            if anchor:
+                self._disc(frame, (left + width // 2, 38), 3, GOLD)
+                self._disc(frame, (left + width // 2, 38), 1, INK)
+                if self.game.state[4]:
+                    frame[38, left + 1:left + width - 1] = GOLD
+        else:
+            x, y = left + width // 2, 11
+            color = (AQUA, GOLD, CORAL, GREEN, VIOLET, ROSE, BLUE)[identity % 7]
+            # Even the miniature target distinguishes landmark identity by shape.
+            if identity % 7 == 0:
+                self._disc(frame, (x, y), 1, color)
+                frame[y, x] = INK
+            elif identity % 7 == 1:
+                frame[y - 1:y + 2, x] = color
+                frame[y, x - 1:x + 2] = color
+            elif identity % 7 == 2:
+                frame[y - 2:y + 3, x] = color
+            elif identity % 7 == 3:
+                frame[y, x - 2:x + 3] = color
+            elif identity % 7 == 4:
+                for d in (-1, 0, 1):
+                    frame[y + d, x + d] = color
+            elif identity % 7 == 5:
+                for d in (-1, 0, 1):
+                    frame[y + d, x - d] = color
+            else:
+                frame[y - 1:y + 2, x - 1] = color
+                frame[y - 1:y + 2, x + 1] = color
+            frame[14 if face else 8, left + 2:left + width - 2] = PAPER
+
+    def _target(self, frame):
+        g = self.game
+        xs, width = self._xs(len(g.state[0]))
+        target = target_state(g.level)[0]
+        for left, panel in zip(xs, target):
+            shown = panel if g.level.get("faces") else (panel[0], 0)
+            self._panel(frame, left, width, shown, tiny=True)
+
+    def _map(self, frame):
+        g = self.game
+        xs, width = self._xs(len(g.state[0]))
+        for left, panel in zip(xs, g.state[0]):
+            self._panel(frame, left, width, panel, panel[0] == g.level.get("anchor"))
+        for seam in range(len(xs) - 1):
+            x = xs[seam] + width
+            spent = bool(g.state[3] & (1 << seam))
+            color = RED if spent else GOLD
+            for y in range(22, 43, 4):
+                frame[y, x + ((y // 4) % 2 if spent else 0)] = color
+            if spent:
+                frame[32, x - 2:x + 3] = color
+            if seam in g.level.get("required", ()):
+                self._disc(frame, (x, 47), 2 if not spent else 1, color)
+                if spent:
+                    self._line(frame, (x - 2, 45), (x + 2, 49), INK)
+        hinge_x = xs[g.state[1]] + width
+        frame[19:46, hinge_x] = CORAL
+        # The selected lift side is a solid bracket; the grounded side is dotted.
+        if g.state[2] == 0:
+            frame[18, xs[0]:hinge_x + 1] = CORAL
+            frame[46, hinge_x:xs[-1] + width:3] = SLATE
+        else:
+            frame[18, hinge_x:xs[-1] + width] = CORAL
+            frame[46, xs[0]:hinge_x:3] = SLATE
+
+    def _budget(self, frame):
+        g = self.game
+        for index in range(g.budget_max):
+            x = 6 + index * 52 // max(1, g.budget_max - 1)
+            if index < g.budget_left:
+                self._disc(frame, (x, 57), 1, GOLD)
+            else:
+                frame[57, x] = SLATE
+
+    def _animation(self, frame):
+        g = self.game
+        if g.intro_mark:
+            frame[4:7, 7:58:3] = AQUA
+        if g.terminal_hold == "win":
+            for radius, color in ((19, GOLD), (13, VIOLET), (7, PAPER)):
+                self._disc(frame, (32, 33), radius, color)
+        elif g.terminal_hold == "loss":
+            frame[18:51:3, 4:60] = RED
+            frame[18:51, 4:60:5] = INK
+        if not g.anim_kind:
+            return
+        p = g.anim_progress
+        xs, width = self._xs(len(g.state[0]))
+        if g.anim_kind == "cursor":
+            a = xs[g.anim_from] + width
+            b = xs[g.anim_to] + width
+            x = a + (b - a) * p // g.anim_total
+            frame[16:49, x] = GOLD
+        elif g.anim_kind == "side":
+            y = 17 + p
+            frame[y, xs[0]:xs[-1] + width:2] = CORAL
+        elif g.anim_kind == "fold":
+            hinge_x = xs[g.state[1]] + width
+            radius = 2 + p * 3
+            for dx in range(-min(radius, 28), min(radius, 28) + 1):
+                yy = 19 + abs(dx) * max(1, 8 - p) // max(1, radius)
+                x = hinge_x + dx
+                if 4 <= x < 60 and yy < 48:
+                    frame[yy, x] = PAPER if p < 4 else GOLD
+            if g.pending_state is not None and p >= 4:
+                for index, panel in enumerate(g.pending_state[0]):
+                    self._glyph(frame, panel[0], panel[1], (xs[index] + width // 2, 31))
+        elif g.anim_kind == "blocked":
+            x = xs[g.state[1]] + width
+            frame[21 + p:44 - p:2, x - 3:x + 4] = RED
+        elif g.anim_kind == "miss":
+            frame[9 + p:17, 6:58:3] = RED
+        elif g.anim_kind == "success":
+            self._disc(frame, (32, 31), min(12, 3 + 2 * p), GOLD)
+            self._disc(frame, (32, 31), min(7, 1 + p), PAPER)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self._background(frame)
+        self._target(frame)
+        self._map(frame)
+        self._budget(frame)
+        self._animation(frame)
+        return frame
+
+
+class Q107(ARCBaseGame):
+    def __init__(self):
+        self.display = AtlasDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_from = self.anim_to = 0
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q107", levels, Camera(0, 0, 64, 64, INK, INK, [self.display]),
+                         False, len(levels), [1, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+
+    def _begin(self, kind, frames, *, next_state=None, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.pending_state = next_state
+        self.pending_terminal = terminal
+
+    def _finish(self):
+        terminal = self.pending_terminal
+        if self.pending_state is not None:
+            self.state = self.pending_state
+        self.anim_kind = None
+        self.pending_state = None
+        self.pending_terminal = None
+        if terminal == "win":
+            self.terminal_hold = "win"
+            self.next_level()
+        elif terminal == "loss" or self.budget_left <= 0:
+            self.terminal_hold = "loss"
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self._finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        self.intro_mark = False
+        if action == 6:
+            won = solved(self.level, self.state)
+            if not won:
+                self.budget_left -= 1
+            self._begin("success" if won else "miss", 6,
+                        terminal="win" if won else ("loss" if self.budget_left <= 0 else None))
+            return
+        after = transition(self.level, self.state, action)
+        if after == self.state:
+            self._begin("blocked", 4)
+            return
+        self.budget_left -= 1
+        self.anim_from, self.anim_to = self.state[1], after[1]
+        kind = "side" if action == 1 else "cursor" if action in (3, 4) else "fold"
+        self._begin(kind, 7 if kind == "fold" else 4, next_state=after,
+                    terminal="loss" if self.budget_left <= 0 else None)

--- a/data/community-games/sonpham/q111_v3_q111.py
+++ b/data/community-games/sonpham/q111_v3_q111.py
@@ -1,0 +1,413 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q111-v3 Silk Compass -- reproduce transformed kite choreography.
+
+Visible ribbon cards are interpreted through a cumulative silk compass: base
+rotation, mirror wings, reverse playback, per-card turn notches, and echo halos.
+The complete diamond kite performs every input while accepted thread visibly
+sews the exact progress rosette.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, PEARL, ASH, SLATE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, AQUA, GOLD, CORAL, EARTH, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+DIRS = {1: (0, -1), 2: (0, 1), 3: (-1, 0), 4: (1, 0)}
+
+
+LEVELS = [
+    {"name": "First Ribbon", "demo": (4, 1, 3), "rotation": 0, "mirror": False},
+    {"name": "Quarter Canopy", "demo": (1, 4, 2, 3, 1, 4, 2, 3, 1, 2),
+     "rotation": 1, "mirror": False},
+    {"name": "Mirror Silk", "demo": (3, 1, 4, 2, 4, 1, 3, 2, 1, 2),
+     "rotation": 1, "mirror": True},
+    {"name": "Backspool", "demo": (1, 4, 4, 2, 3, 1, 2, 4, 3, 3),
+     "rotation": 1, "mirror": True, "reverse": True},
+    {"name": "Turning Beats", "demo": (1, 4, 2, 3, 4, 1, 3, 2, 4, 1),
+     "rotation": 1, "mirror": True, "reverse": True,
+     "beat_turns": (0, 1, 2, 3, 1, 0, 2, 1, 3, 2)},
+    {"name": "Echo Rosettes", "demo": (4, 1, 3, 2, 4, 1, 2),
+     "rotation": 1, "mirror": True, "reverse": True,
+     "beat_turns": (0, 1, 2, 1, 3, 0, 2),
+     "echoes": (True, False, True, False, False, True, False)},
+    {"name": "Reversed Looking Glass", "demo": (1, 4, 2, 3, 1, 3, 4, 2, 1, 4, 3),
+     "rotation": 1, "mirror": True, "reverse": True,
+     "beat_turns": (0, 1, 0, 2, 1, 3, 0, 2, 3, 1, 2)},
+    {"name": "Silk Compass", "demo": (4, 1, 3, 2, 4, 2, 1, 3),
+     "rotation": 3, "mirror": True, "reverse": True,
+     "beat_turns": (0, 1, 3, 2, 1, 0, 2, 3),
+     "echoes": (True, False, True, False, True, False, True, False)},
+]
+
+
+def transform(action, rotation, mirror):
+    dx, dy = DIRS[action]
+    if mirror:
+        dx = -dx
+    for _ in range(rotation % 4):
+        dx, dy = -dy, dx
+    return next(key for key, vector in DIRS.items() if vector == (dx, dy))
+
+
+def expanded_specs(level):
+    turns = level.get("beat_turns", (0,) * len(level["demo"]))
+    echoes = level.get("echoes", (False,) * len(level["demo"]))
+    cards = list(zip(level["demo"], turns, echoes, range(len(level["demo"]))))
+    if level.get("reverse"):
+        cards.reverse()
+    out = []
+    for action, turn, echo, card_index in cards:
+        item = (transform(action, level["rotation"] + turn, level["mirror"]), card_index)
+        out.append(item)
+        if echo:
+            out.append(item)
+    return tuple(out)
+
+
+def expected_actions(level):
+    return tuple(action for action, _card in expanded_specs(level))
+
+
+def start_state(_level):
+    # accepted steps, remaining slip crescents, terminal (0 play / 2 win / 3 loss)
+    return 0, 2, 0
+
+
+def transition(level, state, action):
+    progress, chances, terminal = state
+    expected = expected_actions(level)
+    if terminal or chances <= 0 or progress >= len(expected) or action not in DIRS:
+        return state
+    if action == expected[progress]:
+        progress += 1
+        return progress, chances, 2 if progress == len(expected) else 0
+    chances -= 1
+    return progress, chances, 3 if chances == 0 else 0
+
+
+def solved(_level, state):
+    return state[-1] == 2
+
+
+class SilkDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def _disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius ** 2 and (not hollow or distance >= max(0, radius - 2) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def _line(frame, a, b, color, dotted=False):
+        x0, y0 = a
+        x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for index in range(steps + 1):
+            if dotted and index % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * index // steps
+            y = y0 + (y1 - y0) * index // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    def _diamond(self, frame, center, radius, color, hollow=False):
+        x, y = center
+        for dy in range(-radius, radius + 1):
+            width = radius - abs(dy)
+            yy = y + dy
+            if not 0 <= yy < 64:
+                continue
+            if hollow:
+                for xx in (x - width, x + width):
+                    if 0 <= xx < 64:
+                        frame[yy, xx] = color
+            else:
+                frame[yy, max(0, x - width):min(64, x + width + 1)] = color
+
+    def _arrow(self, frame, action, center, color):
+        x, y = center
+        dx, dy = DIRS[action]
+        self._line(frame, (x - dx * 2, y - dy * 2), (x + dx * 3, y + dy * 3), color)
+        px, py = -dy, dx
+        self._line(frame, (x + dx * 3, y + dy * 3),
+                   (x + dx - px * 2, y + dy - py * 2), color)
+        self._line(frame, (x + dx * 3, y + dy * 3),
+                   (x + dx + px * 2, y + dy + py * 2), color)
+
+    @staticmethod
+    def _positions(count):
+        start = -math.pi / 2
+        return tuple((32 + round(22 * math.cos(start + 2 * math.pi * index / count)),
+                      31 + round(22 * math.sin(start + 2 * math.pi * index / count)))
+                     for index in range(count))
+
+    @staticmethod
+    def _progress_position(count, index):
+        return 5 + round(index * 54 / max(1, count - 1)), 60
+
+    def _background(self, frame):
+        frame[:, :] = PAPER
+        for y in range(2, 62, 6):
+            frame[y, 3 + (y // 2) % 5:61:8] = PEARL
+        for x in range(4, 61, 9):
+            frame[4 + x % 3:59:9, x] = ASH
+        self._disc(frame, (32, 31), 29, ROSE)
+        self._disc(frame, (32, 31), 27, PAPER)
+        for index in range(16):
+            angle = 2 * math.pi * index / 16
+            point = (32 + round(27 * math.cos(angle)), 31 + round(27 * math.sin(angle)))
+            self._disc(frame, point, 2, (AQUA, MAGENTA, GOLD, CORAL)[index % 4])
+
+    def _kite(self, frame, center, error=False):
+        x, y = center
+        silk = RED if error else MAGENTA
+        fill = ROSE if error else PEARL
+        self._diamond(frame, center, 7, fill)
+        self._line(frame, (x, y - 7), (x + 7, y), silk)
+        self._line(frame, (x + 7, y), (x, y + 7), silk)
+        self._line(frame, (x, y + 7), (x - 7, y), silk)
+        self._line(frame, (x - 7, y), (x, y - 7), silk)
+        self._line(frame, (x, y - 7), (x, y + 7), VIOLET)
+        self._line(frame, (x, y), (x + 7, y), AQUA)
+        self._line(frame, (x, y + 7), (x - 4, y + 12), CORAL)
+        self._line(frame, (x - 4, y + 12), (x, y + 15), GOLD)
+
+    def _apparatus(self, frame, draw_kite):
+        level = self.game.level
+        self._disc(frame, (32, 31), 9, PEARL)
+        self._disc(frame, (32, 31), 7, AQUA, hollow=True)
+        if draw_kite:
+            self._kite(frame, (32, 31))
+        if level.get("mirror"):
+            self._line(frame, (20, 21), (20, 42), BLUE, dotted=True)
+            self._line(frame, (44, 21), (44, 42), BLUE, dotted=True)
+            for y in (24, 31, 38):
+                self._line(frame, (17, y), (20, y - 2), BLUE)
+                self._line(frame, (47, y), (44, y - 2), BLUE)
+        if level.get("reverse"):
+            self._arrow(frame, 3, (27, 5), VIOLET)
+            self._arrow(frame, 4, (37, 5), ASH)
+
+    def _compass_overlay(self, frame):
+        """Fixed frame marks render above both settled and traveling silk."""
+        level = self.game.level
+        direction = (1, 4, 2, 3)[level["rotation"] % 4]
+        self._arrow(frame, direction, (32, 31), INK)
+        for index in range(level["rotation"] % 4):
+            frame[28 + index * 3:30 + index * 3, 21:24] = VIOLET
+
+    def _progress_mark(self, frame, center, complete):
+        x, y = center
+        if complete:
+            self._disc(frame, center, 2, GREEN)
+            frame[y, x] = PAPER
+        else:
+            self._line(frame, (x, y - 2), (x + 2, y), SLATE)
+            self._line(frame, (x + 2, y), (x, y + 2), SLATE)
+            self._line(frame, (x, y + 2), (x - 2, y), SLATE)
+            self._line(frame, (x - 2, y), (x, y - 2), SLATE)
+
+    def _current_pointer(self, frame, center, card_radius):
+        x, y = center
+        vx, vy = 32 - x, 31 - y
+        scale = max(abs(vx), abs(vy), 1)
+        distance = card_radius + 3
+        point = (x + round(vx * distance / scale), y + round(vy * distance / scale))
+        self._diamond(frame, point, 2, INK, hollow=True)
+        inner = (point[0] + (1 if vx > 0 else -1 if vx < 0 else 0) * 2,
+                 point[1] + (1 if vy > 0 else -1 if vy < 0 else 0) * 2)
+        self._line(frame, point, inner, INK)
+
+    def _cards(self, frame):
+        g = self.game
+        level = g.level
+        positions = self._positions(len(level["demo"]))
+        specs = expanded_specs(level)
+        current_card = specs[min(g.state[0], len(specs) - 1)][1] if not solved(level, g.state) else -1
+        turns = level.get("beat_turns", (0,) * len(level["demo"]))
+        echoes = level.get("echoes", (False,) * len(level["demo"]))
+        compact = len(level["demo"]) >= 10
+        card_radius = 4 if compact else 5
+        halo_radius = 6 if compact else 7
+        for index, (action, center) in enumerate(zip(level["demo"], positions)):
+            self._disc(frame, center, card_radius, GOLD if index == current_card else PEARL)
+            self._disc(frame, center, card_radius, VIOLET, hollow=True)
+            self._arrow(frame, action, center, INK)
+            for notch in range(turns[index]):
+                x, y = center
+                frame[max(0, y - card_radius - 1 - notch), max(0, x - 1):min(64, x + 2)] = MAGENTA
+            if echoes[index]:
+                self._disc(frame, center, halo_radius, AQUA, hollow=True)
+            if index == current_card:
+                self._current_pointer(frame, center, halo_radius if echoes[index] else card_radius)
+        count = len(specs)
+        sewing = g.anim_kind in ("step", "success") and g.pending_state is not None
+        for index in range(count):
+            if sewing and index == g.state[0]:
+                continue
+            self._progress_mark(frame, self._progress_position(count, index), index < g.state[0])
+
+    def _hud(self, frame):
+        g = self.game
+        # Both radius-three crescents are fully inset; spent state is an X.
+        for index, x in enumerate((54, 60)):
+            if index < g.state[1]:
+                self._disc(frame, (x, 5), 3, AQUA, hollow=True)
+                frame[3:8, x:x + 3] = PAPER
+            else:
+                self._line(frame, (x - 2, 3), (x + 2, 7), RED)
+                self._line(frame, (x + 2, 3), (x - 2, 7), RED)
+
+    def _sew_rosette(self, frame, progress, total):
+        g = self.game
+        count = len(expanded_specs(g.level))
+        center = self._progress_position(count, g.state[0])
+        if progress <= 0:
+            self._progress_mark(frame, center, False)
+            return
+        if progress >= total - 1:
+            self._progress_mark(frame, center, True)
+            return
+        x, y = center
+        petals = min(4, 1 + 4 * progress // max(1, total - 1))
+        frame[y, x] = GREEN
+        for dx, dy in ((0, -2), (2, 0), (0, 2), (-2, 0))[:petals]:
+            self._line(frame, (x, y), (x + dx, y + dy), GREEN)
+
+    @staticmethod
+    def _travel(progress, total, distance):
+        span = max(2, total - 1)
+        half = max(1, span // 2)
+        folded = progress if progress <= half else span - progress
+        return max(0, distance * folded // half)
+
+    def _animation(self, frame):
+        g = self.game
+        if not g.anim_kind:
+            if g.intro_mark:
+                for radius in (4, 8, 12):
+                    self._disc(frame, (32, 31), radius, GOLD, hollow=True)
+            if g.terminal_hold == "loss":
+                self._line(frame, (14, 18), (50, 44), RED)
+                self._line(frame, (50, 18), (14, 44), RED)
+            elif g.terminal_hold == "win":
+                for radius in (9, 15, 21):
+                    self._disc(frame, (32, 31), radius, GREEN, hollow=True)
+            return
+        progress = g.anim_progress
+        total = max(1, g.anim_total)
+        dx, dy = DIRS[g.anim_action]
+        px, py = -dy, dx
+        travel = self._travel(progress, total, 12 if g.anim_kind != "miss" else 9)
+        lift = self._travel(progress, total, 2)
+        center = (32 + dx * travel + px * lift, 31 + dy * travel + py * lift)
+        if g.anim_kind in ("step", "success"):
+            self._kite(frame, center)
+            self._line(frame, (32, 31), center, AQUA, dotted=True)
+            self._sew_rosette(frame, progress, total)
+            if g.anim_kind == "success":
+                for radius in range(5, min(28, 5 + progress * 4), 5):
+                    self._disc(frame, (32, 31), radius, GREEN, hollow=True)
+        elif g.anim_kind == "miss":
+            self._kite(frame, center, error=True)
+            for feather in range(progress + 1):
+                along = 2 + feather * 2
+                side = (1 if feather % 2 == 0 else -1) * (2 + feather // 2)
+                origin = (center[0] - dx * along + px * side,
+                          center[1] - dy * along + py * side)
+                tip = (origin[0] + px * (2 if side > 0 else -2), origin[1] + py * (2 if side > 0 else -2))
+                self._line(frame, origin, tip, CORAL)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        moving = self.game.anim_kind in ("step", "success", "miss")
+        self._background(frame)
+        self._cards(frame)
+        self._apparatus(frame, draw_kite=not moving)
+        self._hud(frame)
+        self._animation(frame)
+        self._compass_overlay(frame)
+        return frame
+
+
+class Q111(ARCBaseGame):
+    def __init__(self):
+        self.display = SilkDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_action = 4
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q111", levels, Camera(0, 0, 64, 64, PAPER, PAPER, [self.display]),
+                         False, len(levels), [1, 2, 3, 4])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+
+    def _begin(self, kind, frames, action, state, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.anim_action = action
+        self.pending_state = state
+        self.pending_terminal = terminal
+
+    def _finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state
+        self.anim_kind = None
+        self.pending_state = None
+        self.pending_terminal = None
+        if terminal == "win":
+            self.terminal_hold = "win"
+            self.next_level()
+        elif terminal == "loss":
+            self.terminal_hold = "loss"
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self._finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        self.intro_mark = False
+        after = transition(self.level, self.state, action)
+        correct = after[0] > self.state[0]
+        won = after[-1] == 2
+        lost = after[-1] == 3
+        self._begin("success" if won else "step" if correct else "miss", 7,
+                    action, after, "win" if won else "loss" if lost else None)

--- a/data/community-games/sonpham/q116_v3_q116.py
+++ b/data/community-games/sonpham/q116_v3_q116.py
@@ -1,0 +1,540 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q116-v3 Counterexample Cabinet -- expose and audit visible policy evidence.
+
+Candidate fingerprints are always visible.  A specimen probe carries the unknown
+report through every row and settles contradictions into physical shutters.  Later
+cabinets compose probe prices, linked slides, closing irises, inverted reports, and
+balanced evidence seals.  Two audit seals are independent of evidence budget.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+BONE, SILVER, ASH, BRASS, BLACK = 0, 1, 2, 11, 5
+MAGENTA, ROSE, RED, BLUE, GLASS, COPPER, GREEN, VIOLET = 6, 7, 8, 9, 10, 12, 14, 15
+
+
+LEVELS = [
+    {"name": "Single Contradiction", "rules": (0b0000, 0b1010, 0b0110, 0b1111),
+     "target": 2, "examples": 4, "quota": 2, "budget": 7},
+    {"name": "Priced Lens", "rules": (0b00000, 0b10110, 0b01101, 0b11011, 0b00111),
+     "target": 3, "examples": 5, "costs": (3, 1, 1, 2, 1),
+     "min_used": 3, "quota": 3, "budget": 11},
+    {"name": "Twin Slide", "rules": (0b00000, 0b10101, 0b01110, 0b11001, 0b00111),
+     "target": 4, "examples": 5, "links": ((1, 3),),
+     "min_used": 4, "quota": 4, "budget": 10},
+    {"name": "Closing Iris", "rules": (0b000000, 0b101011, 0b011101, 0b110110,
+                                           0b001111, 0b111000),
+     "target": 3, "examples": 6, "closes": ((0, 1), (4, 3)),
+     "min_used": 3, "quota": 3, "require_close": True, "budget": 10},
+    {"name": "Prism Report", "rules": (0b000000, 0b101101, 0b011011, 0b110010,
+                                           0b001111, 0b111100),
+     "target": 5, "examples": 6, "invert": (0, 2), "costs": (1, 2, 1, 1, 2, 1),
+     "quota": 2, "budget": 10},
+    {"name": "Balanced Seal", "rules": (0b000000, 0b101101, 0b011010, 0b110011,
+                                            0b001111, 0b111000, 0b100110),
+     "target": 6, "examples": 6, "require_both": True, "links": ((0, 5),),
+     "quota": 3, "budget": 10},
+    {"name": "Crossed Archive", "rules": (0b0000000, 0b1011010, 0b0110101, 0b1100110,
+                                              0b0011111, 0b1110001, 0b1001100),
+     "target": 4, "examples": 7, "costs": (1, 2, 1, 2, 1, 1, 2),
+     "links": ((0, 4),), "invert": (0, 4), "require_both": True, "min_used": 4,
+     "quota": 4, "budget": 11},
+    {"name": "Counterexample Cabinet", "rules": (0b0000000, 0b1011010, 0b0110101,
+                                                     0b1100110, 0b0011111, 0b1110001,
+                                                     0b1001100, 0b0101011),
+     "target": 7, "examples": 7, "costs": (2, 1, 2, 1, 1, 2, 1),
+     "links": ((0, 4),), "closes": ((0, 1), (5, 6)), "invert": (3, 6),
+     "require_both": True, "require_close": True, "require_prism": True,
+     "min_used": 4, "quota": 4, "budget": 17},
+]
+
+
+def start_state(_level):
+    # used, closed, specimen cursor, hypothesis cursor, audit seals, proof latch, terminal
+    return 0, 0, 0, 0, 2, 0, 0
+
+
+def report(level, rule_index, example):
+    bit = (level["rules"][rule_index] >> example) & 1
+    return bit ^ (1 if example in level.get("invert", ()) else 0)
+
+
+def linked_examples(level, example):
+    revealed = {example}
+    for left, right in level.get("links", ()):
+        if example == left:
+            revealed.add(right)
+        elif example == right:
+            revealed.add(left)
+    return revealed
+
+
+def active_candidates(level, state):
+    used = state[0]
+    target = level["target"]
+    return tuple(
+        rule_index for rule_index in range(len(level["rules"]))
+        if all(report(level, rule_index, example) == report(level, target, example)
+               for example in range(level["examples"]) if used & (1 << example))
+    )
+
+
+def configuration_solved(level, state):
+    used, closed, _example, hyp = state[:4]
+    if active_candidates(level, state) != (level["target"],) or hyp != level["target"]:
+        return False
+    if used.bit_count() != level["quota"]:
+        return False
+    if level.get("require_close") and not closed:
+        return False
+    if level.get("require_prism") and not any(
+            used & (1 << example) for example in level.get("invert", ())):
+        return False
+    if level.get("require_both"):
+        outcomes = {report(level, level["target"], example)
+                    for example in range(level["examples"]) if used & (1 << example)}
+        if outcomes != {0, 1}:
+            return False
+    return True
+
+
+def transition(level, state, action):
+    used, closed, example, hyp, audits, proof, terminal = state
+    if terminal or action not in (1, 2, 3, 4, 5, 6):
+        return state
+
+    # While the proof clamp is partly closed, any physical control first acts
+    # as a release handle: it opens the jaws, breaks one wax seal, and leaves
+    # the evidence itself untouched.  A deliberate player closes all three
+    # jaws with action 6; random input cannot wait at zero evidence energy and
+    # receive a free terminal success.
+    if proof and action != 6:
+        audits -= 1
+        return used, closed, example, hyp, audits, 0, 3 if audits <= 0 else terminal
+
+    def edited(next_used, next_closed, next_example, next_hyp):
+        """Opening a partly closed proof clamp breaks one visible wax seal."""
+        next_audits = audits - (1 if proof else 0)
+        next_terminal = 3 if next_audits <= 0 else terminal
+        return next_used, next_closed, next_example, next_hyp, next_audits, 0, next_terminal
+
+    if action == 1:
+        next_example = max(0, example - 1)
+        return state if next_example == example else edited(used, closed, next_example, hyp)
+    if action == 2:
+        next_example = min(level["examples"] - 1, example + 1)
+        return state if next_example == example else edited(used, closed, next_example, hyp)
+    if action == 3:
+        next_hyp = max(0, hyp - 1)
+        return state if next_hyp == hyp else edited(used, closed, example, next_hyp)
+    if action == 4:
+        next_hyp = min(len(level["rules"]) - 1, hyp + 1)
+        return state if next_hyp == hyp else edited(used, closed, example, next_hyp)
+    if action == 6:
+        if configuration_solved(level, state):
+            if proof < 2:
+                return used, closed, example, hyp, audits, proof + 1, terminal
+            return used, closed, example, hyp, audits, proof + 1, 2
+        audits -= 1
+        return used, closed, example, hyp, audits, 0, 3 if audits <= 0 else 0
+    if used & (1 << example) or closed & (1 << example):
+        return state
+    for revealed in linked_examples(level, example):
+        if not closed & (1 << revealed):
+            used |= 1 << revealed
+    for trigger, shuttered in level.get("closes", ()):
+        if example == trigger and not used & (1 << shuttered):
+            closed |= 1 << shuttered
+    return edited(used, closed, example, hyp)
+
+
+def action_cost(level, state, after):
+    """Evidence energy is independent of the two audit seals."""
+    if after == state or after[:4] == state[:4]:
+        return 0
+    if after[0] != state[0] or after[1] != state[1]:
+        return level.get("costs", (1,) * level["examples"])[state[2]]
+    return 1
+
+
+def solved(_level, state):
+    return state[-1] == 2
+
+
+class CabinetDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def _disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius ** 2 and (not hollow or distance >= max(0, radius - 1) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def _line(frame, a, b, color, dotted=False):
+        x0, y0 = a; x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    def _background(self, frame):
+        frame[:, :] = BLACK
+        # A quiet smoked-glass case: depth comes from three rails, not a noisy grid.
+        frame[2:62, 2] = BRASS; frame[2:62, 61] = BRASS
+        frame[2, 2:62] = BRASS; frame[61, 2:62] = BRASS
+        frame[23:25, 4:60] = ASH
+        frame[56:58, 4:60] = ASH
+        for x in (8, 32, 56):
+            frame[3:59:8, x] = SILVER
+
+    def _outcome(self, frame, outcome, center, color, small=False):
+        x, y = center
+        if outcome:
+            self._disc(frame, center, 1 if small else 2, color, hollow=True)
+        else:
+            radius = 1 if small else 2
+            self._line(frame, (x - radius, y - radius), (x + radius, y + radius), color)
+            self._line(frame, (x + radius, y - radius), (x - radius, y + radius), color)
+
+    @staticmethod
+    def _shutter(frame, x, progress=1, total=1):
+        # Expands from the iris center; progress==total exactly matches settled state.
+        width = 4 * progress // max(1, total)
+        up = 5 * progress // max(1, total)
+        down = 6 * progress // max(1, total)
+        top, bottom = 12 - up, 13 + down
+        frame[top:bottom:2, x - width:x + width + 1] = RED
+        frame[top:bottom, x - width:x + width + 1:2] = RED
+
+    def _specimen(self, frame, index, center):
+        x, _ = center
+        frame[8:17, x - 3:x + 4] = BLACK
+        kind = index % 4
+        if kind == 0:
+            self._disc(frame, (x, 12), 3, COPPER, hollow=True)
+        elif kind == 1:
+            for dy in range(4):
+                frame[14 - dy, x - dy:x + dy + 1] = COPPER
+        elif kind == 2:
+            for dy in range(-3, 4):
+                half = 3 - abs(dy)
+                frame[12 + dy, x - half:x + half + 1] = COPPER
+        else:
+            frame[9:15, x - 3:x + 4:2] = COPPER
+            frame[14:17, x - 3:x + 4] = COPPER
+
+    def _example_bracket(self, frame, x, color=BONE):
+        frame[4, x - 5:x + 6] = color
+        frame[18:23, x - 5] = color
+        frame[18:23, x + 5] = color
+        self._disc(frame, (x, 4), 2, color, hollow=True)
+
+    def _hyp_bracket(self, frame, y, color=BONE):
+        frame[y - 2:y + 3, 2] = color
+        frame[y - 2, 2:11] = color
+        frame[y + 2, 2:11] = color
+        frame[y, 2:5] = color
+
+    def _header(self, frame):
+        g = self.game
+        xs = g.example_positions()
+        costs = g.level.get("costs", (1,) * g.level["examples"])
+        used, closed, example = g.state[:3]
+        # The selected column is a broad, notched glass inspection channel.
+        selected_x = xs[example]
+        frame[24:56:2, selected_x - 3:selected_x + 4:2] = ASH
+        for index, x in enumerate(xs):
+            self._specimen(frame, index, (x, 12))
+            for pip in range(costs[index]):
+                frame[18, x - costs[index] + 1 + pip * 2] = BRASS
+            if index in g.level.get("invert", ()):
+                frame[6, x - 2:x + 3] = VIOLET
+                frame[5:8, x] = BONE
+            if closed & (1 << index):
+                self._shutter(frame, x)
+            elif used & (1 << index):
+                self._outcome(frame, report(g.level, g.level["target"], index),
+                              (x, 21), GREEN)
+            if index == example and g.anim_kind != "move_example":
+                self._example_bracket(frame, x)
+        for left, right in g.level.get("links", ()):
+            self._line(frame, (xs[left], 4), (xs[right], 4), GLASS, dotted=True)
+            frame[3, (xs[left] + xs[right]) // 2] = BONE
+        for trigger, shuttered in g.level.get("closes", ()):
+            self._line(frame, (xs[trigger], 24), (xs[shuttered], 24), ROSE, dotted=True)
+            frame[22:25, xs[trigger]] = RED
+            frame[22:25, xs[shuttered] - 1:xs[shuttered] + 2] = RED
+
+    def _candidate_row(self, frame, rule_index, state):
+        g = self.game
+        used, _closed, _example, hyp = state[:4]
+        active = rule_index in active_candidates(g.level, state)
+        xs = g.example_positions()
+        y = 26 + rule_index * 4
+        if active:
+            frame[y - 1:y + 2, 4:60:2] = ASH
+        else:
+            frame[y - 1:y + 2, 4:60:3] = SILVER
+            self._line(frame, (4, y + 1), (59, y - 1), SILVER, dotted=True)
+        color = GLASS if active else SILVER
+        # Each row begins with a deep asymmetric mask rather than a plain index bar.
+        frame[y - 1:y + 2, 5:10] = color
+        frame[y - 2:y + 3, 7] = color
+        frame[y, 4] = color
+        if rule_index == hyp and g.anim_kind != "move_hyp":
+            self._hyp_bracket(frame, y)
+        for example, x in enumerate(xs):
+            prediction = report(g.level, rule_index, example)
+            self._outcome(frame, prediction, (x, y), color, small=True)
+            if used & (1 << example):
+                expected = report(g.level, g.level["target"], example)
+                if prediction != expected:
+                    self._line(frame, (x - 2, y - 1), (x + 2, y + 1), RED)
+                    self._line(frame, (x + 2, y - 1), (x - 2, y + 1), RED)
+
+    def _candidates(self, frame):
+        g = self.game
+        reached = 0
+        if g.anim_kind == "probe" and g.pending_state is not None:
+            reached = min(len(g.level["rules"]), g.anim_progress)
+        for rule_index in range(len(g.level["rules"])):
+            state = g.pending_state if rule_index < reached else g.state
+            self._candidate_row(frame, rule_index, state)
+
+    def _lamp(self, frame, center, filled, color):
+        if filled:
+            self._disc(frame, center, 2, color)
+            frame[center[1], center[0]] = BONE
+        else:
+            self._disc(frame, center, 2, SILVER, hollow=True)
+
+    def _hud(self, frame):
+        g = self.game
+        # Exact evidence budget: five-pixel rivets collapse to one-pixel sockets.
+        for index in range(g.budget_max):
+            x = 4 + index * 48 // max(1, g.budget_max - 1)
+            if index < g.budget_left:
+                self._disc(frame, (x, 62), 1, BRASS)
+            else:
+                frame[62, x] = SILVER
+        # Two large audit lamps are independent of that rail.
+        for index in range(2):
+            self._lamp(frame, (56 + index * 5, 57), index < g.state[4], COPPER)
+        # One mechanical proof clamp has three jaws.  Correct closes converge
+        # each jaw; any subsequent evidence/cursor edit visibly springs all
+        # settled jaws open.  This is terminal proof, not three arbitrary audits.
+        before_proof = g.state[5]
+        after_proof = (g.pending_state[5] if g.pending_state is not None else before_proof)
+        moving_proof = after_proof != before_proof and g.anim_kind is not None
+        p = g.anim_progress; total = max(1, g.anim_total)
+        for index in range(3):
+            x, y = 41 + index * 5, 58
+            if moving_proof and after_proof > before_proof and index == before_proof:
+                gap = max(0, 2 - 2 * p // total)
+                if gap == 0:
+                    frame[y - 2:y + 3, x] = GREEN
+                    frame[y, x - 1:x + 2] = GREEN
+                else:
+                    self._line(frame, (x - 2, y - 2), (x, y - gap), GREEN)
+                    self._line(frame, (x + 2, y + 2), (x, y + gap), GREEN)
+            elif moving_proof and after_proof < before_proof and index < before_proof:
+                gap = min(2, 2 * p // total)
+                self._line(frame, (x, y - gap), (x - 2, y - 2), SILVER)
+                self._line(frame, (x, y + gap), (x + 2, y + 2), SILVER)
+            elif index < before_proof:
+                frame[y - 2:y + 3, x] = GREEN
+                frame[y, x - 1:x + 2] = GREEN
+            else:
+                self._line(frame, (x - 2, y - 2), (x, y - 2), SILVER)
+                self._line(frame, (x + 2, y + 2), (x, y + 2), SILVER)
+        if g.level.get("require_both"):
+            outcomes = {report(g.level, g.level["target"], example)
+                        for example in range(g.level["examples"])
+                        if g.state[0] & (1 << example)}
+            self._outcome(frame, 0, (57, 48), GREEN if 0 in outcomes else SILVER)
+            self._outcome(frame, 1, (57, 52), GREEN if 1 in outcomes else SILVER)
+        for slot in range(g.level["quota"]):
+            y = 47 - slot * 3
+            if g.state[0].bit_count() > slot:
+                frame[y, 58:61] = GREEN
+            else:
+                frame[y, 59] = SILVER
+        if g.state[0].bit_count() > g.level["quota"]:
+            self._line(frame, (56, 34), (61, 38), RED)
+            self._line(frame, (61, 34), (56, 38), RED)
+
+    def _probe_animation(self, frame):
+        g = self.game
+        p = g.anim_progress
+        before, after = g.state, g.pending_state
+        xs = g.example_positions()
+        source_x = xs[before[2]]
+        # A vertical beam reaches the same rows whose final material has settled.
+        self._line(frame, (source_x, 21), (source_x, min(55, 22 + p * 5)), BONE)
+        newly_used = after[0] & ~before[0]
+        for example in range(g.level["examples"]):
+            if not newly_used & (1 << example):
+                continue
+            target_x = xs[example]
+            outcome = report(g.level, g.level["target"], example)
+            if example == before[2]:
+                self._outcome(frame, outcome, (target_x, 21), GREEN)
+            else:
+                x = source_x + (target_x - source_x) * p // g.anim_total
+                self._outcome(frame, outcome, (x, 4), GREEN)
+                if p == g.anim_total:
+                    self._outcome(frame, outcome, (target_x, 21), GREEN)
+        newly_closed = after[1] & ~before[1]
+        for example in range(g.level["examples"]):
+            if newly_closed & (1 << example):
+                self._shutter(frame, xs[example], p, g.anim_total)
+
+    def _animation(self, frame):
+        g = self.game
+        if not g.anim_kind:
+            return
+        p = g.anim_progress
+        if g.anim_kind == "move_example":
+            xs = g.example_positions()
+            x = xs[g.anim_from] + (xs[g.anim_to] - xs[g.anim_from]) * p // g.anim_total
+            self._example_bracket(frame, x)
+        elif g.anim_kind == "move_hyp":
+            y = 26 + g.anim_from * 4 + (g.anim_to - g.anim_from) * 4 * p // g.anim_total
+            self._hyp_bracket(frame, y)
+        elif g.anim_kind == "probe":
+            self._probe_animation(frame)
+        elif g.anim_kind == "blocked":
+            x = g.example_positions()[g.state[2]]
+            self._shutter(frame, x, p, g.anim_total)
+        elif g.anim_kind == "audit_reject":
+            for index in range(2):
+                self._disc(frame, (56 + index * 5, 57), 2 + p, RED, hollow=True)
+        elif g.anim_kind == "proof_release":
+            self._line(frame, (38 + p, 55), (54 - p, 61), RED)
+            self._disc(frame, (56, 57), 2 + p, RED, hollow=True)
+        elif g.anim_kind == "success":
+            for radius, color in ((3 + p * 2, BRASS), (2 + p, GLASS), (1 + p // 2, GREEN)):
+                self._disc(frame, (32, 40), radius, color, hollow=True)
+        elif g.anim_kind == "loss":
+            frame[25:55, 5 + p:59 - p:3] = RED
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self._background(frame)
+        self._header(frame)
+        self._candidates(frame)
+        self._hud(frame)
+        self._animation(frame)
+        return frame
+
+
+class Q116(ARCBaseGame):
+    def __init__(self):
+        self.display = CabinetDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_from = self.anim_to = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q116", levels, Camera(0, 0, 64, 64, BLACK, BLACK, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def example_positions(self):
+        count = self.level["examples"]
+        return tuple(8 + index * 48 // max(1, count - 1) for index in range(count))
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_from = self.anim_to = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+
+    def _begin(self, kind, frames, state, budget, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.pending_state = state
+        self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def _finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state
+        self.budget_left = self.pending_budget
+        self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self._finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        before = self.state
+        after = transition(self.level, before, action)
+        if after == before:
+            self._begin("blocked", 3, before, self.budget_left)
+            return
+        cost = action_cost(self.level, before, after)
+        if cost > self.budget_left:
+            self._begin("blocked", 3, before, self.budget_left)
+            return
+        budget = self.budget_left - cost
+        won = after[-1] == 2
+        lost = after[-1] == 3
+        if won:
+            kind = "success"
+        elif lost:
+            kind = "loss"
+        elif before[5] > 0 and after[5] == 0:
+            kind = "proof_release"
+        elif action == 6 and after[5] > before[5]:
+            kind = "proof_close"
+        elif action == 6:
+            kind = "audit_reject"
+        elif action in (1, 2):
+            self.anim_from, self.anim_to = before[2], after[2]
+            kind = "move_example"
+        elif action in (3, 4):
+            self.anim_from, self.anim_to = before[3], after[3]
+            kind = "move_hyp"
+        else:
+            kind = "probe"
+        frames = (min(8, len(self.level["rules"]) + 1) if kind == "probe"
+                  else 7 if kind in ("success", "loss") else 5 if kind in ("audit_reject", "proof_release") else 4)
+        self._begin(kind, frames, after, budget, "win" if won else "loss" if lost else None)

--- a/data/community-games/sonpham/q121_v2_q121.py
+++ b/data/community-games/sonpham/q121_v2_q121.py
@@ -1,0 +1,683 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q121-v2 Daylight Ribbon Chase -- outrun a visible habit hunter.
+
+The fox travels an irregular painted ribbon.  Its crescent hunter predicts the
+modal direction in the exact ordered footprint window and pounces on that
+direction.  A first bad choice raises a visible scare and remains recoverable;
+the second captures the fox.  Later ribbon knots are traversable only by a
+large snapped mouse/tap target, making direct navigation a structural input
+rather than decorative evidence.
+
+This module deliberately adopts only direct mouse navigation (mx007) and
+remains a deterministic, fully observable route-planning game.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from copy import deepcopy
+import hashlib
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, CREAM, ASH, GRAPHITE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, PINK, CORAL, SKY, AQUA, SUN = 6, 7, 8, 9, 10, 11
+ORANGE, OXBLOOD, LEAF, VIOLET = 12, 13, 14, 15
+
+ACTIVE, WIN, LOSS = 0, 2, 3
+TERMINAL_INDEX = 5
+SNAP_RADIUS = 10
+DIRS = {1: (0, -1), 2: (0, 1), 3: (-1, 0), 4: (1, 0)}
+REVERSE = {1: 2, 2: 1, 3: 4, 4: 3}
+
+
+def prediction(history):
+    """Recent modal direction with the stable low-id tie break."""
+    counts = Counter(history)
+    return max(range(1, 5), key=lambda action: (counts[action], -action))
+
+
+def _walk(directions, start=(11, 34)):
+    """Lay a visibly irregular, dominantly compass-readable painted trail."""
+    points = [start]
+    x, y = start
+    for index, direction in enumerate(directions):
+        dx, dy = DIRS[direction]
+        x += dx * 5
+        y += dy * 5
+        # Small perpendicular hand-painted drift defeats a square-grid read
+        # while preserving an unambiguous compass direction.
+        wobble = (-1, 1, 0)[index % 3]
+        if dx:
+            y += wobble
+        else:
+            x += wobble
+        points.append((x, y))
+    assert all(5 <= x <= 58 and 16 <= y <= 53 for x, y in points)
+    return tuple(points)
+
+
+def ribbon(name, directions, history, window, *, budget=None,
+           backtracks=True, mouse_steps=(), blocked=(), opening_scare=False):
+    """Build one immutable ribbon graph.
+
+    Edges are (source, target, footprint direction, mouse-only, evidence bit).
+    Reverse edges create real route choices.  With a tight budget, taking a
+    backward ribbon is recoverable as an input but cannot be part of a win.
+    """
+    directions = tuple(directions)
+    nodes = _walk(directions)
+    mouse_steps = frozenset(mouse_steps)
+    edges = []
+    bit_index = 0
+    required_mouse = 0
+    for index, direction in enumerate(directions):
+        mouse_only = index in mouse_steps
+        bit = 0
+        if mouse_only:
+            bit = 1 << bit_index
+            bit_index += 1
+            required_mouse |= bit
+        edges.append((index, index + 1, direction, mouse_only, bit))
+        if backtracks and index:
+            back = REVERSE[directions[index - 1]]
+            # An exit cannot carry two meanings. Opposite consecutive strokes
+            # already supply their own return-shaped choice.
+            if back != direction:
+                edges.append((index, index - 1, back, False, 0))
+    if backtracks and len(directions) > 1:
+        edges.append((len(directions), len(directions) - 1,
+                      REVERSE[directions[-1]], False, 0))
+    return {
+        "name": name,
+        "nodes": nodes,
+        "edges": tuple(edges),
+        "start": 0,
+        "goal": len(nodes) - 1,
+        "history": tuple(history),
+        "window": int(window),
+        "budget": len(directions) if budget is None else int(budget),
+        "required_mouse": required_mouse,
+        "opening_scare": bool(opening_scare),
+        "blocked": tuple((int(node), int(direction))
+                         for node, direction in blocked),
+        "witness": ((5,) if opening_scare else ()) + tuple(
+            (6, index + 1) if index in mouse_steps else direction
+            for index, direction in enumerate(directions)),
+    }
+
+
+# The repeated compass phrases are intentional habits, not repeated layouts:
+# the modal window turns a once-safe direction into the hunter's next pounce.
+# Later trails require more lookahead, reverse-route inhibition, and snapped
+# knot selection.  The final two levels compose all three demands.
+LEVELS = (
+    ribbon("First Footfall", (4, 1, 4, 2, 4), (3,), 1,
+           opening_scare=True),
+    ribbon("Two Prints", (4, 4, 1, 4, 4, 2, 4, 4, 2, 4, 4, 1, 4),
+           (3, 3), 2, blocked=((4, 1),)),
+    ribbon("Three-Beat Braid",
+           (4, 4, 1, 2, 4, 4, 2, 2, 4, 4, 1, 1, 4, 4),
+           (3, 3, 3), 3, blocked=((5, 1), (8, 2))),
+    ribbon("Forked Hedgerow",
+           (1, 4, 2, 2, 4, 4, 1, 1, 4, 4, 2, 3, 4, 4),
+           (2, 2, 3), 3, blocked=((3, 3), (7, 1), (10, 2))),
+    ribbon("Finger Gate",
+           (4, 4, 4, 2, 2, 4, 4, 4, 1, 1, 4, 4, 4),
+           (3, 3, 3, 3), 4, mouse_steps=(6,),
+           blocked=((4, 1), (9, 2))),
+    ribbon("Coral Return",
+           (4, 4, 4, 2, 1, 1, 4, 4, 4, 2, 2, 4, 4, 4),
+           (3, 3, 3, 3), 4, mouse_steps=(4,),
+           blocked=((6, 2), (11, 1))),
+    ribbon("Five-Print Chase",
+           (4, 4, 4, 1, 2, 2, 4, 4, 4, 2, 1, 1, 4, 4),
+           (3, 3, 3, 3, 3), 5, mouse_steps=(3, 10),
+           blocked=((5, 3), (9, 1), (12, 2))),
+    ribbon("Daylight Ribbon Chase",
+           (4, 4, 4, 1, 2, 2, 4, 4, 4, 2, 1, 1, 4, 4, 4),
+           (3, 3, 3, 3, 3), 5, mouse_steps=(3, 9, 12),
+           blocked=((4, 3), (7, 1), (11, 2), (13, 1))),
+)
+
+
+def start_state(level):
+    # position, exact ordered history, prior strikes, current scare pose,
+    # crossed mouse-knot evidence, terminal.
+    return (level["start"], level["history"], 0,
+            int(level["opening_scare"]), 0, ACTIVE)
+
+
+def _parse_action(action):
+    if isinstance(action, (tuple, list)):
+        return int(action[0]), int(action[1]) if len(action) > 1 else None
+    return int(action), None
+
+
+def _outgoing(level, position):
+    return tuple(edge for edge in level["edges"] if edge[0] == position)
+
+
+def _edge_for_action(level, state, action):
+    aid, target = _parse_action(action)
+    edges = _outgoing(level, state[0])
+    if aid in DIRS:
+        return next((edge for edge in edges
+                     if edge[2] == aid and not edge[3]), None)
+    if aid == 6 and target is not None:
+        return next((edge for edge in edges if edge[1] == target), None)
+    return None
+
+
+def ready(level, state):
+    return (state[0] == level["goal"]
+            and state[4] & level["required_mouse"]
+            == level["required_mouse"])
+
+
+def transition(level, state, action):
+    """Pure deterministic rules contract used by search and runtime."""
+    if state[TERMINAL_INDEX] != ACTIVE:
+        return state
+    aid, _target = _parse_action(action)
+    position, history, strikes, scare, mouse_mask, _terminal = state
+    if aid == 5:
+        # A calm feint clears the visible recoil. It does not erase the cracked
+        # first-pounce seal, so a later predicted move still causes capture.
+        if scare:
+            return (position, history, strikes, 0, mouse_mask, ACTIVE)
+        return state
+    # During the visible recoil the fox must perform the explicit action-5
+    # feint before another route choice. Repeating the predicted intent after
+    # a real first strike is the finite second capture; other inputs are
+    # blocked, visible in the stable scare diamond, and cost nothing.
+    if scare:
+        edge = _edge_for_action(level, state, action)
+        direction = aid if aid in DIRS else (edge[2] if edge else None)
+        if direction == prediction(history):
+            if strikes:
+                return (position, history, strikes, 1, mouse_mask, LOSS)
+            return (position, history, 1, 1, mouse_mask, ACTIVE)
+        return state
+    # A compass input telegraphs intent even at a leaf-blocked exit.  This is
+    # not a silent wall tax: the first habitual attempt produces the large
+    # visible, zero-cost hunter scare and remains recoverable.
+    if aid in DIRS and aid == prediction(history):
+        if strikes:
+            return (position, history, strikes, 1, mouse_mask, LOSS)
+        return (position, history, 1, 1, mouse_mask, ACTIVE)
+    edge = _edge_for_action(level, state, action)
+    if edge is None:
+        return state
+    direction = edge[2]
+    if direction == prediction(history):
+        if strikes:
+            return (position, history, strikes, 1, mouse_mask, LOSS)
+        return (position, history, 1, 1, mouse_mask, ACTIVE)
+    next_history = (history + (direction,))[-level["window"]:]
+    next_mask = mouse_mask | edge[4]
+    after = (edge[1], next_history, strikes, 0, next_mask, ACTIVE)
+    if ready(level, after):
+        after = after[:TERMINAL_INDEX] + (WIN,)
+    return after
+
+
+def action_cost(state, after):
+    if after == state:
+        return 0
+    # Pounces and the explicit feint are safety feedback, never hidden budget
+    # taxes. A successful trail hop is the only nonterminal cost.
+    if after[TERMINAL_INDEX] == LOSS:
+        return 0
+    if (after[0] != state[0] or after[1] != state[1]
+            or after[4] != state[4]
+            or after[TERMINAL_INDEX] == WIN):
+        return 1
+    return 0
+
+
+def solved(level, state):
+    return state[TERMINAL_INDEX] == WIN and ready(level, state)
+
+
+def action_tokens(level):
+    # Every node is an authored direct target. Nonadjacent clicks are pure
+    # no-ops and are excluded by effective-action random analysis.
+    return (1, 2, 3, 4, 5) + tuple((6, index)
+                                    for index in range(len(level["nodes"])))
+
+
+def encoded_witness(level):
+    result = []
+    for action in level["witness"]:
+        aid, target = _parse_action(action)
+        if aid == 6:
+            x, y = level["nodes"][target]
+            result.append((6, x, y))
+        else:
+            result.append((aid,))
+    return tuple(result)
+
+
+def encode_action(level, action):
+    """Public one-action recording encoder used by independent qualifiers."""
+    aid, target = _parse_action(action)
+    if aid == 6 and target is not None:
+        x, y = level["nodes"][target]
+        return (6, x, y)
+    return (aid,)
+
+
+def _bresenham(start, end):
+    x0, y0 = start; x1, y1 = end
+    dx = abs(x1 - x0); sx = 1 if x0 < x1 else -1
+    dy = -abs(y1 - y0); sy = 1 if y0 < y1 else -1
+    error = dx + dy
+    while True:
+        yield x0, y0
+        if x0 == x1 and y0 == y1:
+            return
+        twice = 2 * error
+        if twice >= dy:
+            error += dy; x0 += sx
+        if twice <= dx:
+            error += dx; y0 += sy
+
+
+class ChaseDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def pixel(frame, x, y, color):
+        if 0 <= x < 64 and 0 <= y < 64:
+            frame[y, x] = color
+
+    @classmethod
+    def line(cls, frame, start, end, color, dotted=False, width=1):
+        for index, (x, y) in enumerate(_bresenham(start, end)):
+            if dotted and index % 4 in (1, 2):
+                continue
+            for oy in range(-(width // 2), width - width // 2):
+                for ox in range(-(width // 2), width - width // 2):
+                    cls.pixel(frame, x + ox, y + oy, color)
+
+    @classmethod
+    def disc(cls, frame, center, radius, color, hollow=False):
+        cx, cy = center; inner = max(0, radius - 1) ** 2
+        for y in range(cy - radius, cy + radius + 1):
+            for x in range(cx - radius, cx + radius + 1):
+                d = (x - cx) ** 2 + (y - cy) ** 2
+                if d <= radius ** 2 and (not hollow or d >= inner):
+                    cls.pixel(frame, x, y, color)
+
+    @classmethod
+    def diamond(cls, frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for dy in range(-radius, radius + 1):
+            reach = radius - abs(dy)
+            if hollow:
+                cls.pixel(frame, cx - reach, cy + dy, color)
+                cls.pixel(frame, cx + reach, cy + dy, color)
+            else:
+                for x in range(cx - reach, cx + reach + 1):
+                    cls.pixel(frame, x, cy + dy, color)
+
+    @classmethod
+    def crescent(cls, frame, center, radius, color, cut=CREAM, flip=False):
+        cls.disc(frame, center, radius, color)
+        shift = -2 if flip else 2
+        cls.disc(frame, (center[0] + shift, center[1] - 1),
+                 max(1, radius - 1), cut)
+
+    @classmethod
+    def leaf(cls, frame, center, color=LEAF, flip=False):
+        x, y = center
+        for dy in range(-3, 4):
+            reach = 3 - abs(dy)
+            start = x - reach if flip else x
+            end = x if flip else x + reach
+            for px in range(start, end + 1):
+                cls.pixel(frame, px, y + dy, color)
+        cls.line(frame, (x - 2 if flip else x + 2, y - 3),
+                 (x + 2 if flip else x - 2, y + 3), GRAPHITE, dotted=True)
+
+    @classmethod
+    def flower(cls, frame, center, color=CORAL, hollow=False):
+        x, y = center
+        for dx, dy in ((0, -4), (4, 0), (0, 4), (-4, 0)):
+            cls.disc(frame, (x + dx, y + dy), 3, color, hollow=hollow)
+        cls.disc(frame, center, 2, SUN if not hollow else GRAPHITE,
+                 hollow=hollow)
+
+    @classmethod
+    def fox(cls, frame, center, color=ORANGE, crouch=0):
+        x, y = center
+        # Teardrop body, two unequal ears, pale muzzle, and dark eye are more
+        # redundant than a colored square.
+        cls.disc(frame, (x, y + crouch), 4, color)
+        cls.diamond(frame, (x - 3, y - 4 + crouch), 3, color)
+        cls.diamond(frame, (x + 2, y - 3 + crouch), 2, PINK)
+        cls.disc(frame, (x + 2, y + crouch), 2, CREAM)
+        cls.pixel(frame, x + 3, y - 1 + crouch, INK)
+        cls.line(frame, (x - 3, y + 2 + crouch),
+                 (x - 7, y + 4 + crouch), OXBLOOD, width=2)
+
+    @classmethod
+    def footprint(cls, frame, center, direction, color=VIOLET,
+                  hollow=False):
+        """Four direction identities differ by silhouette and hatch pattern."""
+        x, y = center
+        if direction == 1:  # pointed crown + vertical dotted stem
+            cls.diamond(frame, (x, y - 1), 3, color, hollow)
+            cls.line(frame, (x, y + 1), (x, y + 4), color, dotted=True)
+        elif direction == 2:  # downward cup with paired heels
+            cls.line(frame, (x - 3, y - 2), (x, y + 3), color)
+            cls.line(frame, (x + 3, y - 2), (x, y + 3), color)
+            cls.pixel(frame, x - 2, y - 3, color)
+            cls.pixel(frame, x + 2, y - 3, color)
+        elif direction == 3:  # left hook + one notch
+            cls.line(frame, (x + 3, y - 2), (x - 3, y), color)
+            cls.line(frame, (x - 3, y), (x + 2, y + 3), color)
+            cls.pixel(frame, x, y - 2, color)
+        else:  # right fork + two notches
+            cls.line(frame, (x - 3, y - 2), (x + 3, y), color)
+            cls.line(frame, (x + 3, y), (x - 2, y + 3), color)
+            cls.pixel(frame, x, y - 3, color)
+            cls.pixel(frame, x - 2, y - 2, color)
+
+    def background(self, frame):
+        frame[:, :] = CREAM
+        # Fibrous paper flecks and broad gouache sun bands are decorative and
+        # stationary, avoiding flashing or state ambiguity.
+        for y in range(0, 64, 4):
+            for x in range((y // 4) % 3, 64, 9):
+                frame[y, x] = PAPER if (x + y) % 2 else ASH
+        self.disc(frame, (57, 18), 12, SUN, hollow=True)
+        self.disc(frame, (57, 18), 9, PAPER, hollow=True)
+        self.line(frame, (2, 54), (62, 51), AQUA, dotted=True, width=2)
+        for x in range(3, 64, 11):
+            self.leaf(frame, (x, 55 + (x // 11) % 3),
+                      LEAF if x % 2 else SKY, flip=bool(x % 3))
+
+    def curved_ribbon(self, frame, start, end, color, mouse_only=False):
+        x0, y0 = start; x1, y1 = end
+        mx, my = (x0 + x1) // 2, (y0 + y1) // 2
+        bend = 2 if (x0 + y1) % 2 else -2
+        if abs(x1 - x0) >= abs(y1 - y0):
+            my += bend
+        else:
+            mx += bend
+        self.line(frame, start, (mx, my), color, dotted=not mouse_only,
+                  width=2)
+        self.line(frame, (mx, my), end, color, dotted=not mouse_only,
+                  width=2)
+        if mouse_only:
+            self.diamond(frame, (mx, my), 2, MAGENTA, hollow=True)
+            self.disc(frame, (mx, my), 1, INK)
+
+    def stable_trail(self, frame, state):
+        level = self.game.level
+        drawn = set()
+        for source, target, _direction, mouse_only, _bit in level["edges"]:
+            pair = tuple(sorted((source, target)))
+            if pair in drawn:
+                continue
+            drawn.add(pair)
+            self.curved_ribbon(frame, level["nodes"][source],
+                               level["nodes"][target],
+                               MAGENTA if mouse_only else PINK, mouse_only)
+        for index, point in enumerate(level["nodes"]):
+            if index == level["goal"]:
+                self.flower(frame, point, CORAL, hollow=True)
+            else:
+                self.disc(frame, point, 2, SKY if index % 2 else AQUA,
+                          hollow=True)
+                self.diamond(frame, point, 1, GRAPHITE,
+                             hollow=bool(index % 2))
+                self.disc(frame, point, 1, GRAPHITE)
+        # Only currently adjacent destinations receive a large halo. This is
+        # both a readable generous click affordance and a sparse composition.
+        for edge in _outgoing(level, state[0]):
+            target = level["nodes"][edge[1]]
+            if edge[3]:
+                self.diamond(frame, target, 5, MAGENTA, hollow=True)
+                self.disc(frame, target, 2, INK, hollow=True)
+            else:
+                self.disc(frame, target, 5, SKY, hollow=True)
+                self.footprint(frame, target, edge[2], GRAPHITE)
+        # Leaf/coral obstruction pairs explicitly mark absent exits.
+        for index, (node, direction) in enumerate(level["blocked"]):
+            x, y = level["nodes"][node]; dx, dy = DIRS[direction]
+            point = (x + dx * 6, y + dy * 6)
+            if index % 2:
+                self.leaf(frame, point, LEAF, flip=bool(direction % 2))
+            else:
+                self.crescent(frame, point, 3, CORAL, CREAM,
+                              flip=bool(direction % 2))
+
+    def forecast(self, frame, state):
+        level = self.game.level; direction = prediction(state[1])
+        position = level["nodes"][state[0]]
+        edge = next((e for e in _outgoing(level, state[0])
+                     if e[2] == direction), None)
+        dx, dy = DIRS[direction]
+        hunter_point = (level["nodes"][edge[1]] if edge else
+                        (position[0] + dx * 8, position[1] + dy * 8))
+        self.crescent(frame, hunter_point, 5, OXBLOOD, CREAM,
+                      flip=direction in (1, 3))
+        # Hatching plus the direction silhouette identifies danger without hue.
+        self.line(frame, (hunter_point[0] - 4, hunter_point[1] - 3),
+                  (hunter_point[0] + 2, hunter_point[1] + 3), INK,
+                  dotted=True)
+        self.footprint(frame, (57, 8), direction, INK)
+        self.crescent(frame, (57, 8), 6, OXBLOOD, CREAM,
+                      flip=direction in (1, 3))
+        self.footprint(frame, (57, 8), direction, PAPER)
+
+    def hud(self, frame, state):
+        # Exact ordered history: every direction has a unique silhouette and
+        # internal mark. Earlier prints are paler but never encoded by hue only.
+        for index, direction in enumerate(state[1]):
+            x = 7 + index * 9
+            self.footprint(frame, (x, 7), direction,
+                           VIOLET if index == len(state[1]) - 1 else GRAPHITE)
+            self.pixel(frame, x, 12, INK if index == len(state[1]) - 1 else ASH)
+        # Two crescent lives: the first remains visibly cracked after a scare.
+        for index, x in enumerate((48, 54)):
+            live = index >= state[2]
+            self.crescent(frame, (x, 14), 3,
+                          ORANGE if live else ASH, CREAM, flip=bool(index))
+            if not live:
+                self.line(frame, (x - 2, 11), (x + 2, 17), INK)
+        if state[3]:
+            self.diamond(frame, (43, 14), 4, OXBLOOD, hollow=True)
+            self.line(frame, (39, 14), (47, 14), INK, dotted=True)
+            # Five separate seed notches map the recovery pose to action 5
+            # without a text or digit glyph.
+            for index in range(5):
+                self.diamond(frame, (39 + index * 2, 20), 1, INK,
+                             hollow=bool(index % 2))
+        # Every required mouse knot has an independent persistent rosette.
+        required = self.game.level["required_mouse"]
+        for index in range(required.bit_length()):
+            used = bool(state[4] & (1 << index))
+            self.flower(frame, (39 + index * 7, 59),
+                        MAGENTA if used else ASH, hollow=not used)
+            if used:
+                self.diamond(frame, (39 + index * 7, 59), 2, INK,
+                             hollow=True)
+        # Exact one-bead-per-action budget, grouped visually at five.
+        for index in range(self.game.budget_max):
+            x = 3 + index * 3 + (index // 5)
+            live = index < self.game.budget_left
+            self.disc(frame, (x, 61), 1, SUN if live else ASH,
+                      hollow=not live)
+            if index % 5 == 4:
+                self.pixel(frame, x + 2, 61, INK)
+
+    def animation(self, frame):
+        g = self.game
+        if not g.anim_kind:
+            return
+        before, after = g.state, g.pending_state
+        p = g.anim_progress; span = max(1, g.anim_total - 1)
+        wave = min(p, span - p)
+        old = g.level["nodes"][before[0]]
+        new = g.level["nodes"][after[0]]
+        if g.anim_kind in ("hop", "mouse", "success"):
+            x = old[0] + (new[0] - old[0]) * p // span
+            y = old[1] + (new[1] - old[1]) * p // span - wave
+            self.fox(frame, (x, y), ORANGE if g.anim_kind != "mouse" else MAGENTA,
+                     crouch=1 if p in (0, span) else 0)
+            self.line(frame, old, (x, y), OXBLOOD, dotted=True)
+            if g.anim_kind == "mouse":
+                self.diamond(frame, (x, y), 6 + wave, MAGENTA, hollow=True)
+            if g.anim_kind == "success":
+                self.flower(frame, new, CORAL if p % 2 else SUN, hollow=True)
+        elif g.anim_kind == "scare":
+            direction = prediction(before[1]); dx, dy = DIRS[direction]
+            hunter = (old[0] + dx * (8 - wave), old[1] + dy * (8 - wave))
+            self.crescent(frame, hunter, 5 + wave, OXBLOOD, CREAM,
+                          flip=direction in (1, 3))
+            self.fox(frame, (old[0] - dx * wave, old[1] - dy * wave),
+                     ORANGE, crouch=wave // 2)
+        elif g.anim_kind == "feint":
+            offset = (-2, 1, 3, 1, 0)[min(p, 4)]
+            self.fox(frame, (old[0] + offset, old[1] - abs(offset)), SKY)
+            self.crescent(frame, (old[0] - offset, old[1] + 5), 3,
+                          OXBLOOD, CREAM, flip=True)
+        elif g.anim_kind == "capture":
+            inset = 10 * p // span
+            self.crescent(frame, (old[0] - 10 + inset, old[1]),
+                          6 + wave, OXBLOOD, CREAM)
+            self.crescent(frame, (old[0] + 10 - inset, old[1]),
+                          6 + wave, OXBLOOD, CREAM, flip=True)
+            self.fox(frame, old, ASH, crouch=wave)
+        else:  # blocked/missed click: visible leaf recoil, no budget cost
+            self.leaf(frame, (old[0] + (-2, 1, 3, 1, 0)[min(p, 4)],
+                              old[1] + 6), LEAF, flip=bool(p % 2))
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self.background(frame)
+        self.stable_trail(frame, self.game.state)
+        self.forecast(frame, self.game.state)
+        self.hud(frame, self.game.state)
+        if not self.game.anim_kind or self.game.anim_kind not in (
+                "hop", "mouse", "success", "scare", "feint", "capture"):
+            self.fox(frame, self.game.level["nodes"][self.game.state[0]])
+        if self.game.state[TERMINAL_INDEX] == LOSS:
+            point = self.game.level["nodes"][self.game.state[0]]
+            self.line(frame, (point[0] - 6, point[1] - 6),
+                      (point[0] + 6, point[1] + 6), OXBLOOD, width=2)
+            self.line(frame, (point[0] + 6, point[1] - 6),
+                      (point[0] - 6, point[1] + 6), OXBLOOD, width=2)
+        elif self.game.state[TERMINAL_INDEX] == WIN:
+            self.flower(frame,
+                        self.game.level["nodes"][self.game.state[0]],
+                        SUN, hollow=True)
+        self.animation(frame)
+        return frame
+
+
+class Q121(ARCBaseGame):
+    def __init__(self):
+        self.display = ChaseDisplay(self)
+        self.level = LEVELS[0]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None; self.anim_total = self.anim_left = 0
+        self.anim_progress = 0; self.pending_state = self.pending_budget = None
+        self.pending_terminal = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(level),
+                        name=level["name"]) for level in LEVELS]
+        super().__init__("q121", levels,
+                         Camera(0, 0, 64, 64, CREAM, CREAM, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None; self.anim_total = self.anim_left = 0
+        self.anim_progress = 0; self.pending_state = self.pending_budget = None
+        self.pending_terminal = None
+
+    def snap_node(self, x, y):
+        candidates = []
+        for edge in _outgoing(self.level, self.state[0]):
+            tx, ty = self.level["nodes"][edge[1]]
+            distance = (tx - x) ** 2 + (ty - y) ** 2
+            if distance <= SNAP_RADIUS ** 2:
+                candidates.append((distance, edge[1]))
+        return min(candidates)[1] if candidates else None
+
+    def begin(self, kind, frames, after, budget, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames
+        self.anim_progress = 0; self.pending_state = after
+        self.pending_budget = budget; self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state; self.budget_left = self.pending_budget
+        self.anim_kind = None; self.anim_total = self.anim_left = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        aid = self.action.id.value
+        if aid == 0:
+            self.complete_action(); return
+        token = aid
+        if aid == 6:
+            target = self.snap_node(int(self.action.data.get("x", -99)),
+                                    int(self.action.data.get("y", -99)))
+            token = aid if target is None else (aid, target)
+        before = self.state; after = transition(self.level, before, token)
+        if after == before:
+            self.begin("blocked", 4, before, self.budget_left); return
+        cost = action_cost(before, after)
+        budget = self.budget_left - cost
+        won = after[TERMINAL_INDEX] == WIN
+        lost = after[TERMINAL_INDEX] == LOSS or (budget <= 0 and not won)
+        if lost and after[TERMINAL_INDEX] != LOSS:
+            after = after[:TERMINAL_INDEX] + (LOSS,)
+        if won:
+            kind, frames, terminal = "success", 5, "win"
+        elif lost:
+            kind, frames, terminal = "capture", 5, "loss"
+        elif after[2] > before[2]:
+            kind, frames, terminal = "scare", 5, None
+        elif aid == 5:
+            kind, frames, terminal = "feint", 5, None
+        else:
+            edge = _edge_for_action(self.level, before, token)
+            kind = "mouse" if aid == 6 and edge and edge[3] else "hop"
+            frames, terminal = 5, None
+        self.begin(kind, frames, after, budget, terminal)
+
+
+if __name__ == "__main__":
+    # Tiny deterministic smoke contract without starting the ARC runtime.
+    for configured in LEVELS:
+        state = start_state(configured); budget = configured["budget"]
+        for move in configured["witness"]:
+            after = transition(configured, state, move)
+            budget -= action_cost(state, after); state = after
+        assert solved(configured, state) and budget == 0
+    print(hashlib.sha256(__file__.encode()).hexdigest()[:12], "q121-v2 ok")

--- a/data/community-games/sonpham/q129_v3_q129.py
+++ b/data/community-games/sonpham/q129_v3_q129.py
@@ -1,0 +1,556 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q129-v3 Velvet Moth Masque -- teach the watchers, turn the stage, steal the bloom."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, CREAM, FIBER, SAGE, MOSS, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, INDIGO, DEW_BLUE, GOLD, CORAL, BARK, LEAF, VIOLET = range(6, 16)
+DIRS = {1: (0, -1), 2: (0, 1), 3: (-1, 0), 4: (1, 0)}
+FLOWERS = "abcd"
+W, H = 7, 5
+SCENT_STUDS = (
+    (-6, -4), (-3, -7), (0, -8), (3, -7), (6, -4), (8, 0), (6, 4), (3, 7),
+    (0, 8), (-3, 7), (-6, 4), (-8, 0), (-5, -6), (5, -6), (5, 6), (-5, 6),
+)
+
+
+PLAIN = ("#######", "#a...b#", "#..S..#", "#c...d#", "#######")
+TWINE_STAGE = ("#######", "#a.#.b#", "#..S..#", "#c.#.d#", "#######")
+GROVE_STAGE = ("#######", "#a...b#", "##.S.##", "#c...d#", "#######")
+ROTOR_STAGE = ("#######", "#a...b#", "#.#S#.#", "#c...d#", "#######")
+DEW_STAGE = ("#######", "#a...b#", "#.#S#.#", "#c.r.d#", "#######")
+PRISM_STAGE = ("#######", "##a.b##", "#..p..#", "#c.rSd#", "#######")
+LEVELS = [
+    {"name": "Soft Opening", "grid": PLAIN, "target": "a", "quota": 2, "distinct": 1,
+     "echo": (), "fade": False, "guards": 1, "swap": 0, "budget": 7, "night_grace": 8},
+    {"name": "Silk Duet", "grid": TWINE_STAGE, "target": "b", "quota": 5, "distinct": 3,
+     "echo": (("a", "c"), ("b", "d")), "fade": False, "guards": 1, "swap": 0,
+     "budget": 17, "night_grace": 8},
+    {"name": "Falling Pollen", "grid": GROVE_STAGE, "target": "c", "quota": 6, "distinct": 3,
+     "echo": (("a", "c"), ("b", "d")), "fade": True, "guards": 1, "swap": 0,
+     "budget": 19, "night_grace": 8},
+    {"name": "Two Velvet Owls", "grid": TWINE_STAGE, "target": "d", "quota": 5, "distinct": 3,
+     "echo": (("a", "c"), ("b", "d")), "fade": True, "guards": 2, "swap": 0,
+     "budget": 17, "night_grace": 8},
+    {"name": "Revolving Beds", "grid": ROTOR_STAGE, "target": "a", "quota": 5, "distinct": 3,
+     "echo": (("a", "c"), ("b", "d")), "fade": True, "guards": 2, "swap": 1,
+     "budget": 15, "night_grace": 9},
+    {"name": "Dew Revision", "grid": DEW_STAGE, "target": "b", "quota": 6, "distinct": 3,
+     "dew_required": True, "echo": (("a", "c"), ("b", "d")), "fade": True,
+     "guards": 2, "swap": 1, "budget": 18, "night_grace": 9},
+    {"name": "Prismatic Gala", "grid": PRISM_STAGE, "target": "c", "quota": 7, "distinct": 4,
+     "dew_required": True, "prism_required": True, "echo": (("a", "d"), ("b", "c")),
+     "fade": True, "guards": 2, "swap": 2, "budget": 21, "night_grace": 10},
+    {"name": "Velvet Moth Masque", "grid": PRISM_STAGE, "target": "d", "quota": 8,
+     "distinct": 4, "dew_required": True, "prism_required": True,
+     "echo": (("a", "d"), ("b", "c")), "fade": True, "guards": 2, "swap": 3,
+     "budget": 24, "night_grace": 10},
+]
+
+
+def locate(grid, char):
+    for y, row in enumerate(grid):
+        for x, value in enumerate(row):
+            if value == char:
+                return x, y
+    raise ValueError(char)
+
+
+def start_state(level):
+    x, y = locate(level["grid"], "S")
+    # phase, x, y, four exact scent values, demonstrations, last species,
+    # bed turn, protected species mask, recoveries, seen mask, dew used,
+    # free night steps, prism used, consecutive refusals, terminal
+    # (0 play / 2 win / 3 loss).
+    return 0, x, y, (0, 0, 0, 0), 0, -1, 0, 0, 2, 0, 0, 0, 0, 0, 0
+
+
+def flower_at(level, state, x, y):
+    base = level["grid"][y][x]
+    if base not in FLOWERS:
+        return None
+    if state[0] != 1:
+        return base
+    slot = FLOWERS.index(base)
+    return FLOWERS[(slot - state[6]) % 4]
+
+
+def echo_partner(level, key):
+    for first, second in level["echo"]:
+        if key == first:
+            return second
+        if key == second:
+            return first
+    return None
+
+
+def guard_mask(level, attention):
+    # The left owl wins exact ties. This stable visible ordering makes the
+    # prepare-then-endure audit deterministic rather than secretly random.
+    ranked = sorted(range(4), key=lambda index: (-attention[index], index))
+    mask = 0
+    for index in ranked[:level["guards"]]:
+        mask |= 1 << index
+    return mask
+
+
+def transition(level, state, action):
+    (phase, x, y, attention, lessons, last, rotation, protected, chances,
+     seen, dew_used, night_steps, prism_used, refusals, terminal) = state
+    if terminal or action not in (1, 2, 3, 4, 5):
+        return state
+    if action == 5:
+        ready = (
+            phase == 0
+            and lessons == level["quota"]
+            and seen.bit_count() >= level["distinct"]
+            and (not level.get("dew_required") or dew_used)
+            and (not level.get("prism_required") or prism_used)
+        )
+        if not ready:
+            refusals += 1
+            return (phase, x, y, attention, lessons, last, rotation, protected,
+                    chances, seen, dew_used, night_steps, prism_used, refusals,
+                    3 if refusals >= 3 else 0)
+        protected = guard_mask(level, attention)
+        sx, sy = locate(level["grid"], "S")
+        return (1, sx, sy, attention, lessons, last, level["swap"], protected,
+                chances, seen, dew_used, level["night_grace"], prism_used, 0, 0)
+
+    dx, dy = DIRS[action]
+    nx, ny = x + dx, y + dy
+    if not (0 <= nx < W and 0 <= ny < H) or level["grid"][ny][nx] == "#":
+        refusals += 1
+        return (phase, x, y, attention, lessons, last, rotation, protected,
+                chances, seen, dew_used, night_steps, prism_used, refusals,
+                3 if refusals >= 3 else 0)
+    key = flower_at(level, state, nx, ny)
+    if phase == 0:
+        values = list(attention)
+        cell = level["grid"][ny][nx]
+        if cell == "r" and last >= 0 and not dew_used and values[last] > 0:
+            values[last] = max(0, values[last] - 2)
+            dew_used = 1
+        elif cell == "p" and last >= 0 and not prism_used:
+            # The triangular prism gives one visible echo to the opposite
+            # silhouette. It is a one-use authored intervention, not RNG.
+            values[(last + 2) % 4] += 1
+            prism_used = 1
+        elif key is not None and lessons < level["quota"]:
+            if level["fade"]:
+                values = [max(0, value - 1) for value in values]
+            index = FLOWERS.index(key)
+            values[index] += 2 if level["fade"] else 1
+            partner = echo_partner(level, key)
+            if partner is not None:
+                values[FLOWERS.index(partner)] += 1
+            lessons += 1
+            last = index
+            seen |= 1 << index
+        return (phase, nx, ny, tuple(values), lessons, last, rotation, protected,
+                chances, seen, dew_used, night_steps, prism_used, 0, terminal)
+
+    night_steps = max(0, night_steps - 1)
+    if key is None:
+        return (phase, nx, ny, attention, lessons, last, rotation, protected,
+                chances, seen, dew_used, night_steps, prism_used, 0, terminal)
+    index = FLOWERS.index(key)
+    if key == level["target"] and not protected & (1 << index):
+        return (phase, nx, ny, attention, lessons, last, rotation, protected,
+                chances, seen, dew_used, night_steps, prism_used, 0, 2)
+    chances -= 1
+    if chances <= 0:
+        return (phase, nx, ny, attention, lessons, last, rotation, protected,
+                0, seen, dew_used, night_steps, prism_used, 0, 3)
+    sx, sy = locate(level["grid"], "S")
+    return (phase, sx, sy, attention, lessons, last, rotation, protected,
+            chances, seen, dew_used, night_steps, prism_used, 0, 0)
+
+
+def action_cost(state, _after):
+    """Dusk supplies a visible flight allowance distinct from preparation leaves."""
+    if _after[13] > state[13]:
+        return 1
+    return 0 if state[0] == 1 and state[11] > 0 else 1
+
+
+def solved(_level, state):
+    return state[-1] == 2
+
+
+class MasqueradeDisplay(RenderableUserDisplay):
+    CELL, OX, OY = 7, 7, 13
+
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius ** 2 and (not hollow or distance >= max(0, radius - 1) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def line(frame, a, b, color, dotted=False):
+        x0, y0 = a
+        x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for i in range(steps + 1):
+            if dotted and i % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * i // steps
+            y = y0 + (y1 - y0) * i // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    @classmethod
+    def triangle(cls, frame, center, radius, color, hollow=False):
+        x, y = center
+        cls.line(frame, (x, y - radius), (x - radius, y + radius), color)
+        cls.line(frame, (x - radius, y + radius), (x + radius, y + radius), color)
+        cls.line(frame, (x + radius, y + radius), (x, y - radius), color)
+        if not hollow:
+            for inset in range(1, radius):
+                cls.line(frame, (x, y - radius + inset), (x - radius + inset, y + radius - inset), color)
+                cls.line(frame, (x, y - radius + inset), (x + radius - inset, y + radius - inset), color)
+
+    @classmethod
+    def center(cls, pos):
+        return cls.OX + pos[0] * cls.CELL + 3, cls.OY + pos[1] * cls.CELL + 3
+
+    def background(self, frame):
+        frame[:, :] = PAPER
+        # Offset pinpricks and short fibers make this feel like warm pressed
+        # paper rather than a flat fill, without turning texture into state.
+        for y in range(2, 63, 5):
+            frame[y, 2 + (y * 3) % 7:62:11] = CREAM
+        for x in range(4, 61, 7):
+            frame[2 + (x * 2) % 5:61:12, x] = FIBER
+        # Scalloped side curtains frame a tiny botanical stage.
+        for y in range(13, 51, 6):
+            self.disc(frame, (2, y), 4, ROSE)
+            self.disc(frame, (61, y + 2), 4, MAGENTA)
+        self.line(frame, (5, 12), (5, 52), GOLD, dotted=True)
+        self.line(frame, (58, 12), (58, 52), GOLD, dotted=True)
+        self.disc(frame, (32, 32), 29, BARK, hollow=True)
+        self.disc(frame, (32, 32), 27, SAGE, hollow=True)
+
+    def echo_silks(self, frame):
+        if self.game.state[0] != 0:
+            return
+        for first, second in self.game.level["echo"]:
+            a = self.center(locate(self.game.level["grid"], first))
+            b = self.center(locate(self.game.level["grid"], second))
+            self.line(frame, a, b, ROSE, dotted=True)
+            mx, my = (a[0] + b[0]) // 2, (a[1] + b[1]) // 2
+            self.disc(frame, (mx, my), 2, GOLD, hollow=True)
+
+    def flower(self, frame, key, center, target=False, protected=False, preview=False):
+        x, y = center
+        colors = (CORAL, VIOLET, DEW_BLUE, GOLD)
+        color = colors[FLOWERS.index(key)]
+        # Four species remain silhouette-readable in monochrome: lobed round,
+        # long diamond, upright triangle, and many-rayed star.
+        if key == "a":
+            for dx, dy in ((0, -3), (3, 0), (0, 3), (-3, 0)):
+                self.disc(frame, (x + dx, y + dy), 2, color)
+        elif key == "b":
+            self.line(frame, (x, y - 5), (x + 4, y), color)
+            self.line(frame, (x + 4, y), (x, y + 5), color)
+            self.line(frame, (x, y + 5), (x - 4, y), color)
+            self.line(frame, (x - 4, y), (x, y - 5), color)
+        elif key == "c":
+            self.triangle(frame, center, 4, color, hollow=True)
+        else:
+            for dx, dy in ((-4, 0), (4, 0), (0, -4), (0, 4), (-3, -3), (3, 3), (3, -3), (-3, 3)):
+                self.line(frame, center, (x + dx, y + dy), color)
+        self.disc(frame, center, 2, INK)
+        if target:
+            self.disc(frame, center, 6, GOLD, hollow=True)
+            self.triangle(frame, (x, y - 8), 2, GOLD, hollow=True)
+        if protected or preview:
+            self.owl(frame, (x, y - 7), muted=preview and not protected)
+
+    def owl(self, frame, center, muted=False):
+        x, y = center
+        color = FIBER if muted else INK
+        self.disc(frame, center, 3, color)
+        self.triangle(frame, (x - 2, y - 3), 2, color)
+        self.triangle(frame, (x + 2, y - 3), 2, color)
+        self.disc(frame, (x - 1, y), 1, CREAM)
+        self.disc(frame, (x + 2, y), 1, CREAM)
+        self.triangle(frame, (x, y + 3), 1, GOLD)
+
+    def moth(self, frame, center, color=MAGENTA, wing=0):
+        x, y = center
+        spread = 3 if wing % 2 == 0 else 2
+        self.disc(frame, (x - spread, y), 3, color)
+        self.disc(frame, (x + spread, y), 3, color)
+        self.triangle(frame, (x - spread, y + 2), 2, ROSE, hollow=True)
+        self.triangle(frame, (x + spread, y + 2), 2, ROSE, hollow=True)
+        self.disc(frame, center, 2, INK)
+        self.line(frame, (x, y - 2), (x - 2, y - 5), INK)
+        self.line(frame, (x, y - 2), (x + 2, y - 5), INK)
+
+    def garden(self, frame):
+        g = self.game
+        state = g.state
+        preview = guard_mask(g.level, state[3]) if state[0] == 0 else state[7]
+        self.echo_silks(frame)
+        for y, row in enumerate(g.level["grid"]):
+            for x, char in enumerate(row):
+                center = self.center((x, y))
+                if char == "#":
+                    # Clustered leaves replace block walls.
+                    self.disc(frame, (center[0] - 2, center[1]), 3, MOSS)
+                    self.disc(frame, (center[0] + 2, center[1] - 1), 3, LEAF)
+                    self.line(frame, (center[0] - 3, center[1] + 2), (center[0] + 3, center[1] - 2), BARK)
+                    continue
+                self.disc(frame, center, 4, CREAM)
+                self.disc(frame, center, 3, PAPER, hollow=True)
+                self.line(frame, (center[0] - 3, center[1] + 2), (center[0] + 3, center[1] - 2), SAGE, dotted=True)
+                key = flower_at(g.level, state, x, y)
+                if key is not None:
+                    index = FLOWERS.index(key)
+                    protected = state[0] == 1 and bool(state[7] & (1 << index))
+                    show_target = key == g.level["target"] and (state[0] == 0 or not g.level["swap"])
+                    self.flower(frame, key, center, show_target, protected,
+                                state[0] == 0 and bool(preview & (1 << index)))
+                    for mark in range(min(state[3][index], len(SCENT_STUDS))):
+                        dx, dy = SCENT_STUDS[mark]
+                        frame[center[1] + dy, center[0] + dx] = GOLD
+                    if index == state[5]:
+                        self.line(frame, (center[0] - 3, center[1] - 9), (center[0], center[1] - 6), ROSE)
+                        self.line(frame, (center[0], center[1] - 6), (center[0] + 3, center[1] - 9), ROSE)
+                elif char == "r":
+                    self.disc(frame, (center[0], center[1] + 1), 3, DEW_BLUE, hollow=not state[10])
+                    self.triangle(frame, (center[0], center[1] - 2), 3, DEW_BLUE, hollow=not state[10])
+                elif char == "p":
+                    self.triangle(frame, center, 4, VIOLET if not state[12] else FIBER, hollow=bool(state[12]))
+                    self.line(frame, (center[0] - 3, center[1] + 2), (center[0] + 3, center[1] - 2), GOLD)
+        if g.anim_kind not in ("move", "pollen", "dew", "prism"):
+            self.moth(frame, self.center((state[1], state[2])))
+
+    def hud(self, frame):
+        g = self.game
+        state = g.state
+        # Exact demonstration quota: closed buds are available, hollow buds spent.
+        for i in range(g.level["quota"]):
+            x = 5 + i * 5
+            self.disc(frame, (x, 6), 2, FIBER if i < state[4] else MAGENTA, hollow=i < state[4])
+        # Exact number of distinct species required and achieved.
+        for i in range(g.level["distinct"]):
+            y = 15 + i * 4
+            collected = i < state[9].bit_count()
+            color = LEAF if collected else FIBER
+            self.line(frame, (2, y + 2), (4, y), color)
+            self.line(frame, (4, y), (6, y + 2), color)
+            if collected:
+                self.disc(frame, (4, y + 1), 1, color)
+        # Watcher count is previewed before dusk; perched masks identify the
+        # exact protected species afterward.
+        for i in range(g.level["guards"]):
+            self.owl(frame, (48 + i * 8, 7), muted=state[0] == 0)
+        # Crescent recoveries are redundantly encoded by count and shape.
+        for i in range(state[8]):
+            x = 51 + i * 6
+            self.disc(frame, (x, 57), 3, GOLD)
+            self.disc(frame, (x + 2, 56), 3, PAPER)
+        # The bottom medallion forecasts bed turns using orbit studs.
+        self.disc(frame, (32, 58), 5, CORAL if state[0] == 0 else INK, hollow=state[0] == 0)
+        if state[0] == 0:
+            self.disc(frame, (32, 58), 2, GOLD)
+            for i, pos in enumerate(((32, 51), (39, 58), (32, 63))):
+                if i < g.level["swap"]:
+                    self.disc(frame, pos, 1, VIOLET)
+        else:
+            self.disc(frame, (34, 56), 4, PAPER)
+            # The free night-flight allowance is exact unary gold fringe.
+            for i in range(state[11]):
+                frame[62, 8 + i * 4] = GOLD
+        # Exact paid-action budget: broad leaves collapse to thin twigs.
+        for i in range(g.budget_max):
+            y = 11 + i * 2
+            remaining = i < g.budget_left
+            color = LEAF if remaining else FIBER
+            if remaining:
+                frame[y:y + 2, 60:62] = color
+                frame[y + (i % 2), 59] = color
+            else:
+                frame[y:y + 2, 61] = color
+
+    def animation(self, frame):
+        g = self.game
+        if not g.anim_kind:
+            if g.intro_mark:
+                self.disc(frame, self.center(locate(g.level["grid"], "S")), 8, MAGENTA, hollow=True)
+            if g.terminal_hold == "loss":
+                self.line(frame, (8, 10), (56, 54), RED)
+                self.line(frame, (56, 10), (8, 54), RED)
+            return
+        p = g.anim_progress
+        total = g.anim_total
+        before = self.center((g.state[1], g.state[2]))
+        after = self.center((g.pending_state[1], g.pending_state[2]))
+        mx = before[0] + (after[0] - before[0]) * p // total
+        my = before[1] + (after[1] - before[1]) * p // total
+        if g.anim_kind == "move":
+            self.line(frame, before, (mx, my), ROSE, dotted=True)
+            self.moth(frame, (mx, my), MAGENTA, p)
+        elif g.anim_kind == "pollen":
+            self.moth(frame, (mx, my), ROSE, p)
+            # Every changed scent wreath animates at its own flower. Positive
+            # remote echo expands gold; global decay folds inward in fiber.
+            changed = []
+            for index, (old, new) in enumerate(zip(g.state[3], g.pending_state[3])):
+                if old == new:
+                    continue
+                center = self.center(locate(g.level["grid"], FLOWERS[index]))
+                color = GOLD if new > old else FIBER
+                radius = 2 + p if new > old else max(2, 9 - p)
+                self.disc(frame, center, radius, color, hollow=True)
+                changed.append(center)
+            if len(changed) > 1:
+                for center in changed[1:]:
+                    self.line(frame, after, center, ROSE, dotted=True)
+            for dx, dy in ((-p, -p), (p, -p), (-p, p), (p, p)):
+                if 0 <= after[1] + dy < 64 and 0 <= after[0] + dx < 64:
+                    frame[after[1] + dy, after[0] + dx] = CORAL
+        elif g.anim_kind == "dew":
+            self.moth(frame, (mx, my), DEW_BLUE, p)
+            self.disc(frame, after, 3 + p, DEW_BLUE, hollow=True)
+            self.line(frame, (after[0], after[1] - p), (after[0], after[1] + p), CREAM)
+        elif g.anim_kind == "prism":
+            self.moth(frame, (mx, my), VIOLET, p)
+            self.triangle(frame, after, min(9, 3 + p), VIOLET, hollow=True)
+            self.line(frame, after, (after[0] - p * 2, after[1] + p), GOLD)
+            self.line(frame, after, (after[0] + p * 2, after[1] + p), ROSE)
+        elif g.anim_kind == "curtain":
+            width = min(32, p * 4)
+            frame[:, :width] = ROSE
+            frame[:, 64 - width:] = MAGENTA
+            for y in range(6, 62, 8):
+                self.disc(frame, (width, y), 2, GOLD)
+                self.disc(frame, (63 - width, y + 3), 2, GOLD)
+        elif g.anim_kind == "turn":
+            self.disc(frame, (32, 32), 7 + p * 3, VIOLET, hollow=True)
+            self.line(frame, (10 + p * 3, 32), (54 - p * 3, 32), GOLD, dotted=True)
+            self.triangle(frame, (32 + p * 2, 18 + p), 2, ROSE, hollow=True)
+        elif g.anim_kind == "recoil":
+            self.disc(frame, (32, 32), 5 + p * 3, RED, hollow=True)
+            self.moth(frame, (32 + (-1) ** p * 3, 32), FIBER, p)
+        elif g.anim_kind == "success":
+            for radius in range(4, min(31, 4 + p * 4), 5):
+                self.disc(frame, (32, 32), radius, LEAF, hollow=True)
+            for x, y in ((12, 14), (52, 14), (12, 50), (52, 50)):
+                self.disc(frame, (x, y), min(5, 1 + p // 2), GOLD, hollow=True)
+        elif g.anim_kind == "loss":
+            self.line(frame, (6 + p, 8), (58 - p, 56), RED)
+            self.line(frame, (58 - p, 8), (6 + p, 56), RED)
+            frame[8 + p:10 + p, 8:56] = FIBER
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self.background(frame)
+        self.garden(frame)
+        self.hud(frame)
+        self.animation(frame)
+        return frame
+
+
+class Q129(ARCBaseGame):
+    def __init__(self):
+        self.display = MasqueradeDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"]) for item in LEVELS]
+        super().__init__("q129", levels, Camera(0, 0, 64, 64, PAPER, PAPER, [self.display]), False, len(levels), [1, 2, 3, 4, 5])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+
+    def begin(self, kind, frames, state, budget, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.pending_state = state
+        self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state
+        self.budget_left = self.pending_budget
+        self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.terminal_hold = "win"
+            self.next_level()
+        elif terminal == "loss":
+            self.terminal_hold = "loss"
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        self.intro_mark = False
+        after = transition(self.level, self.state, action)
+        if after == self.state:
+            self.begin("recoil", 5, after, self.budget_left)
+            return
+        budget = self.budget_left - action_cost(self.state, after)
+        won = after[-1] == 2
+        lost = after[-1] == 3 or (budget <= 0 and not won)
+        if won:
+            kind, frames = "success", 7
+        elif lost:
+            kind, frames = "loss", 7
+        elif after[0] != self.state[0]:
+            kind, frames = ("turn", 8) if self.level["swap"] else ("curtain", 8)
+        elif after[8] < self.state[8]:
+            kind, frames = "recoil", 6
+        elif after[13] > self.state[13]:
+            kind, frames = "recoil", 5
+        elif after[12] > self.state[12]:
+            kind, frames = "prism", 7
+        elif after[10] > self.state[10]:
+            kind, frames = "dew", 7
+        elif after[4] > self.state[4]:
+            kind, frames = "pollen", 7
+        else:
+            kind, frames = "move", 5
+        self.begin(kind, frames, after, budget, "win" if won else "loss" if lost else None)

--- a/data/community-games/sonpham/q139_v2_q139.py
+++ b/data/community-games/sonpham/q139_v2_q139.py
@@ -1,0 +1,573 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q139-v2 Midnight Chronograph -- schedule a packet through skewed orbital clocks.
+
+The visible target is not a tuple to transcribe.  A single angular packet must
+be launched, propagated one link per tick, routed through physical transform
+gates, buffered, and dispatched when both clock hands meet their engraved
+target teeth.  Every rule-relevant quantity is also encoded by geometry,
+position, or pattern rather than color alone.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from math import cos, pi, sin
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+WHITE, PEARL, ASH, SLATE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, AQUA, GOLD, CORAL, EARTH, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+
+
+# The sequence introduces one-clock launch timing, a skewed rate clutch,
+# delayed link propagation, typed gates, a queue, a forked route, and finally
+# two full syntheses.  Budgets are one unit above the shortest
+# physical solution so one wrong dispatch is recoverable; correct dispatch is
+# a zero-cost proof action.
+LEVELS = [
+    {"name": "Amber Tooth", "mods": (4, 1), "rate_b": (0, 0), "target": (2, 0, 0, 0),
+     "path": 1, "delayed": False, "tracks": 1, "budget": 4},
+    {"name": "Skewed Twin", "mods": (7, 8), "rate_b": (1, 3), "target": (3, 0, 0, 0),
+     "path": 1, "delayed": False, "tracks": 1, "coupled": True, "budget": 13},
+    {"name": "Relay Orbit", "mods": (7, 8), "rate_b": (1, 3), "target": (3, 0, 0, 0),
+     "path": 3, "delayed": True, "tracks": 1, "coupled": True, "budget": 13},
+    {"name": "Prism Gate", "mods": (8, 9), "rate_b": (1, 3), "target": (2, 7, 2, 0),
+     "path": 4, "delayed": True, "tracks": 1, "gate": 2, "gate_delta": ((1, 2),),
+     "coupled": True, "budget": 13},
+    {"name": "Holding Moon", "mods": (9, 10), "rate_b": (1, 3), "target": (7, 5, 1, 0),
+     "path": 4, "delayed": True, "tracks": 1, "gate": 2, "gate_delta": ((1, 2),),
+     "coupled": True,
+     "buffer": True, "budget": 12},
+    {"name": "Forked Escapement", "mods": (9, 11), "rate_b": (1, 2), "target": (8, 0, 1, 1),
+     "path": 4, "delayed": True, "tracks": 2, "gate": 2,
+     "gate_delta": ((1, 2), (2, 1)), "buffer": True, "coupled": True, "budget": 13},
+    {"name": "Forked Ephemeris", "mods": (10, 11), "rate_b": (1, 3), "target": (0, 8, 1, 1),
+     "path": 5, "delayed": True, "tracks": 2, "gate": 3,
+     "gate_delta": ((1, 2), (2, 1)), "buffer": True, "coupled": True, "budget": 15},
+    {"name": "Midnight Chronograph", "mods": (11, 13), "rate_b": (1, 2), "target": (0, 9, 2, 1),
+     "path": 6, "delayed": True, "tracks": 2, "gate": 3,
+     "gate_delta": ((1, 0), (0, 2)), "buffer": True, "coupled": True, "budget": 16},
+]
+
+
+# State: phase A, phase B, route lever, actuator mode, packet link (-1=dock),
+# packet kind, locked packet track, queued, audit seals, physical budget,
+# terminal (0=play, 1=win, 2=loss).
+def start_state(level):
+    return 0, 0, 0, 0, -1, 0, -1, 0, 2, level["budget"], 0
+
+
+def _ready(level, state):
+    phase_a, phase_b, _route, _mode, packet, kind, track, queued, audits, _budget, terminal = state
+    target_a, target_b, target_kind, target_track = level["target"]
+    return (terminal == 0 and audits > 0 and queued == 0 and packet == level["path"]
+            and kind == target_kind and track == target_track
+            and phase_a == target_a and phase_b == target_b)
+
+
+def solved(level, state):
+    return _ready(level, state)
+
+
+def action_cost(before, after):
+    return max(0, before[9] - after[9])
+
+
+def _gate_kind(level, track, mode, kind):
+    deltas = level.get("gate_delta")
+    if not deltas:
+        return kind
+    return (kind + deltas[track][mode]) % 3
+
+
+def _consume(level, values):
+    values[9] -= 1
+    if values[9] < 0:
+        values[9] = 0
+        values[10] = 2
+    else:
+        candidate = tuple(values)
+        if values[9] == 0 and not _ready(level, candidate):
+            values[10] = 2
+    return tuple(values)
+
+
+def transition(level, state, action):
+    if state[10] or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    values = list(state)
+    phase_a, phase_b, route, mode, packet, kind, track, queued, audits, budget, _terminal = state
+
+    if action == 6:
+        if _ready(level, state):
+            values[10] = 1
+            return tuple(values)
+        if budget <= 0:
+            values[10] = 2
+            return tuple(values)
+        values[8] = audits - 1
+        values[9] = budget - 1
+        if values[8] <= 0 or (values[9] == 0 and not _ready(level, tuple(values))):
+            values[10] = 2
+        return tuple(values)
+
+    if budget <= 0:
+        return state
+
+    if action == 1:
+        values[0] = (phase_a + 1) % level["mods"][0]
+        values[1] = (phase_b + level["rate_b"][mode]) % level["mods"][1]
+        if 0 <= packet < level["path"]:
+            new_packet = packet + 1
+            values[4] = new_packet
+            if new_packet == level.get("gate"):
+                values[5] = _gate_kind(level, track, mode, kind)
+        return _consume(level, values)
+
+    if action == 2 and level["tracks"] > 1 and packet == -1 and not queued:
+        values[2] = 1 - route
+        return _consume(level, values)
+
+    if action == 3 and level.get("coupled") and packet < level.get("gate", level["path"] + 1):
+        values[3] = 1 - mode
+        return _consume(level, values)
+
+    if action == 4 and level.get("buffer") and queued and packet == -1:
+        values[7] = 0
+        values[4] = 0
+        values[6] = route
+        return _consume(level, values)
+
+    if action == 5 and packet == -1 and not queued:
+        if level.get("buffer"):
+            values[7] = 1
+        else:
+            values[6] = route
+            if level.get("delayed"):
+                values[4] = 0
+            else:
+                values[4] = level["path"]
+                if level.get("gate") is not None:
+                    values[5] = _gate_kind(level, route, mode, kind)
+        return _consume(level, values)
+
+    return state
+
+
+class ChronographDisplay(RenderableUserDisplay):
+    CLOCK_A = (18, 17)
+    CLOCK_B = (46, 17)
+    SOURCE = (5, 39)
+    RECEIVER = (58, 39)
+    BUFFER = (6, 49)
+
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def line(frame, a, b, color, dotted=False):
+        x0, y0 = a; x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for index in range(steps + 1):
+            if dotted and index % 3 == 1:
+                continue
+            x = round(x0 + (x1 - x0) * index / steps)
+            y = round(y0 + (y1 - y0) * index / steps)
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius ** 2 and (not hollow or distance >= max(0, radius - 2) ** 2):
+                    frame[y, x] = color
+
+    def diamond(self, frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(cy - radius, cy + radius + 1):
+            for x in range(cx - radius, cx + radius + 1):
+                distance = abs(x - cx) + abs(y - cy)
+                if (not hollow and distance <= radius) or (hollow and distance == radius):
+                    if 0 <= x < 64 and 0 <= y < 64:
+                        frame[y, x] = color
+
+    def polygon(self, frame, points, color):
+        for start, end in zip(points, points[1:] + points[:1]):
+            self.line(frame, start, end, color)
+
+    @staticmethod
+    def _point(center, radius, phase, modulus):
+        angle = -pi / 2 + 2 * pi * phase / max(1, modulus)
+        return round(center[0] + radius * cos(angle)), round(center[1] + radius * sin(angle))
+
+    def packet(self, frame, center, kind, color=AQUA, small=False):
+        radius = 2 if small else 3
+        x, y = center
+        if kind == 0:
+            self.diamond(frame, center, radius, color, hollow=True)
+            if 0 <= x < 64 and 0 <= y < 64: frame[y, x] = color
+        elif kind == 1:
+            points = [(x, y - radius), (x - radius, y + radius), (x + radius, y + radius)]
+            self.polygon(frame, points, color)
+            if 0 <= y + 1 < 64 and 0 <= x < 64: frame[y + 1, x] = color
+        else:
+            self.line(frame, (x - radius, y), (x + radius, y), color)
+            self.line(frame, (x, y - radius), (x, y + radius), color)
+            self.line(frame, (x - radius + 1, y - radius + 1), (x + radius - 1, y + radius - 1), color)
+            self.line(frame, (x + radius - 1, y - radius + 1), (x - radius + 1, y + radius - 1), color)
+
+    @staticmethod
+    def route_points(level, track):
+        length = level["path"]
+        bend = (-8 if level["tracks"] > 1 and track == 0 else
+                9 if level["tracks"] > 1 else -5)
+        points = []
+        for index in range(length + 1):
+            t = index / length
+            x = round(11 + 47 * t)
+            y = round(39 + bend * 4 * t * (1 - t))
+            points.append((x, y))
+        return points
+
+    @staticmethod
+    def interpolate(a, b, amount):
+        return round(a[0] + (b[0] - a[0]) * amount), round(a[1] + (b[1] - a[1]) * amount)
+
+    def background(self, frame):
+        frame[:, :] = INK
+        frame[1:54, 2:62] = CHARCOAL
+        frame[2:53, 3:61] = INK
+        # Smoked-glass pinholes and fixed engraved seams never flash.
+        for x, y in ((6, 5), (12, 28), (25, 25), (38, 27), (53, 5), (58, 28), (31, 51)):
+            frame[y, x] = SLATE
+        self.line(frame, (3, 29), (60, 29), SLATE, dotted=True)
+
+    def target_packet(self, frame, level):
+        target_a, target_b, target_kind, _track = level["target"]
+        self.line(frame, (25, 3), (43, 3), GOLD)
+        self.packet(frame, (27, 3), target_kind, GOLD, small=True)
+        self.disc(frame, (34, 3), 2, GOLD, hollow=True)
+        self.diamond(frame, (41, 3), 2, GOLD, hollow=True)
+        frame[3, 34] = AQUA if target_a == 0 else GOLD
+        frame[3, 41] = AQUA if target_b == 0 else GOLD
+
+    def clock(self, frame, center, modulus, phase, target, style, mode=0):
+        if modulus <= 1:
+            return
+        cx, cy = center
+        if style == 0:
+            self.disc(frame, center, 9, SLATE, hollow=False)
+            self.disc(frame, center, 8, INK, hollow=False)
+            for tooth in range(modulus):
+                inner = self._point(center, 9, tooth, modulus)
+                outer = self._point(center, 11 if tooth % 2 == 0 else 10, tooth, modulus)
+                self.line(frame, inner, outer, ASH)
+        else:
+            self.polygon(frame, [(cx, cy - 10), (cx + 10, cy), (cx, cy + 10), (cx - 10, cy)], SLATE)
+            self.polygon(frame, [(cx, cy - 8), (cx + 8, cy), (cx, cy + 8), (cx - 8, cy)], ASH)
+            for tooth in range(modulus):
+                inner = self._point(center, 9, tooth, modulus)
+                outer = self._point(center, 11, tooth, modulus)
+                self.line(frame, inner, outer, SLATE)
+        # Engraved target tooth is a large external diamond; the live hand is
+        # a cyan spoke with a differently shaped central axle.
+        target_point = self._point(center, 11, target, modulus)
+        self.diamond(frame, target_point, 1, GOLD)
+        hand = self._point(center, 7, phase, modulus)
+        self.line(frame, center, hand, AQUA)
+        if style == 0:
+            self.disc(frame, center, 2, PEARL, hollow=True)
+        else:
+            self.diamond(frame, center, 2, PEARL, hollow=True)
+            # Coupled speed remains non-color redundant: a vertical jaw is
+            # slow, a horizontal jaw is fast.
+            if self.game.level.get("coupled"):
+                if mode == 0: self.line(frame, (cx, cy - 3), (cx, cy + 3), GOLD)
+                else: self.line(frame, (cx - 3, cy), (cx + 3, cy), GOLD)
+
+    def clocks(self, frame, state, phase_override=None):
+        phase_a, phase_b = state[:2] if phase_override is None else phase_override
+        self.clock(frame, self.CLOCK_A, self.game.level["mods"][0], phase_a,
+                   self.game.level["target"][0], 0, state[3])
+        self.clock(frame, self.CLOCK_B, self.game.level["mods"][1], phase_b,
+                   self.game.level["target"][1], 1, state[3])
+
+    def routes(self, frame, state, draw_marker=True):
+        level = self.game.level
+        active = state[6] if state[6] >= 0 else state[2]
+        for track in range(level["tracks"]):
+            points = self.route_points(level, track)
+            color = ASH if track == active else SLATE
+            for start, end in zip(points, points[1:]):
+                self.line(frame, start, end, color, dotted=track != active)
+            for point in points[1:-1]:
+                self.diamond(frame, point, 1, color, hollow=True)
+        self.disc(frame, self.SOURCE, 4, SLATE, hollow=True)
+        self.diamond(frame, self.RECEIVER, 4, ASH, hollow=True)
+        # On forks, a large open socket on the penultimate link engraves the
+        # required endpoint approach.  Track choice is therefore spatial, not
+        # a color legend, and remains visible while the packet is in flight.
+        if level["tracks"] > 1:
+            target_track = level["target"][3]
+            target_point = self.route_points(level, target_track)[-2]
+            self.diamond(frame, target_point, 3, GOLD, hollow=True)
+        if draw_marker and level["tracks"] > 1:
+            y = 34 if state[2] == 0 else 45
+            self.line(frame, (8, 39), (10, y), GOLD)
+            self.diamond(frame, (10, y), 1, GOLD)
+
+    def gate(self, frame, state, amount=None):
+        level = self.game.level
+        if level.get("gate") is None:
+            return
+        track = state[6] if state[6] >= 0 else state[2]
+        point = self.route_points(level, track)[level["gate"]]
+        x, y = point
+        mode = state[3]
+        if amount is None:
+            if mode == 0:
+                self.polygon(frame, [(x, y - 4), (x - 3, y), (x, y + 4)], GOLD)
+            else:
+                self.polygon(frame, [(x - 4, y - 2), (x + 4, y - 2), (x + 4, y + 2), (x - 4, y + 2)], GOLD)
+        else:
+            reach = round(2 + 2 * amount)
+            self.line(frame, (x - reach, y - (3 - reach // 2)), (x + reach, y + (3 - reach // 2)), GOLD)
+            self.line(frame, (x + reach, y - (3 - reach // 2)), (x - reach, y + (3 - reach // 2)), GOLD)
+        self.packet(frame, (x, y), self.game.level["target"][2], SLATE, small=True)
+
+    def buffer(self, frame, state, draw_packet=True):
+        if not self.game.level.get("buffer"):
+            return
+        x, y = self.BUFFER
+        self.polygon(frame, [(x - 4, y - 3), (x + 3, y - 3), (x + 4, y + 3), (x - 3, y + 3)], ASH)
+        self.line(frame, (x - 2, y - 4), (x + 2, y - 4), GOLD)
+        if state[7] and draw_packet:
+            self.packet(frame, self.BUFFER, state[5], AQUA, small=True)
+
+    def packet_position(self, state):
+        if state[7]:
+            return self.BUFFER
+        if state[4] == -1:
+            return self.SOURCE
+        track = max(0, state[6])
+        return self.route_points(self.game.level, track)[state[4]]
+
+    def budget_rivet(self, frame, number, live, radius=1):
+        group, within = divmod(number, 4)
+        cx = 14 + group * 12; cy = 58
+        offsets = ((-3, -2), (3, -2), (-3, 2), (3, 2))
+        x, y = cx + offsets[within][0], cy + offsets[within][1]
+        if live:
+            self.diamond(frame, (x, y), radius, AQUA)
+        elif 0 <= x < 64 and 0 <= y < 64:
+            frame[y, x] = SLATE
+
+    def hud(self, frame, state, budget_override=None, audits_override=None):
+        budget = state[9] if budget_override is None else budget_override
+        audits = state[8] if audits_override is None else audits_override
+        for group in range(4):
+            cx = 14 + group * 12
+            self.disc(frame, (cx, 58), 5, SLATE, hollow=True)
+        for number in range(self.game.level["budget"]):
+            self.budget_rivet(frame, number, number < budget)
+        # The two dispatch seals differ by both shape and fixed side.
+        if audits >= 1:
+            self.disc(frame, (5, 58), 3, PEARL, hollow=True)
+        else:
+            self.line(frame, (3, 56), (7, 60), RED); self.line(frame, (7, 56), (3, 60), RED)
+        if audits >= 2:
+            self.diamond(frame, (59, 58), 3, PEARL, hollow=True)
+        else:
+            self.line(frame, (57, 56), (61, 60), RED); self.line(frame, (61, 56), (57, 60), RED)
+
+    def shutter(self, frame, amount, color):
+        cx, cy = self.RECEIVER
+        reach = round(5 * amount)
+        self.line(frame, (cx + 5, cy - 6), (cx + 5 - reach, cy - 1), color)
+        self.line(frame, (cx + 5, cy + 6), (cx + 5 - reach, cy + 1), color)
+        self.line(frame, (cx - 5, cy - 6), (cx - 5 + reach, cy - 1), color)
+        self.line(frame, (cx - 5, cy + 6), (cx - 5 + reach, cy + 1), color)
+
+    def terminal(self, frame, state):
+        if state[10] == 1:
+            # The receiver lives near the east edge; nested proof diamonds
+            # stay fully inset rather than relying on camera clipping.
+            for radius in (1, 3, 5):
+                self.diamond(frame, self.RECEIVER, radius, GOLD, hollow=True)
+            self.shutter(frame, 1.0, GOLD)
+            self.line(frame, (43, 3), self.RECEIVER, GOLD, dotted=True)
+        elif state[10] == 2:
+            self.shutter(frame, 1.0, RED)
+            self.line(frame, (48, 31), (63, 47), RED)
+            self.line(frame, (63, 31), (48, 47), ASH)
+            for center in (self.CLOCK_A, self.CLOCK_B):
+                self.line(frame, (center[0] - 3, center[1] - 3), (center[0] + 3, center[1] + 3), RED)
+
+    def scene(self, frame, state, *, draw_packet=True, draw_clocks=True,
+              draw_marker=True, draw_gate=True, draw_hud=True,
+              draw_buffer_packet=True):
+        self.background(frame); self.target_packet(frame, self.game.level)
+        if draw_clocks: self.clocks(frame, state)
+        self.routes(frame, state, draw_marker=draw_marker)
+        if draw_gate: self.gate(frame, state)
+        self.buffer(frame, state, draw_packet=draw_buffer_packet)
+        if draw_packet and state[10] == 0:
+            self.packet(frame, self.packet_position(state), state[5])
+        if draw_hud: self.hud(frame, state)
+        self.terminal(frame, state)
+
+    def hud_transition(self, frame, before, after, p, span):
+        # Stable rivets plus one monotonically contracting spent unit avoid a
+        # whole-HUD settlement pop.
+        self.hud(frame, after)
+        if before[9] > after[9] and p < span:
+            spent = after[9]
+            if p * 3 < span * 2:
+                self.budget_rivet(frame, spent, True, 1 if p * 2 < span else 0)
+        if before[8] > after[8] and p < span:
+            seal_center = (59, 58) if before[8] == 2 else (5, 58)
+            reach = max(1, round(3 * p / span))
+            self.line(frame, (seal_center[0] - reach, seal_center[1] - reach),
+                      (seal_center[0] + reach, seal_center[1] + reach), RED)
+
+    def animated_packet(self, frame, before, after, p, span):
+        start = self.packet_position(before)
+        end = self.packet_position(after)
+        amount = p / span
+        position = self.interpolate(start, end, amount)
+        kind = before[5] if p * 2 < span else after[5]
+        self.packet(frame, position, kind)
+        # A delayed echo trails spatially behind the moving packet.
+        if 0 < p < span:
+            trail = self.interpolate(start, end, max(0.0, amount - 0.18))
+            self.diamond(frame, trail, 1, SLATE)
+
+    def animation(self, frame, p, span):
+        g = self.game; before, after = g.anim_before, g.pending_state
+        kind = g.anim_kind
+        if kind == "tick":
+            moved = before[4] != after[4]
+            self.scene(frame, before, draw_packet=not moved, draw_clocks=False, draw_hud=False)
+            rate_b = g.level["rate_b"][before[3]]
+            phases = (before[0] + p / span, before[1] + rate_b * p / span)
+            self.clocks(frame, before, phase_override=phases)
+            if moved: self.animated_packet(frame, before, after, p, span)
+            self.hud_transition(frame, before, after, p, span)
+        elif kind == "route":
+            self.scene(frame, before, draw_marker=False, draw_hud=False)
+            start_y = 34 if before[2] == 0 else 45; end_y = 34 if after[2] == 0 else 45
+            y = round(start_y + (end_y - start_y) * p / span)
+            self.line(frame, (8, 39), (10, y), GOLD); self.diamond(frame, (10, y), 1, GOLD)
+            self.hud_transition(frame, before, after, p, span)
+        elif kind == "mode":
+            self.scene(frame, before, draw_gate=False, draw_hud=False)
+            self.gate(frame, before, amount=p / span)
+            self.hud_transition(frame, before, after, p, span)
+        elif kind in ("load", "release"):
+            # Release owns the single moving packet; do not retain its stale
+            # buffered body beneath the travel animation.
+            self.scene(frame, before, draw_packet=False, draw_hud=False,
+                       draw_buffer_packet=False)
+            self.animated_packet(frame, before, after, p, span)
+            self.hud_transition(frame, before, after, p, span)
+        elif kind in ("success", "reject", "loss"):
+            self.scene(frame, before, draw_packet=kind == "reject", draw_hud=False)
+            if kind == "success": amount = p / span; color = GOLD
+            elif kind == "loss": amount = p / span; color = RED
+            else: amount = 1 - abs(2 * p - span) / span; color = CORAL
+            self.shutter(frame, amount, color)
+            if kind == "success" and p < span:
+                self.packet(frame, self.RECEIVER, before[5], AQUA)
+            if kind == "loss":
+                reach = round(15 * p / span)
+                self.line(frame, (58 - reach, 32), (58 + min(5, reach), 46), RED)
+            self.hud_transition(frame, before, after, p, span)
+        else:
+            self.scene(frame, before)
+            reach = round(3 * (1 - abs(2 * p - span) / span))
+            self.line(frame, (29 - reach, 51), (35 + reach, 51), CORAL)
+
+        if after[10] == 2 and kind not in ("loss",):
+            reach = round(10 * p / span)
+            self.line(frame, (58 - reach, 32), (58 + min(5, reach), 46), RED)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        g = self.game
+        if not g.anim_kind:
+            self.scene(frame, g.state)
+            if g.intro_mark:
+                # Contract and lower the decorative calibration halo so its
+                # complete silhouette is visible inside the native frame.
+                self.disc(frame, (34, 6), 4, ASH, hollow=True)
+                self.diamond(frame, (34, 6), 6, SLATE, hollow=True)
+            return frame
+        span = max(1, g.anim_total - 1)
+        if g.anim_progress >= span:
+            self.scene(frame, g.pending_state)
+        else:
+            self.animation(frame, g.anim_progress, span)
+        return frame
+
+
+class Q139(ARCBaseGame):
+    def __init__(self):
+        self.display = ChronographDisplay(self); self.level = LEVELS[0]
+        self.state = start_state(self.level); self.budget_left = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = None; self.pending_terminal = None
+        self.intro_mark = True
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q139", levels, Camera(0, 0, 64, 64, INK, INK, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]; self.state = start_state(self.level)
+        self.budget_left = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = None; self.pending_terminal = None
+        self.intro_mark = True
+
+    def begin(self, kind, frames, after, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames; self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = after; self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal; self.state = self.pending_state
+        self.budget_left = self.state[9]; self.anim_kind = None
+        self.pending_state = None; self.pending_terminal = None
+        if terminal == "win": self.next_level()
+        elif terminal == "loss": self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1; self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0: self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action(); return
+        self.intro_mark = False
+        after = transition(self.level, self.state, action)
+        if after == self.state:
+            self.begin("blocked", 5, after); return
+        terminal = "win" if after[10] == 1 else "loss" if after[10] == 2 else None
+        if action == 1: kind, frames = "tick", 7
+        elif action == 2: kind, frames = "route", 5
+        elif action == 3: kind, frames = "mode", 5
+        elif action == 4: kind, frames = "release", 7
+        elif action == 5: kind, frames = "load", 7
+        elif terminal == "win": kind, frames = "success", 7
+        elif terminal == "loss": kind, frames = "loss", 7
+        else: kind, frames = "reject", 7
+        self.begin(kind, frames, after, terminal)

--- a/data/community-games/sonpham/q140_v2_q140.py
+++ b/data/community-games/sonpham/q140_v2_q140.py
@@ -1,0 +1,406 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q140-v2 Grounded Labels -- invent a visible stamp dictionary, then route parcels.
+
+The player chooses an arbitrary one-to-one marker for every active destination bay.
+The same shape-coded markers are then reused as instructions for stop-motion workers.
+Later parcels require compound stamps, pass through visible permutation presses, or
+carry a stamp across a relay. Success grades visible relational consistency, never a
+hidden authored mapping.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, FIBER, ASH, GRAPHITE, INK = 0, 1, 2, 3, 5
+INDIGO, SKY, OCHRE, TANGERINE, CORAL, GREEN, PLUM = 9, 10, 11, 12, 6, 14, 15
+
+
+def parcel(targets, twist=0, carry=False):
+    return {"targets": tuple(targets), "twist": twist, "carry": carry}
+
+
+LEVELS = [
+    {"name": "First Impression", "active": (0,),
+     "items": (parcel((0,)), parcel((0,))), "budget": 7},
+    {"name": "Two Destinations", "active": (0, 1),
+     "items": (parcel((0,)), parcel((1,)), parcel((0,)), parcel((1,))), "budget": 12},
+    {"name": "Compound Parcel", "active": (0, 1),
+     "items": (parcel((0, 1)), parcel((1,)), parcel((1, 0))), "budget": 12},
+    {"name": "Turning Press", "active": (0, 1),
+     "items": (parcel((0,), 1), parcel((1,), 1), parcel((0, 1), 1)), "budget": 11},
+    {"name": "Ribbon Relay", "active": (0, 1),
+     "items": (parcel((0, 1), carry=True), parcel((1,)),
+               parcel((1, 0), carry=True), parcel((0,))), "budget": 12},
+    {"name": "Three-Bay Bundle", "active": (0, 1, 2),
+     "items": (parcel((0, 1, 2)), parcel((2, 0)), parcel((1, 2, 0))), "budget": 16},
+    {"name": "Crossed Dispatch", "active": (0, 1, 2),
+     "items": (parcel((0, 1), 1, True), parcel((1, 2), 1),
+               parcel((2, 0, 1), 2, True), parcel((1,))), "budget": 17},
+    {"name": "Grounded Labels", "active": (0, 1, 2),
+     "items": (parcel((2, 0, 1), 1, True), parcel((1, 2), 1, True),
+               parcel((2, 0)), parcel((0, 1, 2), 2, True), parcel((2,))), "budget": 22},
+]
+
+
+def start_state(_level):
+    return (0, 0, 0), 0, 0, 0, ()
+
+
+def transition(level, state, action):
+    """Pure visible-state transition used by runtime and qualification."""
+    labels, ground_index, phase, item_index, stamps = state
+    labels = list(labels)
+    active = level["active"]
+    items = level["items"]
+
+    if phase == 0:
+        if action in (1, 2, 3) and ground_index < len(active):
+            if action in labels:
+                return state
+            labels[active[ground_index]] = action
+            return tuple(labels), ground_index + 1, phase, item_index, stamps
+        if action == 5 and ground_index == len(active):
+            return tuple(labels), ground_index, 1, item_index, ()
+        return state
+
+    if item_index >= len(items):
+        return state
+    item = items[item_index]
+    targets = item["targets"]
+    if action in (1, 2, 3):
+        if len(stamps) >= len(targets):
+            return state
+        return tuple(labels), ground_index, phase, item_index, stamps + (action,)
+    if action == 5:
+        if not stamps:
+            return state
+        return tuple(labels), ground_index, phase, item_index, ()
+    if action != 4:
+        return state
+    if len(stamps) != len(targets):
+        return (tuple(labels), ground_index, phase, item_index, ()) if stamps else state
+    actual = tuple((stamp - 1 + item["twist"]) % 3 + 1 for stamp in stamps)
+    expected = tuple(labels[target] for target in targets)
+    if actual != expected:
+        return tuple(labels), ground_index, phase, item_index, ()
+    next_index = item_index + 1
+    carried = ()
+    if item["carry"] and next_index < len(items) and items[next_index]["targets"]:
+        carried = (stamps[-1],)
+    return tuple(labels), ground_index, phase, next_index, carried
+
+
+def solved(level, state):
+    return state[2] == 1 and state[3] == len(level["items"])
+
+
+class DispatchDisplay(RenderableUserDisplay):
+    BAYS = ((12, 13), (32, 13), (52, 13))
+
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def _disc(frame, center, radius, color):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                if (x - cx) ** 2 + (y - cy) ** 2 <= radius ** 2:
+                    frame[y, x] = color
+
+    @staticmethod
+    def _class_glyph(frame, kind, center, color, scale=1):
+        cx, cy = center
+        r = 3 * scale
+        if kind == 0:
+            DispatchDisplay._disc(frame, center, r, color)
+            DispatchDisplay._disc(frame, center, max(0, r - scale), PAPER)
+            frame[cy, cx] = color
+        elif kind == 1:
+            for dy in range(-r, r + 1):
+                half = max(0, (dy + r) // 2)
+                frame[cy + dy, max(0, cx - half):min(64, cx + half + 1)] = color
+            frame[cy + scale:cy + r, cx - scale:cx + scale + 1] = PAPER
+        else:
+            frame[cy - r:cy + r + 1, cx - r:cx + r + 1] = color
+            frame[cy - r + scale:cy + r - scale + 1,
+                  cx - r + scale:cx + r - scale + 1] = PAPER
+            frame[cy - r:cy - r + 2 * scale, cx - scale:cx + scale + 1] = PAPER
+
+    @staticmethod
+    def _label_glyph(frame, label, center, color, scale=1):
+        cx, cy = center
+        if label == 1:
+            DispatchDisplay._disc(frame, center, 3 * scale, color)
+            frame[cy - 2 * scale:cy + 2 * scale + 1:2 * scale,
+                  cx - 2 * scale:cx + 2 * scale + 1:2 * scale] = PAPER
+        elif label == 2:
+            for offset in range(-3 * scale, 3 * scale + 1):
+                x = cx + offset
+                y1 = cy + offset
+                y2 = cy - offset
+                if 0 <= x < 64 and 0 <= y1 < 64:
+                    frame[y1, x] = color
+                if 0 <= x < 64 and 0 <= y2 < 64:
+                    frame[y2, x] = color
+        elif label == 3:
+            frame[cy - 3 * scale:cy + 3 * scale + 1, cx - scale:cx + scale + 1] = color
+            frame[cy - scale:cy + scale + 1, cx - 3 * scale:cx + 3 * scale + 1] = color
+            frame[cy - 3 * scale:cy + 3 * scale + 1:2 * scale, cx - 3 * scale:cx + 3 * scale + 1] = color
+
+    def _paper(self, frame):
+        frame[:, :] = PAPER
+        for y in range(2, 63, 5):
+            frame[y, 1:63:4] = FIBER
+        for x in range(4, 62, 9):
+            frame[1:63:7, x] = ASH
+        frame[2:62, 2] = GRAPHITE
+        frame[2:62, 61] = GRAPHITE
+
+    def _press(self, frame, twist, phase=0):
+        """Draw opposite, animated chiralities for +1 and +2 permutations."""
+        if not twist:
+            return
+        cx, cy = 50, 31
+        turn = phase % 2
+        if (twist == 1) ^ bool(turn):
+            frame[cy - 4:cy - 1, cx - 3:cx + 2] = CORAL
+            frame[cy - 1:cy + 4, cx:cx + 3] = CORAL
+            frame[cy + 2:cy + 5, cx - 3:cx + 1] = CORAL
+            frame[cy - 1:cy + 3, cx - 5:cx - 2] = CORAL
+        else:
+            frame[cy - 4:cy - 1, cx - 1:cx + 4] = CORAL
+            frame[cy - 1:cy + 4, cx - 3:cx] = CORAL
+            frame[cy + 2:cy + 5, cx:cx + 4] = CORAL
+            frame[cy - 1:cy + 3, cx + 2:cx + 5] = CORAL
+        frame[cy, cx] = INK
+        # One or two punched dots redundantly expose permutation magnitude.
+        for dot in range(twist):
+            frame[cy + 6, cx - 1 + dot * 3] = INK
+
+    def _dictionary(self, frame):
+        g = self.game
+        for index, cls in enumerate(g.level["active"]):
+            cx, cy = self.BAYS[cls]
+            # Cloth awning and punched class plate.
+            frame[4:7, cx - 7:cx + 8] = OCHRE if index % 2 == 0 else TANGERINE
+            frame[7:22, cx - 8:cx + 9] = PAPER
+            frame[7:22, cx - 8:cx - 6] = INK
+            frame[7:22, cx + 6:cx + 8] = INK
+            frame[20:22, cx - 8:cx + 8] = INK
+            self._class_glyph(frame, cls, (cx, 12), INK)
+            if g.labels[cls]:
+                self._label_glyph(frame, g.labels[cls], (cx, 18), INDIGO)
+            elif g.phase == 0 and index == g.ground_index:
+                frame[16:21, cx - 4:cx + 5:2] = CORAL
+
+    def _queue(self, frame):
+        g = self.game
+        if g.phase == 0:
+            # Raised blank card tells the player the dictionary is being authored.
+            frame[27:44, 22:43] = FIBER
+            frame[26:43, 21:42] = PAPER
+            frame[26:43, 21:23] = INDIGO
+            next_cls = g.level["active"][min(g.ground_index, len(g.level["active"]) - 1)]
+            self._class_glyph(frame, next_cls, (31, 34), INK, 2)
+            return
+        if g.item_index >= len(g.level["items"]):
+            frame[27:43, 23:41] = GREEN
+            frame[30:40, 26:38] = PAPER
+            return
+        item = g.level["items"][g.item_index]
+        targets = item["targets"]
+        frame[26:44, 18:46] = FIBER
+        frame[25:43, 17:45] = PAPER
+        frame[25:43, 17:19] = INDIGO
+        spacing = 10
+        start = 31 - (len(targets) - 1) * spacing // 2
+        for slot, target in enumerate(targets):
+            self._class_glyph(frame, target, (start + slot * spacing, 32), INK)
+            if slot < len(g.stamps):
+                self._label_glyph(frame, g.stamps[slot], (start + slot * spacing, 39), INDIGO)
+            else:
+                frame[38:41, start - 3 + slot * spacing:start + 4 + slot * spacing:2] = ASH
+        if item["twist"]:
+            self._press(frame, item["twist"])
+        if item["carry"]:
+            frame[42:45, 39:57:3] = OCHRE
+
+        # Remaining queue is a punched-card strip, fully visible by class silhouette.
+        for offset, queued in enumerate(g.level["items"][g.item_index + 1:g.item_index + 4]):
+            x = 7 + offset * 18
+            frame[48:57, x:x + 15] = FIBER
+            frame[47:56, x - 1:x + 14] = PAPER
+            for j, cls in enumerate(queued["targets"][:3]):
+                self._class_glyph(frame, cls, (x + 3 + j * 4, 51), GRAPHITE)
+
+    def _animation(self, frame):
+        g = self.game
+        if g.intro_mark:
+            frame[1:4, 8:57:4] = OCHRE
+            frame[59:62, 8:57:4] = INDIGO
+        if g.terminal_hold == "win":
+            frame[22:46, 7:58] = OCHRE
+            frame[25:43, 10:55] = PAPER
+            for x in range(14, 54, 10):
+                self._disc(frame, (x, 34), 4, GREEN)
+                frame[32:37, x] = INK
+        elif g.terminal_hold == "loss":
+            frame[23:46:3, 8:57] = CORAL
+            frame[23:46, 8:57:4] = GRAPHITE
+        if not g.anim_kind:
+            return
+        p = g.anim_progress
+        if g.anim_kind == "stamp":
+            y = 22 + min(p, 3) * 4
+            frame[y:y + 3, 24:40] = INDIGO
+            frame[y + 3:y + 5, 28:36] = GRAPHITE
+        elif g.anim_kind == "dispatch":
+            x = 10 + p * 8
+            self._disc(frame, (min(55, x), 45 - p % 2), 3, TANGERINE)
+            frame[44 - p % 2:47 - p % 2, min(58, x + 2):min(61, x + 5)] = INDIGO
+            item = g.level["items"][g.item_index]
+            if item["twist"]:
+                self._press(frame, item["twist"], p)
+                if g.stamps:
+                    raw = g.stamps[0]
+                    transformed = (raw - 1 + item["twist"]) % 3 + 1
+                    self._label_glyph(frame, raw, (42, 39), INDIGO)
+                    self._label_glyph(frame, transformed, (57, 39), CORAL)
+        elif g.anim_kind == "clear":
+            # A cool paper sweep reads as deliberate recovery, never an error.
+            edge = min(44, 18 + p * 7)
+            frame[36:42, 18:edge] = SKY
+            frame[38:40, 18:edge:3] = PAPER
+        elif g.anim_kind == "blocked":
+            offset = -2 if p % 2 else 2
+            frame[24:44, 29 + offset:33 + offset] = CORAL
+        elif g.anim_kind == "seal":
+            frame[23 + p:27 + p, 16:46] = OCHRE
+        elif g.anim_kind == "success":
+            frame[21 + p:44 - p, 9 + p:56 - p:3] = GREEN
+        elif g.anim_kind == "fail":
+            frame[26:42, 12 + p:53 - p:3] = CORAL
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self._paper(frame)
+        self._dictionary(frame)
+        self._queue(frame)
+        g = self.game
+        # Stamp rack: three permanent, non-color-coded tool silhouettes.
+        for label, x in enumerate((9, 32, 55), 1):
+            frame[58:63, x - 5:x + 6] = GRAPHITE
+            self._label_glyph(frame, label, (x, 59), SKY if label == 1 else INDIGO)
+        # Exact bound-page holes: each available action owns one persistent pip.
+        # Long levels continue down the opposite spine instead of compressing state.
+        per_spine = (g.budget_max + 1) // 2
+        spacing = 50 // max(1, per_spine - 1)
+        for index in range(g.budget_max):
+            column = index // per_spine
+            row = index % per_spine
+            self._disc(frame, (4 if column == 0 else 59, 6 + row * spacing), 1,
+                       OCHRE if index < g.budget_left else ASH)
+        self._animation(frame)
+        return frame
+
+
+class Q140(ARCBaseGame):
+    def __init__(self):
+        self.display = DispatchDisplay(self)
+        self.level = LEVELS[0]
+        self.labels = (0, 0, 0)
+        self.ground_index = self.phase = self.item_index = 0
+        self.stamps = ()
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q140", levels, Camera(0, 0, 64, 64, PAPER, PAPER, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.labels, self.ground_index, self.phase, self.item_index, self.stamps = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+
+    def _begin(self, kind, frames, *, next_state=None, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.pending_state = next_state
+        self.pending_terminal = terminal
+
+    def _finish(self):
+        terminal = self.pending_terminal
+        if self.pending_state is not None:
+            (self.labels, self.ground_index, self.phase,
+             self.item_index, self.stamps) = self.pending_state
+        self.anim_kind = None
+        self.pending_state = None
+        self.pending_terminal = None
+        if terminal == "win":
+            self.terminal_hold = "win"
+            self.next_level()
+        elif terminal == "loss" or self.budget_left <= 0:
+            self.terminal_hold = "loss"
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self._finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        self.intro_mark = False
+        state = (self.labels, self.ground_index, self.phase, self.item_index, self.stamps)
+        if action == 6:
+            won = solved(self.level, state)
+            if not won:
+                self.budget_left -= 1
+            self._begin("success" if won else "fail", 4, terminal="win" if won else None)
+            return
+        after = transition(self.level, state, action)
+        if after == state:
+            self._begin("blocked", 3)
+            return
+        if state[2] == 0 and action in (1, 2, 3):
+            kind, frames = "stamp", 4
+        elif state[2] == 0 and action == 5:
+            kind, frames = "seal", 4
+        elif action == 4 and after[3] > state[3]:
+            kind, frames = "dispatch", 5
+        elif action in (1, 2, 3):
+            kind, frames = "stamp", 4
+        elif action == 5 and state[2] == 1 and state[4]:
+            kind, frames = "clear", 4
+        else:
+            kind, frames = "blocked", 3
+        if kind != "clear":
+            self.budget_left -= 1
+        self._begin(kind, frames, next_state=after)

--- a/data/community-games/sonpham/q142_v2_q142.py
+++ b/data/community-games/sonpham/q142_v2_q142.py
@@ -1,0 +1,581 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q142-v2 Veiled Orrery -- scarce counterfactual observation in a spectral observatory.
+
+Only short unlabelled arc mouths are initially visible.  Observing an arc spends
+one glass droplet and reveals its otherwise unavailable destination together
+with hazard, sigil, gate, or delayed-echo consequences.  A body may commit only
+to an observed counterfactual.  Later instruments make outcomes phase-specific
+or split one observation across two costly panes.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+WHITE, PEARL, ASH, SLATE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, AQUA, GOLD, CORAL, EARTH, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+NONE, SIGIL, ECHO = 0, 1, 2
+
+
+def observatory(name, n, start, goal, budget, charges, paths0, *, paths1=(),
+                mode_rule="none", require_key=False, goal_mode=-1,
+                hazard_decoys=False):
+    def table(rows):
+        # node, mouth, destination, effect, requires-key
+        return {(a, b): (c, d, bool(e)) for a, b, c, d, e in rows}
+    return {
+        "name": name,
+        "n": n,
+        "start": start,
+        "goal": goal,
+        "budget": budget,
+        "charges": charges,
+        "paths": (table(paths0), table(paths1) if paths1 else table(paths0)),
+        "mode_rule": mode_rule,
+        "require_key": require_key,
+        "goal_mode": goal_mode,
+        "hazard_decoys": hazard_decoys,
+    }
+
+
+LEVELS = [
+    observatory("First Glass", 4, 0, 3, 7, 4,
+                ((0, 1, 1, NONE, 0), (1, 2, 3, NONE, 0))),
+    observatory("Fracture Paths", 5, 0, 4, 9, 5,
+                ((0, 2, 2, NONE, 0), (2, 1, 3, NONE, 0),
+                 (3, 0, 4, NONE, 0)), hazard_decoys=True),
+    observatory("Turning Prism", 5, 0, 4, 11, 5,
+                ((0, 0, 1, NONE, 0), (3, 2, 4, NONE, 0)),
+                paths1=((1, 1, 3, NONE, 0),), mode_rule="phase", goal_mode=0,
+                hazard_decoys=True),
+    observatory("Patient Echo", 6, 0, 5, 9, 5,
+                ((0, 1, 2, ECHO, 0), (2, 0, 3, NONE, 0),
+                 (4, 2, 5, NONE, 0)), hazard_decoys=True),
+    observatory("Sealed Meridian", 6, 0, 5, 9, 5,
+                ((0, 2, 2, SIGIL, 0), (2, 1, 4, NONE, 0),
+                 (4, 0, 5, NONE, 1)), require_key=True, hazard_decoys=True),
+    observatory("Two Half Lenses", 5, 0, 4, 12, 6,
+                ((0, 1, 2, NONE, 0), (2, 2, 4, NONE, 0)), mode_rule="split",
+                hazard_decoys=True),
+    observatory("Vesper Engine", 7, 0, 6, 14, 6,
+                ((0, 1, 1, SIGIL, 0), (5, 1, 6, NONE, 1)),
+                paths1=((1, 2, 3, ECHO, 0), (3, 0, 4, NONE, 0)),
+                mode_rule="phase", require_key=True, goal_mode=0, hazard_decoys=True),
+    observatory("Veiled Orrery", 7, 0, 6, 22, 10,
+                ((0, 2, 2, SIGIL, 0), (2, 1, 3, ECHO, 0),
+                 (3, 0, 4, NONE, 0), (5, 2, 6, NONE, 1)),
+                mode_rule="split", require_key=True, hazard_decoys=True),
+]
+
+
+def start_state(level):
+    # node, selected mouth, lens mode, knowledge pane A/B, sigil, queued echo,
+    # remaining observations, two mistake wards, terminal (0 play/2 win/3 loss)
+    return level["start"], 0, 0, 0, 0, 0, 0, level["charges"], 2, 0
+
+
+def _edge_bit(level, node, mouth, mode):
+    if level["mode_rule"] == "phase":
+        return 1 << (mode * level["n"] * 3 + node * 3 + mouth)
+    return 1 << (node * 3 + mouth)
+
+
+def _base_outcome(level, node, mouth, mode):
+    table = level["paths"][mode if level["mode_rule"] == "phase" else 0]
+    if (node, mouth) not in table:
+        return node, NONE, False, level["hazard_decoys"]
+    destination, effect, needs_key = table[(node, mouth)]
+    return destination, effect, needs_key, False
+
+
+def resolved_outcome(level, state):
+    node, mouth, mode, _known_a, _known_b, key, pending, _charges, _wards, _terminal = state
+    base, effect, needs_key, authored_hazard = _base_outcome(level, node, mouth, mode)
+    destination = (base + pending) % level["n"] if pending else base
+    unsafe = authored_hazard or (needs_key and not key)
+    return destination, effect, needs_key, unsafe, base
+
+
+def _observed(level, state):
+    node, mouth, mode, known_a, known_b, *_rest = state
+    bit = _edge_bit(level, node, mouth, mode)
+    if level["mode_rule"] == "split":
+        return bool(known_a & bit) and bool(known_b & bit)
+    return bool(known_a & bit)
+
+
+def configuration_solved(level, state):
+    node, _mouth, mode, _a, _b, key, pending, _charges, _wards, terminal = state
+    correct_mode = level["goal_mode"] < 0 or mode == level["goal_mode"]
+    return (not terminal and node == level["goal"] and pending == 0 and correct_mode
+            and (not level["require_key"] or key == 1))
+
+
+def _mistake(state):
+    values = list(state)
+    if values[8] > 0:
+        values[8] -= 1
+    else:
+        values[9] = 3
+    return tuple(values)
+
+
+def transition(level, state, action):
+    node, mouth, mode, known_a, known_b, key, pending, charges, wards, terminal = state
+    if terminal or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    if action == 1:
+        return node, (mouth - 1) % 3, mode, known_a, known_b, key, pending, charges, wards, 0
+    if action == 2:
+        return node, (mouth + 1) % 3, mode, known_a, known_b, key, pending, charges, wards, 0
+    if action == 3:
+        if level["mode_rule"] == "none":
+            return state
+        return node, mouth, 1 - mode, known_a, known_b, key, pending, charges, wards, 0
+    if action == 4:
+        if charges <= 0:
+            return state
+        bit = _edge_bit(level, node, mouth, mode)
+        if level["mode_rule"] == "split":
+            if (known_a if mode == 0 else known_b) & bit:
+                return state
+            if mode == 0:
+                known_a |= bit
+            else:
+                known_b |= bit
+        else:
+            if known_a & bit:
+                return state
+            known_a |= bit
+        return node, mouth, mode, known_a, known_b, key, pending, charges - 1, wards, 0
+    if action == 5:
+        if not _observed(level, state):
+            return state
+        destination, effect, _needs_key, unsafe, _base = resolved_outcome(level, state)
+        if unsafe:
+            return _mistake(state)
+        had_pending = bool(pending)
+        pending = 0
+        if effect == SIGIL:
+            key = 1
+        elif effect == ECHO:
+            pending = 1
+        # Changing the causal frame invalidates old counterfactual evidence.
+        if had_pending or effect == ECHO:
+            known_a = known_b = 0
+        return destination, 0, mode, known_a, known_b, key, pending, charges, wards, 0
+    if configuration_solved(level, state):
+        return state[:-1] + (2,)
+    return _mistake(state)
+
+
+def action_cost(before, after):
+    if after == before or after[8] != before[8] or after[9] in (2, 3):
+        return 0
+    return 1
+
+
+def solved(_level, state):
+    return state[-1] == 2
+
+
+class OrreryDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def line(frame, a, b, color, dotted=False, limit=None):
+        x0, y0 = a; x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        last = steps if limit is None else min(steps, max(0, limit * steps // 100))
+        for step in range(last + 1):
+            if dotted and step % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * step // steps; y = y0 + (y1 - y0) * step // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                d = (x - cx) ** 2 + (y - cy) ** 2
+                if d <= radius * radius and (not hollow or d >= max(0, radius - 2) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def diamond(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for dy in range(-radius, radius + 1):
+            y = cy + dy
+            if not 0 <= y < 64:
+                continue
+            width = radius - abs(dy)
+            if hollow:
+                for x in (cx - width, cx + width):
+                    if 0 <= x < 64: frame[y, x] = color
+            else:
+                frame[y, max(0, cx - width):min(64, cx + width + 1)] = color
+
+    @staticmethod
+    def positions(n):
+        return tuple((32 + round(18 * math.cos(-math.pi / 2 + 2 * math.pi * i / n)),
+                      29 + round(18 * math.sin(-math.pi / 2 + 2 * math.pi * i / n)))
+                     for i in range(n))
+
+    def background(self, frame):
+        frame[:, :] = INK
+        self.disc(frame, (32, 29), 27, CHARCOAL)
+        self.disc(frame, (32, 29), 25, INK)
+        self.disc(frame, (32, 29), 18, CHARCOAL, hollow=True)
+        for radius in (9, 15, 23):
+            self.disc(frame, (32, 29), radius, SLATE, hollow=True)
+        for i in range(18):
+            angle = 2 * math.pi * i / 18
+            x = 32 + round(27 * math.cos(angle)); y = 29 + round(25 * math.sin(angle))
+            self.diamond(frame, (x, y), 1, ASH if i % 2 else BLUE)
+        for y in range(7, 54, 8):
+            frame[y, 5 + y % 5:59:11] = SLATE
+
+    def node(self, frame, index, center, selected=False, goal=False):
+        x, y = center; kind = index % 4
+        if kind == 0:
+            self.disc(frame, center, 4, ASH, hollow=True)
+            self.disc(frame, center, 1, PEARL)
+        elif kind == 1:
+            self.diamond(frame, center, 5, ASH, hollow=True)
+            self.line(frame, (x, y - 3), (x, y + 3), SLATE)
+        elif kind == 2:
+            self.line(frame, (x, y - 5), (x - 5, y + 4), ASH)
+            self.line(frame, (x - 5, y + 4), (x + 5, y + 4), ASH)
+            self.line(frame, (x + 5, y + 4), (x, y - 5), ASH)
+        else:
+            self.disc(frame, center, 5, ASH, hollow=True)
+            frame[y - 5:y + 6, x:x + 5] = INK
+            self.line(frame, (x, y - 4), (x, y + 4), PEARL, dotted=True)
+        if goal:
+            for dx, dy in ((0, -7), (7, 0), (0, 7), (-7, 0)):
+                self.diamond(frame, (x + dx, y + dy), 2, AQUA, hollow=True)
+        if selected:
+            self.disc(frame, center, 7, WHITE, hollow=True)
+
+    def wisp(self, frame, center, key=False):
+        x, y = center
+        self.diamond(frame, (x, y - 1), 4, PEARL)
+        self.line(frame, (x, y + 2), (x - 4, y + 7), ASH)
+        self.line(frame, (x, y + 2), (x + 3, y + 6), SLATE)
+        frame[y - 1, x] = VIOLET
+        if key:
+            self.diamond(frame, (x + 5, y - 5), 2, GOLD, hollow=True)
+            frame[y - 5, x + 5] = WHITE
+
+    @staticmethod
+    def mouth_offset(mouth):
+        return ((0, -8), (7, 5), (-7, 5))[mouth]
+
+    def mouth(self, frame, center, mouth, selected=False):
+        x, y = center; dx, dy = self.mouth_offset(mouth); p = (x + dx, y + dy)
+        if mouth == 0:
+            self.disc(frame, p, 2, WHITE if selected else SLATE, hollow=True)
+        elif mouth == 1:
+            self.line(frame, (p[0], p[1] - 2), (p[0] - 2, p[1] + 2), WHITE if selected else SLATE)
+            self.line(frame, (p[0] - 2, p[1] + 2), (p[0] + 2, p[1] + 2), WHITE if selected else SLATE)
+            self.line(frame, (p[0] + 2, p[1] + 2), (p[0], p[1] - 2), WHITE if selected else SLATE)
+        else:
+            self.line(frame, (p[0] - 2, p[1] - 2), (p[0] - 2, p[1] + 2), WHITE if selected else SLATE)
+            self.line(frame, (p[0] + 2, p[1] - 2), (p[0] + 2, p[1] + 2), WHITE if selected else SLATE)
+            self.line(frame, (p[0] - 2, p[1]), (p[0] + 2, p[1]), WHITE if selected else SLATE)
+        if selected:
+            # An external two-post bracket makes selection geometric rather
+            # than relying on the mouth's WHITE-versus-SLATE value alone.
+            self.line(frame, (p[0] - 4, p[1] - 3), (p[0] - 4, p[1] + 3), WHITE)
+            self.line(frame, (p[0] + 4, p[1] - 3), (p[0] + 4, p[1] + 3), WHITE)
+
+    def observed_path(self, frame, state, mouth, mode):
+        g = self.game; node = state[0]; positions = self.positions(g.level["n"])
+        synthetic = list(state); synthetic[1] = mouth; synthetic[2] = mode; synthetic = tuple(synthetic)
+        destination, effect, needs_key, unsafe, base = resolved_outcome(g.level, synthetic)
+        source, target, base_target = positions[node], positions[destination], positions[base]
+        bit = _edge_bit(g.level, node, mouth, mode)
+        if g.level["mode_rule"] == "split":
+            first = bool(state[3] & bit); second = bool(state[4] & bit)
+            if first:
+                midpoint = ((source[0] + target[0]) // 2, (source[1] + target[1]) // 2)
+                self.line(frame, source, midpoint, AQUA, dotted=True)
+            if second:
+                midpoint = ((source[0] + target[0]) // 2, (source[1] + target[1]) // 2)
+                self.line(frame, midpoint, target, VIOLET, dotted=True)
+            if not (first and second):
+                return
+        else:
+            if not state[3] & bit:
+                return
+            self.line(frame, source, target, AQUA if not unsafe else ROSE, dotted=True)
+        if state[6] and base != destination:
+            self.line(frame, source, base_target, ASH, dotted=True)
+            self.line(frame, base_target, target, VIOLET)
+        if unsafe:
+            self.line(frame, (target[0] - 3, target[1] - 3), (target[0] + 3, target[1] + 3), RED)
+            self.line(frame, (target[0] + 3, target[1] - 3), (target[0] - 3, target[1] + 3), RED)
+        elif effect == SIGIL:
+            self.diamond(frame, ((source[0] + target[0]) // 2,
+                                 (source[1] + target[1]) // 2), 3, GOLD, hollow=True)
+        elif effect == ECHO:
+            mid = ((source[0] + target[0]) // 2, (source[1] + target[1]) // 2)
+            self.disc(frame, mid, 3, VIOLET, hollow=True)
+            self.line(frame, mid, (mid[0] + 5, mid[1] - 4), PEARL, dotted=True)
+        if needs_key:
+            self.line(frame, (target[0] - 4, target[1]), (target[0] + 4, target[1]), GOLD)
+            self.diamond(frame, target, 2, WHITE, hollow=True)
+
+    def apparatus(self, frame):
+        g = self.game; state = g.state; positions = self.positions(g.level["n"])
+        for index, center in enumerate(positions):
+            self.node(frame, index, center, goal=index == g.level["goal"])
+        for mouth in range(3):
+            suppress_selector = (g.anim_kind == "select"
+                                  and g.anim_progress < max(1, g.anim_total - 1))
+            self.mouth(frame, positions[state[0]], mouth,
+                       selected=mouth == state[1] and not suppress_selector)
+            modes = (state[2],) if g.level["mode_rule"] == "phase" else (0,)
+            for mode in modes:
+                self.observed_path(frame, state, mouth, mode)
+        moving = g.anim_kind in ("commit", "hazard", "blocked")
+        if not moving:
+            self.wisp(frame, positions[state[0]], bool(state[5]))
+        # Central glass shows phase orientation or the split observation panes.
+        if g.level["mode_rule"] == "phase":
+            self.diamond(frame, (32, 29), 6, BLUE if state[2] == 0 else VIOLET, hollow=True)
+            dx = -4 if state[2] == 0 else 4
+            self.line(frame, (32, 23), (32 + dx, 29), WHITE)
+            self.line(frame, (32 + dx, 29), (32, 35), WHITE)
+        elif g.level["mode_rule"] == "split":
+            self.disc(frame, (32, 29), 7, ASH, hollow=True)
+            if state[2] == 0:
+                frame[24:35, 27:32] = BLUE
+                frame[25:34, 28:32] = INK
+            else:
+                frame[24:35, 33:38] = VIOLET
+                frame[25:34, 33:37] = INK
+        if state[6]:
+            self.disc(frame, (32, 29), 3, VIOLET, hollow=True)
+            self.line(frame, (28, 34), (36, 24), PEARL, dotted=True)
+        if g.level["require_key"]:
+            goal = positions[g.level["goal"]]
+            self.diamond(frame, goal, 3, GOLD, hollow=True)
+        if g.level["goal_mode"] >= 0:
+            goal = positions[g.level["goal"]]; dx = -5 if g.level["goal_mode"] == 0 else 5
+            self.line(frame, (goal[0], goal[1] - 6), (goal[0] + dx, goal[1] - 9), WHITE)
+
+    def hud(self, frame):
+        g = self.game
+        # Four-spoke groups expose every unit of the exact action budget.
+        shown_budget = g.budget_left
+        if (g.anim_kind and g.pending_budget is not None
+                and g.anim_progress >= max(1, g.anim_total - 1)
+                and g.anim_kind != "success"):
+            shown_budget = g.pending_budget
+        for group in range((g.budget_max + 3) // 4):
+            cx = 7 + group * 9; cy = 4
+            self.diamond(frame, (cx, cy), 1, SLATE)
+            for tooth, (dx, dy) in enumerate(((0, -2), (2, 0), (0, 2), (-2, 0))):
+                unit = group * 4 + tooth
+                if unit < g.budget_max:
+                    live = unit < shown_budget
+                    ux, uy = cx + dx, cy + dy
+                    if live:
+                        # A live unit is a plus/faceted diamond.
+                        self.diamond(frame, (ux, uy), 1, AQUA)
+                    else:
+                        # A spent unit is a diagonal X: its geometry remains
+                        # distinguishable when palette values are collapsed.
+                        for ox, oy in ((-1, -1), (1, -1), (0, 0), (-1, 1), (1, 1)):
+                            if 0 <= ux + ox < 64 and 0 <= uy + oy < 64:
+                                frame[uy + oy, ux + ox] = SLATE
+        # Observation droplets are countable and independent from energy.
+        for index in range(g.level["charges"]):
+            x = 6 + index * 4
+            self.diamond(frame, (x, 60), 2, VIOLET if index < g.state[7] else SLATE,
+                         hollow=index >= g.state[7])
+        # Two wards may both be spent recoverably; a third mistake fractures.
+        for index, x in enumerate((54, 60)):
+            active = index < g.state[8]
+            self.disc(frame, (x, 60), 3, PEARL if active else SLATE, hollow=True)
+            if not active:
+                self.line(frame, (x - 2, 58), (x + 2, 62), RED)
+                self.line(frame, (x + 2, 58), (x - 2, 62), RED)
+
+    def terminal(self, frame):
+        g = self.game
+        if g.state[9] == 3 and not g.anim_kind:
+            for radius in (7, 13, 19):
+                self.disc(frame, (32, 29), radius, RED, hollow=True)
+            self.line(frame, (13, 10), (51, 48), ASH)
+            self.line(frame, (51, 10), (13, 48), ASH)
+
+    def animation(self, frame):
+        g = self.game
+        if g.intro_mark:
+            for radius in (4, 8, 12):
+                self.disc(frame, (32, 29), radius, VIOLET, hollow=True)
+        if not g.anim_kind:
+            return
+        p = g.anim_progress; total = max(1, g.anim_total); span = max(1, total - 1)
+        before, after = g.anim_before, g.pending_state
+        positions = self.positions(g.level["n"]); source = positions[before[0]]
+        if g.anim_kind == "select":
+            if p < span:
+                a = self.mouth_offset(before[1]); b = self.mouth_offset(after[1])
+                center = (source[0] + a[0] + (b[0] - a[0]) * p // span,
+                          source[1] + a[1] + (b[1] - a[1]) * p // span)
+                self.disc(frame, center, 3, WHITE, hollow=True)
+        elif g.anim_kind == "lens":
+            if p < span:
+                radius = 2 + 4 * p // span
+                self.diamond(frame, (32, 29), radius, WHITE, hollow=True)
+        elif g.anim_kind == "preview":
+            if p < span:
+                destination, _effect, _needs, unsafe, _base = resolved_outcome(g.level, before)
+                target = positions[destination]
+                self.line(frame, source, target, RED if unsafe else AQUA,
+                          dotted=True, limit=100 * p // span)
+                point = (source[0] + (target[0] - source[0]) * p // span,
+                         source[1] + (target[1] - source[1]) * p // span)
+                self.disc(frame, point, 2, PEARL, hollow=True)
+        elif g.anim_kind == "commit":
+            target = positions[after[0]]
+            point = (source[0] + (target[0] - source[0]) * p // span,
+                     source[1] + (target[1] - source[1]) * p // span)
+            self.wisp(frame, point, bool(after[5] if p >= span else before[5]))
+            if p < span:
+                self.line(frame, source, point, AQUA, dotted=True)
+            elif g.level["require_key"]:
+                # Stable rendering lays the goal's key socket over the arrived
+                # wisp; preserve that exact layer order at the animation endpoint.
+                goal = positions[g.level["goal"]]
+                self.diamond(frame, goal, 3, GOLD, hollow=True)
+        elif g.anim_kind in ("hazard", "blocked"):
+            if g.anim_kind == "hazard":
+                target = positions[resolved_outcome(g.level, before)[0]]
+            else:
+                dx, dy = self.mouth_offset(before[1])
+                target = (source[0] + dx, source[1] + dy)
+            folded = min(p, span - p); denominator = max(1, span // 2)
+            fraction = folded * 55 // denominator
+            point = (source[0] + (target[0] - source[0]) * fraction // 100,
+                     source[1] + (target[1] - source[1]) * fraction // 100)
+            self.wisp(frame, point, bool(before[5]))
+            if p < span:
+                self.line(frame, (point[0] - 4, point[1] - 4),
+                          (point[0] + 4, point[1] + 4), RED)
+        elif g.anim_kind == "reject":
+            if p < span:
+                x = (54, 60)[max(0, before[8] - 1)] if before[8] else 60
+                radius = 3 * p // span
+                self.line(frame, (x - radius, 60 - radius), (x + radius, 60 + radius), RED)
+                self.line(frame, (x + radius, 60 - radius), (x - radius, 60 + radius), RED)
+        elif g.anim_kind == "success":
+            for radius in range(4, min(28, 4 + p * 4), 5):
+                self.disc(frame, (32, 29), radius, GREEN, hollow=True)
+            for index, center in enumerate(positions):
+                if index <= p:
+                    self.diamond(frame, center, 3, AQUA, hollow=True)
+        elif g.anim_kind == "loss":
+            left = 8 + 5 * p // span; right = 56 - 5 * p // span
+            top = 5 + 5 * p // span; bottom = 53 - 5 * p // span
+            self.line(frame, (left, top), (right, bottom), ASH if p >= span else RED)
+            self.line(frame, (right, top), (left, bottom), ASH)
+            if p >= span:
+                for radius in (7, 13, 19):
+                    self.disc(frame, (32, 29), radius, RED, hollow=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        g = self.game
+        preview_settle = (g.anim_kind in (
+            "select", "lens", "preview", "commit", "hazard", "blocked", "reject", "loss")
+            and g.pending_state is not None
+            and g.anim_progress >= max(1, g.anim_total - 1))
+        current = g.state
+        if preview_settle:
+            g.state = g.pending_state
+        self.background(frame); self.apparatus(frame); self.hud(frame); self.terminal(frame)
+        if preview_settle:
+            g.state = current
+        self.animation(frame)
+        return frame
+
+
+class Q142(ARCBaseGame):
+    def __init__(self):
+        self.display = OrreryDisplay(self); self.level = LEVELS[0]
+        self.state = start_state(self.level); self.budget_left = self.budget_max = 0
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = None; self.pending_budget = None
+        self.pending_terminal = None; self.intro_mark = True
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q142", levels, Camera(0, 0, 64, 64, INK, INK, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state; self.pending_state = self.pending_budget = None
+        self.pending_terminal = None; self.intro_mark = True
+
+    def begin(self, kind, frames, before, after, budget, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames; self.anim_progress = 0
+        self.anim_before = before; self.pending_state = after; self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal; self.state = self.pending_state
+        self.budget_left = self.pending_budget; self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win": self.next_level()
+        elif terminal == "loss": self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1; self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0: self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action(); return
+        self.intro_mark = False; before = self.state; after = transition(self.level, before, action)
+        if after == before:
+            self.begin("blocked", 5, before, before, self.budget_left); return
+        cost = action_cost(before, after)
+        if cost > self.budget_left:
+            lost = before[:-1] + (3,)
+            self.begin("loss", 7, before, lost, self.budget_left, "loss"); return
+        budget = self.budget_left - cost
+        if after[-1] == 2:
+            kind, frames, terminal = "success", 7, "win"
+        elif after[-1] == 3:
+            kind, frames, terminal = "loss", 7, "loss"
+        elif action in (1, 2):
+            kind, frames, terminal = "select", 4, None
+        elif action == 3:
+            kind, frames, terminal = "lens", 5, None
+        elif action == 4:
+            kind, frames, terminal = "preview", 7, None
+        elif action == 5:
+            kind = "commit" if after[0] != before[0] else "hazard"
+            frames, terminal = 7, None
+        else:
+            kind, frames, terminal = "reject", 5, None
+        self.begin(kind, frames, before, after, budget, terminal)

--- a/data/community-games/sonpham/q145_v2_q145.py
+++ b/data/community-games/sonpham/q145_v2_q145.py
@@ -1,0 +1,794 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q145-v2 Twin Tidepool Policy Observatory.
+
+Two translucent tidepools receive the same authored sequence of exact pulse
+quanta.  Their round and diamond floats have different starts, masses, walls,
+and (later) support gates, so the pair of stateful trajectories identifies one
+concealed policy law.  The player selects that policy, previews its complete
+effect on a separate main pool, and only then makes the irreversible release.
+
+The module exposes a pure, hashable rules contract for independent search,
+counterfactual mutation, replay, and exact random-policy analysis.  It adopts
+mx002 deterministic physics only; there is no stochastic or twitch component.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import NamedTuple
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+# ARC palette indices only.
+PAPER, MIST, PEARL, SLATE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+ORCHID, ROSE, CORAL, SKY, GLASS, SUN = 6, 7, 8, 9, 10, 11
+AMBER, OXBLOOD, MOSS, VIOLET = 12, 13, 14, 15
+
+ACTIVE, WIN, LOSS = 0, 2, 3
+TEST_ACTIONS = (1, 2)
+
+
+class State(NamedTuple):
+    tick: int
+    left_trace: tuple
+    right_trace: tuple
+    pulse_history: tuple
+    selected: int
+    preview: tuple
+    strikes: int
+    last_event: int
+    terminal: int
+
+
+TERMINAL_INDEX = 8
+
+
+POLICY_NAMES = ("lift", "sink", "tide", "reed")
+
+
+def _shortest_selection(policies, answer):
+    target = policies.index(answer)
+    size = len(policies)
+    backward = (size - target) % size
+    forward = target
+    if backward <= forward:
+        return (3,) * backward
+    return (4,) * forward
+
+
+def observatory(name, probes, policies, answer, starts, *, limit=12,
+                masses=(1, 1, 1), gates=(None, None, None), tide_phase=0,
+                curriculum=()):
+    probes = tuple(int(item) for item in probes)
+    policies = tuple(int(item) for item in policies)
+    starts = tuple((int(p), int(v)) for p, v in starts)
+    witness = probes + _shortest_selection(policies, answer) + (5, 6)
+    return {
+        "name": name,
+        "probes": probes,
+        "policies": policies,
+        "answer": int(answer),
+        "starts": starts,
+        "limit": int(limit),
+        "masses": tuple(int(item) for item in masses),
+        "gates": tuple(gates),
+        "tide_phase": int(tide_phase),
+        "budget": len(witness) + 4,
+        "witness": witness,
+        "curriculum": tuple(curriculum),
+    }
+
+
+# Pulse 1 is a pointed sun quantum; pulse 2 is a cut-diamond moon quantum.
+# Level 2+ uses exactly eighteen prescribed pulses. Even after allowing one
+# recoverable wrong pulse, blindly reproducing the visible experiment has the
+# strict upper bound 19 / 2^18 < 1e-4 before policy selection is considered.
+# Length is held flat while new laws, typed bodies, collision, and support
+# compose rather than relying on later count inflation.
+LEVELS = (
+    observatory(
+        "First Paired Drift",
+        (1, 2, 1, 1, 2, 2, 1, 2),
+        (0, 1), 1,
+        ((5, 0), (8, 0), (6, 0)),
+        limit=14,
+        curriculum=("parallel-pulse", "constant-current"),
+    ),
+    observatory(
+        "Momentum Ledger",
+        (1, 1, 2, 1, 2, 2, 1, 2, 1, 1, 2, 2, 1, 2, 1, 2, 1, 2),
+        (0, 1, 2), 1,
+        ((4, 1), (10, -1), (7, 0)),
+        limit=16, tide_phase=1,
+        curriculum=("parallel-pulse", "persistent-momentum",
+                    "three-policy-discrimination"),
+    ),
+    observatory(
+        "Pearl Wall Return",
+        (1, 1, 1, 2, 2, 1, 2, 2, 1, 1, 2, 1, 2, 2, 1, 2, 2, 1),
+        (0, 1, 2), 2,
+        ((2, -1), (8, 1), (5, 0)),
+        limit=10, tide_phase=0,
+        curriculum=("momentum", "exact-wall-reflection",
+                    "paired-collision-evidence"),
+    ),
+    observatory(
+        "Reed Brake",
+        (2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 1, 2, 2, 1, 2, 1, 2, 2),
+        (0, 1, 2, 3), 3,
+        ((3, 2), (9, -2), (6, 1)),
+        limit=12, tide_phase=1,
+        curriculum=("momentum", "reflection", "velocity-opposing-drag",
+                    "four-policy-discrimination"),
+    ),
+    observatory(
+        "Alternating Spring Tide",
+        (1, 2, 2, 1, 1, 2, 1, 2, 2, 1, 2, 1, 1, 2, 2, 1, 2, 1),
+        (0, 1, 2, 3), 1,
+        ((1, 1), (11, -1), (6, 0)),
+        limit=12, tide_phase=1,
+        curriculum=("momentum", "reflection", "alternating-tide",
+                    "drag-comparison"),
+    ),
+    observatory(
+        "Shell and Seed Mass",
+        (1, 1, 2, 1, 2, 1, 2, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2),
+        (0, 1, 2, 3), 2,
+        ((2, 0), (10, 0), (5, 1)),
+        limit=12, masses=(1, 2, 1), tide_phase=0,
+        curriculum=("typed-body-mass", "momentum", "reflection",
+                    "alternating-tide", "drag"),
+    ),
+    observatory(
+        "Lily Support Gate",
+        (2, 1, 1, 2, 1, 2, 2, 1, 1, 2, 1, 2, 1, 2, 2, 1, 2, 1),
+        (0, 1, 2, 3), 3,
+        ((1, 2), (10, -1), (4, 1)),
+        limit=12, masses=(1, 2, 1), gates=(6, 6, 7), tide_phase=1,
+        curriculum=("typed-body-mass", "support-threshold", "collision",
+                    "tide", "drag"),
+    ),
+    observatory(
+        "Twin Tidepool Policy Observatory",
+        (1, 2, 1, 1, 2, 2, 1, 2, 1, 2, 2, 1, 1, 2, 1, 2, 2, 1),
+        (0, 1, 2, 3), 1,
+        ((2, 1), (11, -2), (5, 1)),
+        limit=13, masses=(1, 2, 2), gates=(7, 6, 8), tide_phase=0,
+        curriculum=("paired-stateful-trajectories", "typed-mass",
+                    "momentum", "support", "reflection", "alternating-tide",
+                    "drag", "previewed-irreversible-commit"),
+    ),
+)
+
+
+def _sign(value):
+    return (value > 0) - (value < 0)
+
+
+def _reflect(position, velocity, limit):
+    """Exact mirror reflection on an integer interval."""
+    while position < 0 or position > limit:
+        if position < 0:
+            position = -position
+            velocity = -velocity
+        elif position > limit:
+            position = 2 * limit - position
+            velocity = -velocity
+    return position, velocity
+
+
+def physics_step(level, body, tick, position, velocity, policy, pulse):
+    """One public deterministic position/momentum quantum.
+
+    Bodies 0/1 are the parallel round/diamond sandbox floats; body 2 is the
+    separately previewed main float.  Mass is an exact skipped impulse quantum,
+    not division or floating-point integration.  A support gate catches only a
+    slow crossing; faster momentum passes it.  Walls mirror exactly.
+    """
+    pulse_force = 1 if int(pulse) == 1 else -1
+    mass = level["masses"][body]
+    if mass > 1 and (tick + body) % mass:
+        pulse_force = 0
+
+    if policy == 0:      # steady lift current
+        current = 1
+    elif policy == 1:    # steady sink current
+        current = -1
+    elif policy == 2:    # alternating spring tide
+        current = 1 if (tick + body + level["tide_phase"]) % 2 == 0 else -1
+    else:                # reed brake opposes current momentum
+        current = -_sign(velocity)
+
+    velocity = max(-4, min(4, velocity + pulse_force + current))
+    proposed = position + velocity
+    gate = level["gates"][body]
+    if gate is not None:
+        crossed = ((position < gate <= proposed)
+                   or (position > gate >= proposed))
+        if crossed and abs(velocity) <= 1:
+            return int(gate), 0
+    return _reflect(proposed, velocity, level["limit"])
+
+
+def sandbox_trajectory(level, body, policy, probes=None):
+    """Public exact trajectory including the initial (position, velocity)."""
+    probes = level["probes"] if probes is None else tuple(probes)
+    position, velocity = level["starts"][body]
+    trace = [(position, velocity)]
+    for tick, pulse in enumerate(probes):
+        position, velocity = physics_step(
+            level, body, tick, position, velocity, policy, pulse)
+        trace.append((position, velocity))
+    return tuple(trace)
+
+
+def sandbox_trajectories(level, policy):
+    """The paired visible evidence signature for one candidate policy."""
+    return (sandbox_trajectory(level, 0, policy),
+            sandbox_trajectory(level, 1, policy))
+
+
+def main_trajectory(level, policy):
+    """The separate preview trajectory; it never mutates the main pool."""
+    return sandbox_trajectory(level, 2, policy)
+
+
+def start_state(level):
+    return State(
+        0,
+        (tuple(level["starts"][0]),),
+        (tuple(level["starts"][1]),),
+        (),
+        0,
+        (),
+        0,
+        0,
+        ACTIVE,
+    )
+
+
+def selected_policy(level, state):
+    return level["policies"][state.selected]
+
+
+def evidence_ready(level, state):
+    expected_left, expected_right = sandbox_trajectories(
+        level, level["answer"])
+    return (state.tick == len(level["probes"])
+            and state.pulse_history == level["probes"]
+            and state.left_trace == expected_left
+            and state.right_trace == expected_right)
+
+
+def commit_ready(level, state):
+    return (evidence_ready(level, state)
+            and state.preview == main_trajectory(
+                level, selected_policy(level, state)))
+
+
+def solved(level, state):
+    return (state.terminal == WIN and commit_ready(level, state)
+            and selected_policy(level, state) == level["answer"])
+
+
+def action_tokens(_level):
+    return (1, 2, 3, 4, 5, 6)
+
+
+def encode_action(_level, action):
+    aid = int(action[0]) if isinstance(action, (tuple, list)) else int(action)
+    return (aid,)
+
+
+def _transition(level, state, action, mode="physics"):
+    if state.terminal != ACTIVE:
+        return state
+    aid = int(action[0]) if isinstance(action, (tuple, list)) else int(action)
+    if aid not in action_tokens(level):
+        return state
+
+    if aid in TEST_ACTIONS:
+        if state.tick >= len(level["probes"]):
+            return state
+        tick = state.tick
+        expected_pulse = level["probes"][tick]
+        if aid != expected_pulse:
+            strikes = state.strikes + 1
+            return state._replace(
+                strikes=strikes,
+                last_event=aid,
+                terminal=LOSS if strikes >= 2 else ACTIVE,
+            )
+        pulse_history = state.pulse_history + (aid,)
+        if mode == "without_physics":
+            left = state.left_trace + (state.left_trace[-1],)
+            right = state.right_trace + (state.right_trace[-1],)
+        else:
+            lp, lv = state.left_trace[-1]
+            left_after = physics_step(
+                level, 0, tick, lp, lv, level["answer"], aid)
+            left = state.left_trace + (left_after,)
+            if mode == "without_parallel":
+                right = state.right_trace + (state.right_trace[-1],)
+            else:
+                rp, rv = state.right_trace[-1]
+                right_after = physics_step(
+                    level, 1, tick, rp, rv, level["answer"], aid)
+                right = state.right_trace + (right_after,)
+        return state._replace(
+            tick=tick + 1,
+            left_trace=left,
+            right_trace=right,
+            pulse_history=pulse_history,
+            preview=(),
+            last_event=aid,
+        )
+
+    if aid in (3, 4):
+        size = len(level["policies"])
+        delta = -1 if aid == 3 else 1
+        choice = (state.selected + delta) % size
+        if choice == state.selected:
+            return state
+        return state._replace(
+            selected=choice, preview=(), last_event=aid)
+
+    if aid == 5:
+        if not evidence_ready(level, state):
+            return state
+        preview = main_trajectory(level, selected_policy(level, state))
+        if preview == state.preview:
+            return state
+        return state._replace(preview=preview, last_event=5)
+
+    if not commit_ready(level, state):
+        return state
+    if selected_policy(level, state) == level["answer"]:
+        return state._replace(last_event=6, terminal=WIN)
+    strikes = state.strikes + 1
+    return state._replace(
+        preview=(), strikes=strikes, last_event=6,
+        terminal=LOSS if strikes >= 2 else ACTIVE,
+    )
+
+
+def transition(level, state, action):
+    return _transition(level, state, action, "physics")
+
+
+def without_physics(level, state, action):
+    """Counterfactual: pulses record but bodies never obey a physical law."""
+    return _transition(level, state, action, "without_physics")
+
+
+def without_parallel(level, state, action):
+    """Counterfactual: only the left sandbox runs; paired evidence disappears."""
+    return _transition(level, state, action, "without_parallel")
+
+
+def action_cost(before, after):
+    if after == before:
+        return 0
+    # The first mistaken irreversible release cracks a persistent shell but
+    # costs no bead, leaving enough exact budget to select, preview, and apply
+    # the corrected law.  It cannot cycle: the second mistake terminates.
+    if after.strikes > before.strikes:
+        return 0
+    return 1
+
+
+def execute(level, actions, transition_fn=transition):
+    state = start_state(level)
+    budget = level["budget"]
+    for action in actions:
+        after = transition_fn(level, state, action)
+        budget -= action_cost(state, after)
+        state = after
+    return state, budget
+
+
+# Public assertions pin causal curriculum and prevent a decorative physics
+# implementation from importing successfully.
+for _level in LEVELS:
+    _signatures = tuple(sandbox_trajectories(_level, policy)
+                        for policy in _level["policies"])
+    assert len(set(_signatures)) == len(_signatures), _level["name"]
+    assert len(set(main_trajectory(_level, policy)
+                   for policy in _level["policies"])) == len(_level["policies"])
+    _state, _left = execute(_level, _level["witness"])
+    assert solved(_level, _state) and _left == 4, (_level["name"], _state, _left)
+    _mutant, _ = execute(_level, _level["witness"], without_physics)
+    assert not solved(_level, _mutant)
+    _mutant, _ = execute(_level, _level["witness"], without_parallel)
+    assert not solved(_level, _mutant)
+assert {action for level in LEVELS for action in level["witness"]} == set(range(1, 7))
+
+
+class TidepoolDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def pixel(frame, x, y, color):
+        if 0 <= x < 64 and 0 <= y < 64:
+            frame[y, x] = color
+
+    @classmethod
+    def line(cls, frame, start, end, color, dotted=False, width=1):
+        x0, y0 = start; x1, y1 = end
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 4 in (1, 2):
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            for offset in range(width):
+                cls.pixel(frame, x, y + offset, color)
+
+    @classmethod
+    def disc(cls, frame, center, radius, color, hollow=False):
+        cx, cy = center
+        inner = max(0, radius - 1) ** 2
+        for y in range(cy - radius, cy + radius + 1):
+            for x in range(cx - radius, cx + radius + 1):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius ** 2 and (not hollow or distance >= inner):
+                    cls.pixel(frame, x, y, color)
+
+    @classmethod
+    def diamond(cls, frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for dy in range(-radius, radius + 1):
+            reach = radius - abs(dy)
+            if hollow:
+                cls.pixel(frame, cx - reach, cy + dy, color)
+                cls.pixel(frame, cx + reach, cy + dy, color)
+            else:
+                for x in range(cx - reach, cx + reach + 1):
+                    cls.pixel(frame, x, cy + dy, color)
+
+    @classmethod
+    def triangle(cls, frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for dy in range(radius + 1):
+            reach = dy
+            y = cy - radius + dy
+            if hollow:
+                cls.pixel(frame, cx - reach, y, color)
+                cls.pixel(frame, cx + reach, y, color)
+            else:
+                for x in range(cx - reach, cx + reach + 1):
+                    cls.pixel(frame, x, y, color)
+
+    @classmethod
+    def pulse_glyph(cls, frame, center, pulse, color, large=False):
+        radius = 3 if large else 2
+        if pulse == 1:
+            cls.triangle(frame, center, radius, color, hollow=True)
+            cls.line(frame, (center[0], center[1] - radius + 1),
+                     (center[0], center[1] + radius), color, dotted=True)
+        else:
+            cls.diamond(frame, center, radius, color, hollow=True)
+            cls.line(frame, (center[0] - radius + 1, center[1]),
+                     (center[0] + radius - 1, center[1]), color, dotted=True)
+
+    @classmethod
+    def policy_glyph(cls, frame, center, policy, color, hollow=False):
+        x, y = center
+        if policy == 0:
+            cls.triangle(frame, (x, y - 1), 4, color, hollow)
+            cls.line(frame, (x, y + 3), (x, y - 3), color, dotted=True)
+        elif policy == 1:
+            cls.triangle(frame, (x, y + 1), 4, color, hollow)
+            cls.line(frame, (x, y - 3), (x, y + 3), color, dotted=True)
+        elif policy == 2:
+            cls.line(frame, (x - 4, y + 2), (x - 2, y - 2), color, width=2)
+            cls.line(frame, (x - 2, y - 2), (x, y + 2), color, width=2)
+            cls.line(frame, (x, y + 2), (x + 2, y - 2), color, width=2)
+            cls.line(frame, (x + 2, y - 2), (x + 4, y + 2), color, width=2)
+        else:
+            for offset in (-3, 0, 3):
+                cls.line(frame, (x - 4, y + offset),
+                         (x + 2, y + offset), color, dotted=bool(offset))
+            cls.line(frame, (x + 3, y - 4), (x + 3, y + 4), color, width=2)
+
+    def background(self, frame):
+        frame[:, :] = PAPER
+        # Sparse fibrous paper and translucent sea-glass crescents.
+        for y in range(1, 64, 6):
+            for x in range((y * 3) % 8, 64, 13):
+                frame[y, x] = MIST if (x + y) % 2 else PEARL
+        self.disc(frame, (18, 27), 14, SKY)
+        self.disc(frame, (18, 27), 12, GLASS)
+        self.disc(frame, (18, 27), 10, PAPER)
+        self.disc(frame, (46, 27), 14, MOSS)
+        self.disc(frame, (46, 27), 12, GLASS)
+        self.disc(frame, (46, 27), 10, PAPER)
+        # Unequal petal notches defeat a raw circle/square read.
+        for center, flip in (((8, 21), False), ((27, 34), True),
+                             ((55, 19), True), ((38, 36), False)):
+            self.diamond(frame, center, 3, MIST if flip else PEARL)
+        self.disc(frame, (32, 45), 8, VIOLET, hollow=True)
+        self.disc(frame, (32, 45), 6, GLASS, hollow=True)
+
+    def schedule(self, frame, state):
+        level = self.game.level
+        # Every prescribed quantum remains visible. Shape and internal hatch,
+        # not hue, distinguish the two pulses. A halo marks the next quantum.
+        for index, pulse in enumerate(level["probes"]):
+            row, column = divmod(index, 9)
+            center = (13 + column * 5, 3 + row * 5)
+            done = index < state.tick
+            color = MOSS if done and state.pulse_history[index] == pulse else (
+                OXBLOOD if done else SLATE)
+            self.pulse_glyph(frame, center, pulse, color)
+            if index == state.tick:
+                self.disc(frame, center, 3, SUN, hollow=True)
+
+        # Exact remaining action beads, split along the open margins and
+        # grouped by five with a diamond knot.
+        for index in range(self.game.budget_max):
+            side = index % 2
+            row = index // 2
+            center = (2 if side == 0 else 61, 4 + row * 4)
+            live = index < self.game.budget_left
+            self.disc(frame, center, 1, SUN if live else PEARL,
+                      hollow=not live)
+            if row and row % 5 == 0:
+                self.diamond(frame, (4 if side == 0 else 59, center[1]),
+                             1, SLATE, hollow=True)
+
+    def _pool_x(self, body, position):
+        center = 18 if body == 0 else 46
+        limit = self.game.level["limit"]
+        return center - 9 + (18 * position // max(1, limit))
+
+    def body(self, frame, body, position, center_y=27, color=CORAL):
+        center = (self._pool_x(body, position), center_y)
+        if body == 0:
+            self.disc(frame, center, 4, color)
+            self.disc(frame, center, 2, PAPER, hollow=True)
+            self.line(frame, (center[0] - 3, center[1]),
+                      (center[0] + 3, center[1]), INK, dotted=True)
+        else:
+            self.diamond(frame, center, 5, color)
+            self.diamond(frame, center, 2, PAPER, hollow=True)
+            self.line(frame, (center[0], center[1] - 4),
+                      (center[0], center[1] + 4), INK, dotted=True)
+        return center
+
+    def pool(self, frame, body, trace):
+        # Full stateful trajectory is retained as a patterned wake. Position
+        # and signed velocity are both visible without digits.
+        color = CORAL if body == 0 else VIOLET
+        for index, (position, _velocity) in enumerate(trace[:-1]):
+            center = (self._pool_x(body, position), 22 + (index % 4) * 3)
+            if body == 0:
+                self.disc(frame, center, 1, color, hollow=bool(index % 2))
+            else:
+                self.diamond(frame, center, 1, color, hollow=bool(index % 2))
+        position, velocity = trace[-1]
+        center = self.body(frame, body, position, color=color)
+        direction = _sign(velocity)
+        for mark in range(abs(velocity)):
+            x = center[0] + direction * (5 + mark * 2)
+            self.triangle(frame, (x, center[1]), 1, INK, hollow=True)
+        gate = self.game.level["gates"][body]
+        if gate is not None:
+            x = self._pool_x(body, gate)
+            self.line(frame, (x, 16), (x, 38), MOSS, dotted=True)
+            self.diamond(frame, (x, 18), 2, MOSS, hollow=True)
+
+    def policies(self, frame, state):
+        level = self.game.level
+        count = len(level["policies"])
+        spacing = 13 if count == 4 else 17
+        start = 32 - spacing * (count - 1) // 2
+        for index, policy in enumerate(level["policies"]):
+            center = (start + index * spacing, 59)
+            selected = index == state.selected
+            # Each policy card openly predicts the two sandbox endpoints.
+            # The round upper mark and diamond lower mark match the large
+            # bodies, while the one-pixel tail shows signed final momentum.
+            # Players can therefore compare observed evidence with every
+            # candidate rather than relying on an answer hidden in state.
+            predicted = sandbox_trajectories(level, policy)
+            for body, y in ((0, 51), (1, 54)):
+                position, velocity = predicted[body][-1]
+                x = center[0] - 4 + 8 * position // max(1, level["limit"])
+                if body == 0:
+                    self.disc(frame, (x, y), 1, CORAL, hollow=True)
+                else:
+                    self.diamond(frame, (x, y), 1, VIOLET, hollow=True)
+                self.pixel(frame, x + _sign(velocity) * 2, y, INK)
+            if selected:
+                self.disc(frame, center, 6, SUN, hollow=True)
+                self.disc(frame, center, 5, VIOLET, hollow=True)
+            self.policy_glyph(frame, center, policy,
+                              INK if selected else SLATE, hollow=not selected)
+
+    def main_pool(self, frame, state):
+        trace = state.preview
+        if not trace:
+            trace = (tuple(self.game.level["starts"][2]),)
+        limit = self.game.level["limit"]
+        for index, (position, _velocity) in enumerate(trace[:-1]):
+            x = 26 + 12 * position // max(1, limit)
+            y = 43 + (index % 3)
+            self.diamond(frame, (x, y), 1, VIOLET, hollow=bool(index % 2))
+        position, velocity = trace[-1]
+        x = 26 + 12 * position // max(1, limit)
+        self.diamond(frame, (x, 45), 3, AMBER if state.preview else PEARL)
+        for mark in range(abs(velocity)):
+            self.pixel(frame, x + _sign(velocity) * (4 + mark), 45, INK)
+        # Two shell seals make the recoverable first release and terminal
+        # second release countable by shape and fracture pattern.
+        for index, sx in enumerate((22, 42)):
+            cracked = index < state.strikes
+            self.disc(frame, (sx, 47), 3, OXBLOOD if cracked else MOSS,
+                      hollow=not cracked)
+            if cracked:
+                self.line(frame, (sx - 2, 45), (sx + 2, 49), INK)
+
+    def animation(self, frame, state):
+        g = self.game
+        if not g.anim_kind:
+            if state.terminal == LOSS:
+                self.line(frame, (6, 14), (58, 40), OXBLOOD, width=2)
+                self.line(frame, (58, 14), (6, 40), VIOLET, width=2)
+            return
+        before, after = g.state, g.pending_state
+        p = g.anim_progress
+        span = max(1, g.anim_total - 1)
+        wave = min(p, span - p)
+        if g.anim_kind == "probe":
+            for body, center_y in ((0, 27), (1, 27)):
+                before_pos = (before.left_trace if body == 0
+                              else before.right_trace)[-1][0]
+                after_pos = (after.left_trace if body == 0
+                             else after.right_trace)[-1][0]
+                shown = before_pos + (after_pos - before_pos) * p // span
+                center = self.body(frame, body, shown, center_y - wave // 2,
+                                   SUN if body == 0 else ORCHID)
+                self.disc(frame, center, 5 + wave, SKY, hollow=True)
+            self.pulse_glyph(frame, (32, 13), after.last_event, OXBLOOD,
+                             large=True)
+        elif g.anim_kind == "select":
+            count = len(g.level["policies"])
+            spacing = 13 if count == 4 else 17
+            start = 32 - spacing * (count - 1) // 2
+            x0 = start + before.selected * spacing
+            x1 = start + after.selected * spacing
+            x = x0 + (x1 - x0) * p // span
+            self.disc(frame, (x, 59), 6 + wave, SUN, hollow=True)
+        elif g.anim_kind == "preview":
+            trace = after.preview
+            index = min(len(trace) - 1,
+                        p * max(1, len(trace) - 1) // span)
+            position, _velocity = trace[index]
+            x = 26 + 12 * position // max(1, g.level["limit"])
+            self.diamond(frame, (x, 44 - wave // 2), 4, VIOLET)
+            self.disc(frame, (32, 45), 8 + wave, GLASS, hollow=True)
+        elif g.anim_kind == "reject":
+            offset = (-2, 2, -1, 1, 0, 1, 0)[min(p, 6)]
+            self.disc(frame, (32 + offset, 45), 8 + wave,
+                      OXBLOOD, hollow=True)
+            self.line(frame, (25, 42 + offset), (39, 48 - offset), INK)
+        elif g.anim_kind == "success":
+            self.disc(frame, (32, 45), 8 + p * 2, MOSS, hollow=True)
+            for index in range(8):
+                x = 32 + ((p + 4) * (-1 if index % 2 else 1))
+                y = 45 + (index - 4) * max(1, p) // 3
+                self.diamond(frame, (x, y), 1, SUN)
+        elif g.anim_kind == "loss":
+            inset = min(20, p * 3)
+            self.line(frame, (5 + inset, 12), (59 - inset, 42), OXBLOOD,
+                      width=2)
+            self.line(frame, (59 - inset, 12), (5 + inset, 42), VIOLET,
+                      width=2)
+        else:
+            self.disc(frame, (32, 45), 8 + wave, PEARL, hollow=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        state = self.game.state
+        self.background(frame)
+        self.schedule(frame, state)
+        self.pool(frame, 0, state.left_trace)
+        self.pool(frame, 1, state.right_trace)
+        self.main_pool(frame, state)
+        self.policies(frame, state)
+        self.animation(frame, state)
+        return frame
+
+
+class Q145(ARCBaseGame):
+    def __init__(self):
+        self.display = TidepoolDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        levels = [
+            Level(sprites=[], grid_size=(64, 64), data=deepcopy(item),
+                  name=item["name"])
+            for item in LEVELS
+        ]
+        super().__init__(
+            "q145", levels,
+            Camera(0, 0, 64, 64, PAPER, PAPER, [self.display]),
+            False, len(levels), [1, 2, 3, 4, 5, 6],
+        )
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+
+    def begin(self, kind, frames, after, budget, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.pending_state = after
+        self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state
+        self.budget_left = self.pending_budget
+        self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        aid = self.action.id.value
+        if aid == 0:
+            self.complete_action()
+            return
+        before = self.state
+        after = transition(self.level, before, aid)
+        if after == before:
+            self.begin("blocked", 5, before, self.budget_left)
+            return
+        cost = action_cost(before, after)
+        budget = self.budget_left - cost
+        won = after.terminal == WIN
+        lost = after.terminal == LOSS or (budget <= 0 and not won)
+        if lost and after.terminal != LOSS:
+            after = after._replace(terminal=LOSS)
+        if won:
+            # Level transitions add one engine frame; seven internal frames
+            # keep the complete response within the 5-9 frame contract.
+            kind, frames, terminal = "success", 7, "win"
+        elif lost:
+            kind, frames, terminal = "loss", 7, "loss"
+        elif after.strikes > before.strikes:
+            kind, frames, terminal = "reject", 7, None
+        elif aid in TEST_ACTIONS:
+            kind, frames, terminal = "probe", 7, None
+        elif aid in (3, 4):
+            kind, frames, terminal = "select", 6, None
+        else:
+            kind, frames, terminal = "preview", 7, None
+        self.begin(kind, frames, after, budget, terminal)

--- a/data/community-games/sonpham/q151_v2_q151.py
+++ b/data/community-games/sonpham/q151_v2_q151.py
@@ -1,0 +1,751 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q151-v2 Daywind Ribbon Atlas.
+
+Transfer highlighted source-graph roles into an independently embedded paper
+fiber network.  Correct ties persist as stitched correspondences; a wrong tie
+or premature launch gives one free diagnostic rewind and a finite second loss.
+Only a complete structural transfer lets one wind action cascade through the
+whole destination route.
+
+The pure helpers expose structural role signatures, transfer progress, large
+consequence size, two causal counterfactuals, and recording action encoding.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+from typing import NamedTuple
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, PEARL, FOG, GRAPHITE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+CORAL, ROSE, RED, SKY, GLASS, SUN = 6, 7, 8, 9, 10, 11
+ORANGE, PLUM, LEAF, VIOLET = 12, 13, 14, 15
+
+ACTIVE, WIN, LOSS = 0, 2, 3
+ROLE_ACTIONS = (1, 2)
+DESTINATION_ACTIONS = (3, 4)
+TIE_ACTION = 5
+CASCADE_ACTION = 6
+
+
+class State(NamedTuple):
+    bound_roles: int
+    role_cursor: int
+    destination_cursor: int
+    cascade_count: int
+    cascade_used: int
+    strikes: int
+    rewind_role: int
+    rewind_destination: int
+    last_event: int
+    terminal: int
+
+
+TERMINAL_INDEX = 9
+
+
+def _navigate(current, target, size, previous_action, next_action):
+    backward = (current - target) % size
+    forward = (target - current) % size
+    if backward <= forward:
+        return (previous_action,) * backward
+    return (next_action,) * forward
+
+
+def _embedding(order, offsets, base_y):
+    count = len(order)
+    points = [None] * count
+    for column, node in enumerate(order):
+        x = 6 if count == 1 else 6 + round(51 * column / (count - 1))
+        points[node] = (x, base_y + offsets[column])
+    return tuple(points)
+
+
+def atlas(name, edges, source_path, mapping, source_offsets,
+          destination_order, destination_offsets, role_start,
+          destination_start, solution, curriculum):
+    node_count = len(mapping)
+    mapping = tuple(int(item) for item in mapping)
+    assert sorted(mapping) == list(range(node_count))
+    source_path = tuple(int(item) for item in source_path)
+    source_edges = tuple(tuple(sorted(edge)) for edge in edges)
+    destination_edges = tuple(
+        tuple(sorted((mapping[a], mapping[b]))) for a, b in source_edges)
+    source_positions = _embedding(tuple(range(node_count)), source_offsets, 17)
+    destination_positions = _embedding(
+        destination_order, destination_offsets, 44)
+
+    actions = []
+    role_cursor = int(role_start)
+    destination_cursor = int(destination_start)
+    for role_index in solution:
+        actions.extend(_navigate(
+            role_cursor, role_index, len(source_path), 1, 2))
+        role_cursor = role_index
+        target = mapping[source_path[role_index]]
+        actions.extend(_navigate(
+            destination_cursor, target, node_count, 3, 4))
+        destination_cursor = target
+        actions.append(5)
+    actions.append(6)
+    return {
+        "name": name,
+        "node_count": node_count,
+        "source_edges": source_edges,
+        "destination_edges": destination_edges,
+        "source_path": source_path,
+        "mapping": mapping,
+        "source_positions": source_positions,
+        "destination_positions": destination_positions,
+        "role_start": int(role_start),
+        "destination_start": int(destination_start),
+        "solution": tuple(int(item) for item in solution),
+        "large_consequence": len(source_path),
+        "budget": len(actions),
+        "witness": tuple(actions),
+        "curriculum": tuple(curriculum),
+    }
+
+
+LEVELS = (
+    atlas(
+        "First Tailwind",
+        ((0, 1), (1, 2)), (0, 1, 2), (2, 0, 1),
+        (0, -5, 2), (1, 2, 0), (3, -4, 1),
+        0, 0, (1, 0, 2),
+        ("paired-embodiments", "role-ties", "whole-route-cascade"),
+    ),
+    atlas(
+        "Forked Pennant",
+        ((0, 1), (1, 2), (1, 3)), (0, 1, 2), (1, 3, 0, 2),
+        (2, -5, 3, -1), (2, 0, 3, 1), (-4, 2, -2, 4),
+        2, 3, (1, 2, 0),
+        ("branch-role", "independent-permutation", "diagnostic-rewind"),
+    ),
+    atlas(
+        "Looping Kites",
+        ((0, 1), (0, 2), (1, 3), (2, 3), (3, 4), (1, 4)),
+        (0, 1, 3, 4), (3, 0, 4, 1, 2),
+        (1, -6, 5, -2, 3), (4, 1, 3, 0, 2), (-5, 4, -1, 3, -3),
+        1, 4, (1, 2, 3, 0),
+        ("cycle-role", "nonmatching-geometry", "four-role-transfer"),
+    ),
+    atlas(
+        "Bent Estuary",
+        ((0, 1), (0, 2), (1, 3), (2, 4), (3, 4), (4, 5)),
+        (0, 2, 4, 5), (2, 5, 1, 4, 0, 3),
+        (4, -5, 0, -7, 5, -1), (3, 0, 5, 1, 4, 2),
+        (-6, 3, -2, 5, -4, 1),
+        3, 5, (2, 1, 0, 3),
+        ("bent-route", "degree-and-neighbor-role", "cascade-preview"),
+    ),
+    atlas(
+        "Crosswind Orchard",
+        ((0, 1), (0, 2), (1, 3), (2, 3), (2, 4), (3, 5), (4, 5)),
+        (0, 2, 4, 5), (4, 1, 5, 0, 3, 2),
+        (0, -7, 4, -2, 6, -4), (2, 5, 1, 4, 0, 3),
+        (5, -3, 2, -6, 4, -1),
+        0, 2, (3, 2, 0, 1),
+        ("crossing-inhibition", "structural-not-geometric-match",
+         "four-role-cascade"),
+    ),
+    atlas(
+        "Seven-Reed Delta",
+        ((0, 1), (0, 2), (1, 3), (2, 4), (3, 4), (3, 5),
+         (4, 6), (5, 6)),
+        (0, 1, 3, 5, 6), (5, 2, 6, 0, 4, 1, 3),
+        (3, -6, 5, -2, 6, -5, 1), (4, 1, 6, 0, 5, 2, 3),
+        (-6, 4, -2, 5, -4, 2, -1),
+        4, 6, (0, 4, 3, 2, 1),
+        ("seven-node-role-transfer", "five-stitch-plan",
+         "large-network-cascade"),
+    ),
+    atlas(
+        "Eight-Sail Weave",
+        ((0, 1), (0, 2), (1, 3), (2, 4), (3, 5), (4, 5),
+         (4, 6), (5, 7), (6, 7)),
+        (0, 2, 4, 6, 7), (6, 1, 4, 7, 0, 5, 2, 3),
+        (1, -7, 5, -3, 6, -5, 3, -1),
+        (5, 2, 7, 1, 6, 0, 4, 3), (-6, 5, -2, 6, -4, 3, -5, 1),
+        2, 7, (2, 3, 4, 1, 0),
+        ("eight-node-field", "crossing-decoys", "five-role-composition",
+         "whole-network-cascade"),
+    ),
+    atlas(
+        "Daywind Ribbon Atlas",
+        ((0, 1), (0, 2), (1, 3), (2, 4), (3, 4), (3, 5),
+         (4, 6), (5, 7), (6, 7), (2, 6)),
+        (0, 1, 3, 5, 7), (4, 7, 1, 5, 0, 2, 6, 3),
+        (4, -6, 2, -7, 6, -3, 4, -1),
+        (3, 6, 1, 7, 0, 5, 2, 4), (-5, 3, -7, 5, -2, 6, -4, 1),
+        1, 6, (1, 2, 0, 4, 3),
+        ("eight-node-synthesis", "independent-embodiments",
+         "five-role-transfer", "diagnostic-rewind",
+         "large-consequence-tailwind"),
+    ),
+)
+
+
+def action_tokens(_level):
+    return (1, 2, 3, 4, 5, 6)
+
+
+def encode_action(_level, action):
+    aid = int(action[0]) if isinstance(action, (tuple, list)) else int(action)
+    return (aid,)
+
+
+def start_state(level):
+    return State(
+        0, level["role_start"], level["destination_start"],
+        0, 0, 0, -1, -1, 0, ACTIVE,
+    )
+
+
+def _adjacency(edges, node_count):
+    result = [[] for _ in range(node_count)]
+    for a, b in edges:
+        result[a].append(b)
+        result[b].append(a)
+    return tuple(tuple(sorted(items)) for items in result)
+
+
+def _distances(adjacency, start):
+    values = [-1] * len(adjacency)
+    values[start] = 0
+    frontier = [start]
+    for node in frontier:
+        for neighbor in adjacency[node]:
+            if values[neighbor] < 0:
+                values[neighbor] = values[node] + 1
+                frontier.append(neighbor)
+    return tuple(values)
+
+
+def role_signature(level, state_or_node):
+    """Return a non-positional rooted graph signature for a source role.
+
+    ``State`` selects its current source-path role.  An integer names a source
+    node.  ``("destination", node)`` names a destination node, allowing an
+    evaluator to compare corresponding signatures across embodiments.
+    """
+    destination = False
+    if isinstance(state_or_node, State):
+        node = level["source_path"][state_or_node.role_cursor]
+    elif isinstance(state_or_node, (tuple, list)):
+        destination = str(state_or_node[0]).lower().startswith("d")
+        node = int(state_or_node[1])
+    else:
+        node = int(state_or_node)
+    edges = (level["destination_edges"] if destination
+             else level["source_edges"])
+    adjacency = _adjacency(edges, level["node_count"])
+    start = (level["mapping"][level["source_path"][0]] if destination
+             else level["source_path"][0])
+    goal = (level["mapping"][level["source_path"][-1]] if destination
+            else level["source_path"][-1])
+    distances = _distances(adjacency, node)
+    degree_profile = tuple(sorted(
+        (distances[index], len(adjacency[index]))
+        for index in range(level["node_count"])))
+    return (
+        len(adjacency[node]),
+        tuple(sorted(len(adjacency[n]) for n in adjacency[node])),
+        _distances(adjacency, start)[node],
+        _distances(adjacency, goal)[node],
+        degree_profile,
+    )
+
+
+def expected_destination(level, role_index):
+    return level["mapping"][level["source_path"][int(role_index)]]
+
+
+def transfer_progress(_level, state):
+    return state.bound_roles.bit_count()
+
+
+def transfer_complete(level, state):
+    return transfer_progress(level, state) == len(level["source_path"])
+
+
+def large_consequence_count(_level, before, action, after):
+    aid = int(action[0]) if isinstance(action, (tuple, list)) else int(action)
+    if aid != CASCADE_ACTION:
+        return 0
+    return max(0, after.cascade_count - before.cascade_count)
+
+
+def solved(_level, state):
+    return state.terminal == WIN
+
+
+def _strike(level, state, event, destination=-1):
+    strikes = state.strikes + 1
+    missing = (state.role_cursor if event == TIE_ACTION else next(
+        (index for index in range(len(level["source_path"]))
+         if not state.bound_roles & (1 << index)),
+        state.role_cursor,
+    ))
+    return state._replace(
+        strikes=strikes,
+        rewind_role=missing,
+        rewind_destination=int(destination),
+        last_event=event,
+        terminal=LOSS if strikes >= 2 else ACTIVE,
+    )
+
+
+def _transition(level, state, action, mode="normal"):
+    if state.terminal != ACTIVE:
+        return state
+    aid = int(action[0]) if isinstance(action, (tuple, list)) else int(action)
+    if aid not in action_tokens(level):
+        return state
+
+    if aid in ROLE_ACTIONS:
+        delta = -1 if aid == 1 else 1
+        cursor = (state.role_cursor + delta) % len(level["source_path"])
+        return state._replace(
+            role_cursor=cursor,
+            rewind_role=-1,
+            rewind_destination=-1,
+            last_event=aid,
+        )
+
+    if aid in DESTINATION_ACTIONS:
+        delta = -1 if aid == 3 else 1
+        cursor = (state.destination_cursor + delta) % level["node_count"]
+        return state._replace(
+            destination_cursor=cursor,
+            rewind_role=-1,
+            rewind_destination=-1,
+            last_event=aid,
+        )
+
+    if aid == TIE_ACTION:
+        bit = 1 << state.role_cursor
+        if state.bound_roles & bit:
+            return state
+        expected = expected_destination(level, state.role_cursor)
+        if state.destination_cursor != expected:
+            return _strike(
+                level, state, TIE_ACTION, state.destination_cursor)
+        if mode == "without_role_transfer":
+            return state._replace(
+                rewind_role=state.role_cursor,
+                rewind_destination=state.destination_cursor,
+                last_event=TIE_ACTION,
+            )
+        return state._replace(
+            bound_roles=state.bound_roles | bit,
+            rewind_role=-1,
+            rewind_destination=-1,
+            last_event=TIE_ACTION,
+        )
+
+    if not transfer_complete(level, state):
+        return _strike(level, state, CASCADE_ACTION)
+    if state.cascade_used:
+        return state
+    if mode == "without_large_consequence":
+        return state._replace(
+            cascade_count=1,
+            cascade_used=1,
+            last_event=CASCADE_ACTION,
+        )
+    return state._replace(
+        cascade_count=level["large_consequence"],
+        cascade_used=1,
+        last_event=CASCADE_ACTION,
+        terminal=WIN,
+    )
+
+
+def transition(level, state, action):
+    return _transition(level, state, action, "normal")
+
+
+def without_large_consequence(level, state, action):
+    return _transition(level, state, action, "without_large_consequence")
+
+
+def without_role_transfer(level, state, action):
+    return _transition(level, state, action, "without_role_transfer")
+
+
+def action_cost(before, after):
+    if before == after:
+        return 0
+    if after.strikes > before.strikes:
+        return 0
+    return 1
+
+
+def execute(level, actions, transition_fn=transition):
+    state = start_state(level)
+    budget = level["budget"]
+    for action in actions:
+        after = transition_fn(level, state, action)
+        budget -= action_cost(state, after)
+        state = after
+    return state, budget
+
+
+for _level in LEVELS:
+    _end, _left = execute(_level, _level["witness"])
+    assert solved(_level, _end) and _left == 0, (_level["name"], _end, _left)
+    for _role in range(len(_level["source_path"])):
+        _source = _level["source_path"][_role]
+        _destination = expected_destination(_level, _role)
+        assert role_signature(_level, _source) == role_signature(
+            _level, ("destination", _destination))
+
+
+class AtlasDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def pixel(frame, x, y, color):
+        if 0 <= x < 64 and 0 <= y < 64:
+            frame[y, x] = color
+
+    @classmethod
+    def line(cls, frame, start, end, color, dotted=False, width=1):
+        x0, y0 = start
+        x1, y1 = end
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 4 in (1, 2):
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            for offset in range(width):
+                cls.pixel(frame, x, y + offset, color)
+
+    @classmethod
+    def disc(cls, frame, center, radius, color, hollow=False):
+        cx, cy = center
+        inner = max(0, radius - 1) ** 2
+        for y in range(cy - radius, cy + radius + 1):
+            for x in range(cx - radius, cx + radius + 1):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius ** 2 and (not hollow or distance >= inner):
+                    cls.pixel(frame, x, y, color)
+
+    @classmethod
+    def diamond(cls, frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for dy in range(-radius, radius + 1):
+            reach = radius - abs(dy)
+            if hollow:
+                cls.pixel(frame, cx - reach, cy + dy, color)
+                cls.pixel(frame, cx + reach, cy + dy, color)
+            else:
+                for x in range(cx - reach, cx + reach + 1):
+                    cls.pixel(frame, x, cy + dy, color)
+
+    @classmethod
+    def triangle(cls, frame, center, radius, color, invert=False,
+                 hollow=False):
+        cx, cy = center
+        for step in range(radius + 1):
+            reach = step
+            y = cy + (radius - step if invert else step - radius)
+            if hollow:
+                cls.pixel(frame, cx - reach, y, color)
+                cls.pixel(frame, cx + reach, y, color)
+            else:
+                for x in range(cx - reach, cx + reach + 1):
+                    cls.pixel(frame, x, y, color)
+
+    def background(self, frame):
+        frame[:, :] = PAPER
+        frame[5:29, :] = GLASS
+        frame[33:56, :] = PEARL
+        for x in range(0, 64, 8):
+            self.line(frame, (x, 30 + (x // 8) % 2),
+                      (min(63, x + 5), 30), SKY, dotted=True)
+        for x, y in ((3, 9), (18, 27), (40, 8), (59, 25), (9, 48), (51, 40)):
+            self.pixel(frame, x, y, FOG)
+
+    def graph(self, frame, edges, positions, color, highlighted=()):
+        marked = {frozenset(edge) for edge in highlighted}
+        for a, b in edges:
+            edge = frozenset((a, b))
+            edge_color = SUN if edge in marked else color
+            self.line(frame, positions[a], positions[b], edge_color,
+                      dotted=edge not in marked, width=2 if edge in marked else 1)
+            if edge in marked:
+                midpoint = ((positions[a][0] + positions[b][0]) // 2,
+                            (positions[a][1] + positions[b][1]) // 2)
+                self.diamond(frame, midpoint, 1, PAPER)
+
+    def node(self, frame, point, degree, color, role_mark=False,
+             bound=False):
+        if degree <= 1:
+            self.triangle(frame, point, 3, color, hollow=True)
+        elif degree == 2:
+            self.diamond(frame, point, 3, color, hollow=True)
+        elif degree == 3:
+            self.disc(frame, point, 3, color, hollow=True)
+        else:
+            x, y = point
+            self.line(frame, (x - 3, y), (x + 3, y), color, width=2)
+            self.line(frame, (x, y - 3), (x, y + 3), color, width=2)
+        if role_mark:
+            self.pixel(frame, point[0], point[1], INK)
+        if bound:
+            x, y = point
+            self.line(frame, (x - 2, y - 2), (x + 2, y + 2), CORAL)
+            self.line(frame, (x + 2, y - 2), (x - 2, y + 2), CORAL)
+
+    def field(self, frame, state):
+        level = self.game.level
+        source_adjacency = _adjacency(
+            level["source_edges"], level["node_count"])
+        destination_adjacency = _adjacency(
+            level["destination_edges"], level["node_count"])
+        path_edges = tuple(zip(level["source_path"], level["source_path"][1:]))
+        self.graph(frame, level["source_edges"], level["source_positions"],
+                   SKY, path_edges)
+        self.graph(frame, level["destination_edges"],
+                   level["destination_positions"], GRAPHITE)
+        for node, point in enumerate(level["source_positions"]):
+            self.node(frame, point, len(source_adjacency[node]),
+                      SUN if node in level["source_path"] else SKY,
+                      role_mark=node in level["source_path"])
+        for node, point in enumerate(level["destination_positions"]):
+            bound = any(
+                state.bound_roles & (1 << role)
+                and expected_destination(level, role) == node
+                for role in range(len(level["source_path"])))
+            self.node(frame, point, len(destination_adjacency[node]),
+                      LEAF if bound else GRAPHITE, bound=bound)
+
+        source_node = level["source_path"][state.role_cursor]
+        source_point = level["source_positions"][source_node]
+        destination_point = level["destination_positions"][
+            state.destination_cursor]
+        self.disc(frame, source_point, 5, INK, hollow=True)
+        self.diamond(frame, destination_point, 5, VIOLET, hollow=True)
+
+        for role in range(len(level["source_path"])):
+            if not state.bound_roles & (1 << role):
+                continue
+            a = level["source_positions"][level["source_path"][role]]
+            b = level["destination_positions"][expected_destination(level, role)]
+            self.line(frame, a, (a[0], 30), CORAL, dotted=True)
+            self.line(frame, (a[0], 30), (b[0], 32), CORAL, dotted=True)
+            self.line(frame, (b[0], 32), b, CORAL, dotted=True)
+
+        start_destination = expected_destination(level, 0)
+        goal_destination = expected_destination(
+            level, len(level["source_path"]) - 1)
+        self.triangle(frame, level["destination_positions"][start_destination],
+                      5, SKY, hollow=True)
+        self.disc(frame, level["destination_positions"][goal_destination],
+                  5, SUN, hollow=True)
+
+    def hud(self, frame, state):
+        game = self.game
+        # Non-text control legend in the paper horizon: paired round arrows
+        # select source roles (1/2), paired diamond arrows select destination
+        # nodes (3/4), a vertical stitch ties (5), and a wind star launches (6).
+        frame[28:33, 37:64] = PAPER
+        self.disc(frame, (41, 30), 2, INK, hollow=True)
+        self.pixel(frame, 38, 30, INK)
+        self.pixel(frame, 44, 30, INK)
+        self.diamond(frame, (49, 30), 2, VIOLET, hollow=True)
+        self.pixel(frame, 46, 30, VIOLET)
+        self.pixel(frame, 52, 30, VIOLET)
+        self.disc(frame, (56, 29), 1, INK, hollow=True)
+        self.diamond(frame, (56, 32), 1, VIOLET, hollow=True)
+        self.line(frame, (56, 29), (56, 32), CORAL, dotted=True)
+        self.line(frame, (59, 30), (63, 30), SUN)
+        self.line(frame, (61, 28), (61, 32), SUN)
+        self.diamond(frame, (61, 30), 1, SKY)
+        # One leaf-shaped diamond per exact remaining action.
+        for index in range(game.budget_max):
+            row, column = divmod(index, 20)
+            center = (3 + column * 3, 59 + row * 3)
+            self.diamond(frame, center, 1,
+                         SUN if index < game.budget_left else FOG,
+                         hollow=index >= game.budget_left)
+        # Route roles are exact countable pennants; stitched roles turn solid.
+        count = len(game.level["source_path"])
+        for role in range(count):
+            x = 4 + role * 5
+            self.triangle(frame, (x, 3), 1,
+                          LEAF if state.bound_roles & (1 << role) else GRAPHITE,
+                          hollow=not bool(state.bound_roles & (1 << role)))
+        # Paired diagnostic seals expose free first rewind and finite second loss.
+        for index, y in enumerate((42, 49)):
+            cracked = index < state.strikes
+            self.disc(frame, (61, y), 2, RED if cracked else SKY,
+                      hollow=not cracked)
+            if cracked:
+                self.line(frame, (60, y - 1), (62, y + 1), PAPER)
+
+    def animation(self, frame, state):
+        game = self.game
+        if not game.anim_kind:
+            return
+        before = game.state
+        after = game.pending_state
+        p = game.anim_progress
+        span = max(1, game.anim_total - 1)
+        wave = min(p, span - p)
+        level = game.level
+        if game.anim_kind in ("role_cursor", "destination_cursor"):
+            if game.anim_kind == "role_cursor":
+                points = level["source_positions"]
+                old = level["source_path"][before.role_cursor]
+                new = level["source_path"][after.role_cursor]
+            else:
+                points = level["destination_positions"]
+                old = before.destination_cursor
+                new = after.destination_cursor
+            a, b = points[old], points[new]
+            moving = (a[0] + (b[0] - a[0]) * p // span,
+                      a[1] + (b[1] - a[1]) * p // span)
+            self.line(frame, a, moving, CORAL, dotted=True)
+            self.diamond(frame, moving, 2 + wave // 2, SUN)
+        elif game.anim_kind == "tie":
+            a = level["source_positions"][
+                level["source_path"][before.role_cursor]]
+            b = level["destination_positions"][before.destination_cursor]
+            midpoint = (a[0] + (b[0] - a[0]) * p // span,
+                        a[1] + (b[1] - a[1]) * p // span)
+            self.line(frame, a, midpoint, CORAL, dotted=p % 2 == 0, width=2)
+            self.disc(frame, midpoint, 2 + wave // 2, SUN, hollow=True)
+        elif game.anim_kind == "diagnostic":
+            offset = (-2, 2, -1, 1, 0, 1, 0)[min(p, 6)]
+            self.line(frame, (7, 30 + offset), (57, 30 - offset), RED,
+                      dotted=True, width=2)
+            self.diamond(frame, (32, 30), 4 + wave, CORAL, hollow=True)
+        elif game.anim_kind == "cascade":
+            destination_path = tuple(
+                level["mapping"][node] for node in level["source_path"])
+            for index, (a, b) in enumerate(zip(
+                    destination_path, destination_path[1:])):
+                if index > p * len(destination_path) // max(1, span):
+                    continue
+                start = level["destination_positions"][a]
+                end = level["destination_positions"][b]
+                self.line(frame, start, end, SUN, width=2)
+                step = min(span, max(0, p - index))
+                moving = (start[0] + (end[0] - start[0]) * step // span,
+                          start[1] + (end[1] - start[1]) * step // span)
+                self.diamond(frame, moving, 2 + wave // 2, CORAL)
+            self.disc(frame, (32, 31), 3 + p, SKY, hollow=True)
+        elif game.anim_kind == "loss":
+            inset = min(24, p * 4)
+            self.line(frame, (inset, 5), (63 - inset, 55), RED, width=2)
+            self.line(frame, (63 - inset, 5), (inset, 55), PLUM, width=2)
+        else:
+            self.disc(frame, (32, 31), 4 + wave, FOG, hollow=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        state = self.game.state
+        self.background(frame)
+        self.field(frame, state)
+        self.hud(frame, state)
+        self.animation(frame, state)
+        return frame
+
+
+class Q151(ARCBaseGame):
+    def __init__(self):
+        self.display = AtlasDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        levels = [
+            Level(sprites=[], grid_size=(64, 64), data=deepcopy(item),
+                  name=item["name"])
+            for item in LEVELS
+        ]
+        super().__init__(
+            "q151", levels,
+            Camera(0, 0, 64, 64, PAPER, PAPER, [self.display]),
+            False, len(levels), [1, 2, 3, 4, 5, 6],
+        )
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+
+    def begin(self, kind, frames, after, budget, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.pending_state = after
+        self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state
+        self.budget_left = self.pending_budget
+        self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        aid = self.action.id.value
+        if aid == 0:
+            self.complete_action()
+            return
+        before = self.state
+        after = transition(self.level, before, aid)
+        if after == before:
+            self.begin("blocked", 5, before, self.budget_left)
+            return
+        cost = action_cost(before, after)
+        budget = self.budget_left - cost
+        won = after.terminal == WIN
+        lost = after.terminal == LOSS or (budget <= 0 and not won)
+        if lost and after.terminal != LOSS:
+            after = after._replace(terminal=LOSS)
+        if won:
+            kind, frames, terminal = "cascade", 7, "win"
+        elif lost:
+            kind, frames, terminal = "loss", 6, "loss"
+        elif after.strikes > before.strikes:
+            kind, frames, terminal = "diagnostic", 7, None
+        elif aid in ROLE_ACTIONS:
+            kind, frames, terminal = "role_cursor", 6, None
+        elif aid in DESTINATION_ACTIONS:
+            kind, frames, terminal = "destination_cursor", 6, None
+        elif aid == TIE_ACTION:
+            kind, frames, terminal = "tie", 7, None
+        else:
+            kind, frames, terminal = "blocked", 5, None
+        self.begin(kind, frames, after, budget, terminal)

--- a/data/community-games/sonpham/q155_v2_q155.py
+++ b/data/community-games/sonpham/q155_v2_q155.py
@@ -1,0 +1,333 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q155-v2 Echo Council -- transfer one visible relation across strange roles.
+
+The upper gallery demonstrates a transformation on simple emblems.  The lower
+council asks for the matching embodied role.  Turns, marked soloists, duets,
+and a passed baton compose the same relation without language or digits.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, PEARL, MIST, ASH, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, AQUA, SUN, CORAL, EARTH, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+TWIST, MARKED, DUET, RELAY = 1, 2, 4, 8
+
+
+LEVELS = [
+    {"name": "Four Echoes", "axis": 0, "turn": 0, "emblem_roles": True,
+     "queries": ((0, 0, 0), (1, 0, 0), (3, 0, 0), (2, 0, 0))},
+    {"name": "New Masks", "axis": 1, "turn": 0, "emblem_roles": False,
+     "queries": ((0, 0, 0), (2, 0, 0), (1, 0, 0), (3, 0, 0),
+                 (2, 0, 0), (0, 0, 0), (3, 0, 0), (1, 0, 0), (2, 0, 0))},
+    {"name": "Turning Chorus", "axis": 2, "turn": 1, "emblem_roles": False,
+     "queries": ((0, 0, 0), (1, TWIST, 0), (3, 0, 0), (2, TWIST, 0),
+                 (1, 0, 0), (0, TWIST, 0), (2, 0, 0), (3, TWIST, 0), (1, TWIST, 0))},
+    {"name": "Marked Soloists", "axis": 3, "turn": 0,
+     "queries": ((0, 0, 0), (1, MARKED, 0), (2, 0, 0), (3, MARKED, 0),
+                 (0, MARKED, 0), (2, MARKED, 0), (1, 0, 0), (3, 0, 0), (2, 0, 0))},
+    {"name": "Duet Relation", "axis": 1, "turn": 0,
+     "queries": ((0, DUET, 1), (2, DUET, 3), (1, DUET, 1), (3, DUET, 0),
+                 (2, DUET, 0), (1, DUET, 3), (0, DUET, 2), (3, DUET, 2), (1, DUET, 0))},
+    {"name": "Passing Baton", "axis": 2, "turn": 0,
+     "queries": ((0, RELAY, 0), (1, RELAY, 0), (3, RELAY, 0), (2, RELAY, 0),
+                 (0, RELAY, 0), (2, RELAY, 0), (1, RELAY, 0), (3, RELAY, 0), (2, RELAY, 0))},
+    {"name": "Festival Round", "axis": 0, "turn": 1,
+     "queries": ((0, TWIST, 0), (1, MARKED, 0), (2, TWIST | DUET, 3),
+                 (3, MARKED | DUET, 1), (1, TWIST | MARKED, 0),
+                 (0, DUET, 2), (3, TWIST | MARKED | DUET, 2),
+                 (2, MARKED, 0), (1, TWIST | DUET, 0), (0, TWIST | MARKED, 0))},
+    {"name": "Echo Council", "axis": 3, "turn": 1,
+     "queries": ((0, TWIST | RELAY, 0), (1, MARKED | RELAY, 0),
+                 (2, DUET | RELAY, 3), (3, TWIST | MARKED | RELAY, 0),
+                 (1, TWIST | DUET | RELAY, 0), (0, MARKED | DUET | RELAY, 2),
+                 (3, TWIST | MARKED | DUET | RELAY, 1), (2, RELAY, 0),
+                 (1, TWIST | MARKED | RELAY, 0), (0, DUET | RELAY, 3))},
+]
+
+
+def start_state(_level):
+    return 0, 2, 0
+
+
+def answer(level, query, last):
+    shape, flags, partner = query
+    value = (level["axis"] - shape) % 4
+    if flags & TWIST:
+        value = (value + level["turn"]) % 4
+    if flags & MARKED:
+        value = (-value) % 4
+    if flags & DUET:
+        value = (value + (level["axis"] - partner)) % 4
+    if flags & RELAY:
+        value = (value + last) % 4
+    return value + 1
+
+
+def transition(level, state, action):
+    progress, chances, last = state
+    if action not in (1, 2, 3, 4) or progress >= len(level["queries"]):
+        return state
+    if action == answer(level, level["queries"][progress], last):
+        return progress + 1, chances, action - 1
+    return progress, chances - 1, last
+
+
+def solved(level, state):
+    return state[0] == len(level["queries"])
+
+
+class CouncilDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def _disc(frame, center, radius, color):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                if (x - cx) ** 2 + (y - cy) ** 2 <= radius ** 2:
+                    frame[y, x] = color
+
+    @staticmethod
+    def _line(frame, a, b, color, dotted=False):
+        x0, y0 = a
+        x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    def _background(self, frame):
+        frame[:, :] = PAPER
+        self._disc(frame, (32, 32), 29, PEARL)
+        self._disc(frame, (32, 32), 25, MIST)
+        for x, y in ((7, 8), (56, 9), (5, 39), (59, 36), (12, 58), (50, 57)):
+            self._disc(frame, (x, y), 3, ROSE)
+            self._disc(frame, (x, y), 1, SUN)
+        for radius in (19, 23):
+            for x, y in ((32, 32 - radius), (32 + radius, 32), (32, 32 + radius), (32 - radius, 32)):
+                self._disc(frame, (x, y), 1, VIOLET)
+
+    def _emblem(self, frame, shape, center, scale=1, color=VIOLET):
+        x, y = center
+        r = 2 * scale
+        if shape == 0:
+            self._disc(frame, center, r, color)
+            self._disc(frame, center, max(0, r - scale), PAPER)
+        elif shape == 1:
+            for dy in range(-r, r + 1):
+                span = r - abs(dy)
+                frame[y + dy, x - span:x + span + 1] = color
+        elif shape == 2:
+            for row in range(2 * r + 1):
+                span = row
+                frame[y - r + row, x - span // 2:x + span // 2 + 1] = color
+        else:
+            frame[y - r:y + r + 1, x] = color
+            frame[y, x - r:x + r + 1] = color
+
+    def _role(self, frame, role, center, scale=1, color=None):
+        x, y = center
+        colors = (AQUA, CORAL, GREEN, MAGENTA)
+        color = colors[role] if color is None else color
+        if role == 0:
+            self._disc(frame, (x, y), 3 * scale, color)
+            self._disc(frame, (x, y), scale, PAPER)
+            frame[y - 5 * scale:y - 3 * scale, x] = color
+        elif role == 1:
+            for dy in range(-3 * scale, 3 * scale + 1):
+                span = 3 * scale - abs(dy)
+                frame[y + dy, x - span:x + span + 1] = color
+            frame[y, x - 5 * scale:x + 6 * scale:2 * scale] = color
+        elif role == 2:
+            for row in range(6 * scale + 1):
+                span = row
+                frame[y - 3 * scale + row, x - span // 2:x + span // 2 + 1] = color
+            frame[y - scale:y + 2 * scale, x - 5 * scale:x + 6 * scale:3 * scale] = color
+        else:
+            frame[y - 3 * scale:y + 4 * scale, x - 3 * scale:x + 4 * scale] = color
+            frame[y - 5 * scale:y + 6 * scale, x] = PAPER
+            frame[y, x - 5 * scale:x + 6 * scale] = PAPER
+
+    def _output(self, frame, role, center, scale=1, color=None):
+        if self.game.level.get("emblem_roles"):
+            self._emblem(frame, role, center, scale, VIOLET if color is None else color)
+        else:
+            self._role(frame, role, center, scale, color)
+
+    def _query(self, frame, query, center, last, small=False):
+        shape, flags, partner = query
+        x, y = center
+        scale = 1
+        self._emblem(frame, shape, center, scale, VIOLET)
+        if flags & TWIST:
+            for dx, dy in ((0, -6), (6, 0), (0, 6), (-6, 0)):
+                frame[y + dy, x + dx] = BLUE
+            self._line(frame, (x - 5, y - 5), (x + 5, y - 5), BLUE, dotted=True)
+        if flags & MARKED:
+            frame[y - 7:y - 5, x - 5:x + 6:2] = INK
+            frame[y + 5:y + 7, x - 5:x + 6:2] = INK
+        if flags & DUET:
+            self._emblem(frame, partner, (x + (8 if not small else 6), y + 3), 1, CORAL)
+            self._line(frame, (x + 3, y), (x + 6, y + 2), GREEN, dotted=True)
+        if flags & RELAY:
+            self._role(frame, last, (x - (9 if not small else 7), y + 2), 1, SUN)
+            self._line(frame, (x - 6, y + 1), (x - 3, y), SUN, dotted=True)
+
+    def _examples(self, frame):
+        g = self.game
+        last = 0
+        for index, query in enumerate(g.level["queries"][:3]):
+            x = 12 + index * 20
+            self._disc(frame, (x, 10), 7, PAPER)
+            self._query(frame, query, (x - 3, 10), last, small=True)
+            role = answer(g.level, query, last) - 1
+            self._output(frame, role, (x + 5, 10), 1)
+            self._line(frame, (x, 4), (x, 16), ASH, dotted=True)
+            last = role
+
+    def _council(self, frame):
+        g = self.game
+        if not solved(g.level, g.state):
+            query = g.level["queries"][g.state[0]]
+            self._disc(frame, (32, 31), 13, PAPER)
+            self._disc(frame, (32, 31), 10, PEARL)
+            self._query(frame, query, (32, 31), g.state[2])
+        positions = ((9, 52), (24, 55), (40, 55), (55, 52))
+        for role, center in enumerate(positions):
+            self._disc(frame, center, 7, PAPER)
+            self._output(frame, role, center)
+        total = len(g.level["queries"])
+        for index in range(total):
+            x = 8 + index * 48 // max(1, total - 1)
+            if index < g.state[0]:
+                self._disc(frame, (x, 43), 2, GREEN)
+            elif index == g.state[0]:
+                for dx, dy in ((0, -2), (2, 0), (0, 2), (-2, 0)):
+                    frame[43 + dy, x + dx] = VIOLET
+            else:
+                frame[43, x] = ASH
+        for chance in range(2):
+            x = 29 + chance * 6
+            if chance < g.state[1]:
+                self._disc(frame, (x, 19), 2, ROSE)
+                frame[17:22, x] = PAPER
+            else:
+                self._line(frame, (x - 2, 17), (x + 2, 21), RED)
+                self._line(frame, (x + 2, 17), (x - 2, 21), RED)
+
+    def _animation(self, frame):
+        g = self.game
+        if g.intro_mark:
+            for x in range(8, 59, 5):
+                self._disc(frame, (x, 3), 1, SUN)
+        if g.terminal_hold == "win":
+            for role, center in enumerate(((32, 14), (49, 31), (32, 48), (15, 31))):
+                self._role(frame, role, center)
+            for radius, color in ((13, ROSE), (8, SUN), (3, PAPER)):
+                self._disc(frame, (32, 31), radius, color)
+        elif g.terminal_hold == "loss":
+            frame[8:57:3, 5:60] = RED
+            frame[8:57, 5:60:4] = CHARCOAL
+        if not g.anim_kind:
+            return
+        p = g.anim_progress
+        if g.anim_kind == "correct":
+            start = ((9, 52), (24, 55), (40, 55), (55, 52))[g.anim_action - 1]
+            x = start[0] + (32 - start[0]) * p // g.anim_total
+            y = start[1] + (31 - start[1]) * p // g.anim_total
+            self._output(frame, g.anim_action - 1, (x, y))
+            self._disc(frame, (32, 31), min(9, 2 + p), SUN)
+        elif g.anim_kind == "wrong":
+            offset = -2 if p % 2 else 2
+            self._output(frame, g.anim_action - 1, (32 + offset, 31), color=RED)
+            frame[22 + p:41 - p:3, 23:42] = RED
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self._background(frame)
+        self._examples(frame)
+        self._council(frame)
+        self._animation(frame)
+        return frame
+
+
+class Q155(ARCBaseGame):
+    def __init__(self):
+        self.display = CouncilDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_action = 1
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q155", levels, Camera(0, 0, 64, 64, PAPER, PAPER, [self.display]),
+                         False, len(levels), [1, 2, 3, 4])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_action = 1
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+
+    def _begin(self, kind, action, next_state, terminal=None):
+        self.anim_kind = kind
+        self.anim_action = action
+        self.anim_total = self.anim_left = 6
+        self.anim_progress = 0
+        self.pending_state = next_state
+        self.pending_terminal = terminal
+
+    def _finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state
+        self.anim_kind = None
+        self.pending_state = None
+        self.pending_terminal = None
+        if terminal == "win":
+            self.terminal_hold = "win"
+            self.next_level()
+        elif terminal == "loss":
+            self.terminal_hold = "loss"
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self._finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        self.intro_mark = False
+        after = transition(self.level, self.state, action)
+        correct = after[0] > self.state[0]
+        terminal = "win" if solved(self.level, after) else "loss" if after[1] <= 0 else None
+        self._begin("correct" if correct else "wrong", action, after, terminal)

--- a/data/community-games/sonpham/q161_v2_q161.py
+++ b/data/community-games/sonpham/q161_v2_q161.py
@@ -1,0 +1,777 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q161-v2 Velvet Probability Planetarium.
+
+The player chooses among visibly partitioned comet lenses.  A charged probe
+collapses every incompatible constellation on the deterministic side that
+contains the concealed answer.  The golden claim aperture opens only when
+exactly one hypothesis survives and the spotlight rests on it.  Probing or
+claiming past that stopping condition produces one recoverable warning and a
+finite second failure.
+
+Pure hashable helpers expose partition choice, large-consequence elimination,
+singleton stopping, counterfactual mutations, and recording action encoding.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+from typing import NamedTuple
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, MIST, ASH, SLATE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, PINK, RED, SKY, GLASS, GOLD = 6, 7, 8, 9, 10, 11
+AMBER, VELVET, MOSS, VIOLET = 12, 13, 14, 15
+
+ACTIVE, WIN, LOSS = 0, 2, 3
+PROBE_ACTIONS = (5,)
+
+
+class State(NamedTuple):
+    survivors: int
+    probe_cursor: int
+    hypothesis_cursor: int
+    used_probes: int
+    charge: int
+    evidence_left: int
+    strikes: int
+    last_eliminated: int
+    last_event: int
+    terminal: int
+
+
+TERMINAL_INDEX = 9
+
+
+def probe(mask, cost=1, *, requires=0, excludes=0):
+    return {
+        "mask": int(mask),
+        "cost": int(cost),
+        "requires": int(requires),
+        "excludes": int(excludes),
+    }
+
+
+def _navigate(current, target, size, previous_action, next_action):
+    backward = (current - target) % size
+    forward = (target - current) % size
+    if backward <= forward:
+        return (previous_action,) * backward
+    return (next_action,) * forward
+
+
+def planetarium(name, n, answer, probes, solution, evidence_budget,
+                large_elimination, curriculum, budget_slack=0):
+    probes = tuple(dict(item) for item in probes)
+    actions = []
+    cursor = 0
+    for target in solution:
+        actions.extend(_navigate(cursor, target, len(probes), 1, 2))
+        cursor = target
+        actions.extend((5,) * probes[target]["cost"])
+    actions.extend(_navigate(0, answer, n, 3, 4))
+    actions.append(6)
+    return {
+        "name": name,
+        "n": int(n),
+        "answer": int(answer),
+        "probes": probes,
+        "solution": tuple(solution),
+        "evidence_budget": int(evidence_budget),
+        "large_elimination": int(large_elimination),
+        "budget": len(actions) + int(budget_slack),
+        "budget_slack": int(budget_slack),
+        "witness": tuple(actions),
+        "curriculum": tuple(curriculum),
+    }
+
+
+LEVELS = (
+    planetarium(
+        "First Aperture", 3, 2,
+        (
+            probe(0b011, 1),
+            probe(0b101, 2),
+        ),
+        (0,), 1, 2,
+        ("one-visible-partition", "one-probe-large-collapse",
+         "singleton-claim"),
+    ),
+    planetarium(
+        "Charged Pair", 4, 1,
+        (
+            probe(0b0011, 2),
+            probe(0b0101, 3),
+            probe(0b0110, 2),
+            probe(0b1001, 3),
+        ),
+        (0, 2), 4, 2,
+        ("chosen-probes", "two-step-comet-charge", "overlapping-partitions",
+         "singleton-claim"),
+    ),
+    planetarium(
+        "Overlapping Orbits", 5, 4,
+        (
+            probe(0b10011, 2),
+            probe(0b11111, 3),
+            probe(0b11101, 2, requires=1 << 0),
+            probe(0b11111, 3),
+            probe(0b10110, 2, requires=1 << 2),
+        ),
+        (0, 2, 4), 6, 2,
+        ("three-way-overlap", "probe-order-planning", "charge",
+         "large-collapse", "singleton-claim"),
+    ),
+    planetarium(
+        "Nested Lens", 6, 2,
+        (
+            probe(0b001111, 2),
+            probe(0b111111, 2),
+            probe(0b110101, 2, requires=1 << 0),
+            probe(0b111111, 2),
+            probe(0b010110, 2, requires=1 << 2),
+            probe(0b111111, 2),
+        ),
+        (0, 2, 4), 6, 2,
+        ("dependency-ring", "nested-partitions", "charge",
+         "large-collapse", "singleton-claim"),
+    ),
+    planetarium(
+        "Weighted Comets", 6, 5,
+        (
+            probe(0b101011, 3),
+            probe(0b111111, 3),
+            probe(0b110101, 2, requires=1 << 0),
+            probe(0b111111, 3),
+            probe(0b100110, 1, requires=1 << 2),
+            probe(0b111111, 3),
+        ),
+        (0, 2, 4), 6, 2,
+        ("heterogeneous-visible-cost", "evidence-budget-planning",
+         "overlap", "large-collapse", "singleton-claim"),
+    ),
+    planetarium(
+        "Forked Ephemeris", 7, 3,
+        (
+            probe(0b0011011, 2),
+            probe(0b1101111, 1, excludes=1 << 4),
+            probe(0b0101101, 2, requires=1 << 0),
+            probe(0b1111111, 3),
+            probe(0b1001110, 2, requires=1 << 2),
+            probe(0b1111111, 3),
+        ),
+        (0, 2, 4), 7, 3,
+        ("exclusive-probe-branch", "visible-lockout", "dependency-planning",
+         "cost", "large-collapse", "singleton-claim"),
+        budget_slack=1,
+    ),
+    planetarium(
+        "Eightfold Transit", 8, 6,
+        (
+            probe(0b01001011, 2),
+            probe(0b11110111, 1, excludes=1 << 4),
+            probe(0b01010101, 2, requires=1 << 0),
+            probe(0b11111111, 3),
+            probe(0b11100110, 2, requires=1 << 2),
+            probe(0b11111111, 3),
+        ),
+        (0, 2, 4), 7, 4,
+        ("eight-hypothesis-field", "dependency", "exclusive-branch",
+         "charged-cost", "large-collapse", "singleton-claim"),
+        budget_slack=1,
+    ),
+    planetarium(
+        "Velvet Probability Planetarium", 8, 3,
+        (
+            probe(0b00011011, 3),
+            probe(0b11101111, 1, excludes=1 << 4),
+            probe(0b00101101, 2, requires=1 << 0),
+            probe(0b11111111, 3),
+            probe(0b11001110, 1, requires=1 << 2),
+            probe(0b11111111, 3),
+        ),
+        (0, 2, 4), 7, 4,
+        ("eight-hypothesis-field", "heterogeneous-cost", "dependency",
+         "exclusive-branch", "charged-comet", "large-collapse",
+         "exact-stopping", "recoverable-warning", "irreversible-aperture"),
+        budget_slack=1,
+    ),
+)
+
+
+def all_candidates(level):
+    return (1 << level["n"]) - 1
+
+
+def survivor_count(state):
+    return state.survivors.bit_count()
+
+
+def singleton_ready(level, state):
+    return (survivor_count(state) == 1
+            and bool(state.survivors & (1 << level["answer"])))
+
+
+def probe_partition(level, probe_index):
+    """Return complementary visible partition masks over the level field."""
+    side_a = level["probes"][probe_index]["mask"] & all_candidates(level)
+    return side_a, all_candidates(level) ^ side_a
+
+
+def chosen_probe(level, state):
+    return level["probes"][state.probe_cursor]
+
+
+def probe_outcome(level, state, probe_index=None):
+    """Return the deterministic surviving side for a selected partition."""
+    index = state.probe_cursor if probe_index is None else int(probe_index)
+    side_a, side_b = probe_partition(level, index)
+    answer_bit = 1 << level["answer"]
+    side = side_a if side_a & answer_bit else side_b
+    return state.survivors & side
+
+
+def probe_available(level, state, probe_index=None, *, ignore_dependencies=False):
+    index = state.probe_cursor if probe_index is None else int(probe_index)
+    item = level["probes"][index]
+    bit = 1 << index
+    return (not state.used_probes & bit
+            and (ignore_dependencies
+                 or state.used_probes & item["requires"] == item["requires"])
+            and item["cost"] <= state.evidence_left
+            and probe_outcome(level, state, index) != state.survivors)
+
+
+def start_state(level):
+    return State(
+        all_candidates(level), 0, 0, 0, 0,
+        level["evidence_budget"], 0, 0, 0, ACTIVE,
+    )
+
+
+def action_tokens(_level):
+    return (1, 2, 3, 4, 5, 6)
+
+
+def encode_action(_level, action):
+    aid = int(action[0]) if isinstance(action, (tuple, list)) else int(action)
+    return (aid,)
+
+
+def solved(_level, state):
+    # Normal transition is solely responsible for enforcing singleton entry.
+    # Keeping solved terminal-only lets the explicit no-gate mutation be caught.
+    return state.terminal == WIN
+
+
+def _strike(state, event):
+    strikes = state.strikes + 1
+    return state._replace(
+        strikes=strikes,
+        last_eliminated=0,
+        last_event=event,
+        terminal=LOSS if strikes >= 2 else ACTIVE,
+    )
+
+
+def _transition(level, state, action, mode="normal"):
+    if state.terminal != ACTIVE:
+        return state
+    aid = int(action[0]) if isinstance(action, (tuple, list)) else int(action)
+    if aid not in action_tokens(level):
+        return state
+
+    if aid in (1, 2):
+        size = len(level["probes"])
+        delta = -1 if aid == 1 else 1
+        cursor = (state.probe_cursor + delta) % size
+        return state._replace(
+            probe_cursor=cursor,
+            charge=0,
+            last_eliminated=0,
+            last_event=aid,
+        )
+
+    if aid in (3, 4):
+        delta = -1 if aid == 3 else 1
+        cursor = (state.hypothesis_cursor + delta) % level["n"]
+        return state._replace(
+            hypothesis_cursor=cursor,
+            last_eliminated=0,
+            last_event=aid,
+        )
+
+    if aid == 5:
+        if singleton_ready(level, state):
+            return _strike(state, 5)
+        if not probe_available(
+                level, state, ignore_dependencies=mode == "without_dependencies"):
+            return state
+        item = chosen_probe(level, state)
+        if state.charge + 1 < item["cost"]:
+            return state._replace(
+                charge=state.charge + 1,
+                last_eliminated=0,
+                last_event=5,
+            )
+
+        bit = 1 << state.probe_cursor
+        excluded = 0 if mode == "without_exclusions" else item["excludes"]
+        used = state.used_probes | bit | excluded
+        expected = probe_outcome(level, state)
+        removed = state.survivors ^ expected
+        if mode == "without_probe_effect":
+            after_survivors = state.survivors
+            removed = 0
+        elif mode == "without_large_consequence" and removed.bit_count() > 1:
+            one = removed & -removed
+            after_survivors = state.survivors ^ one
+            removed = one
+        else:
+            after_survivors = expected
+        return state._replace(
+            survivors=after_survivors,
+            used_probes=used,
+            charge=0,
+            evidence_left=state.evidence_left - item["cost"],
+            last_eliminated=removed,
+            last_event=5,
+        )
+
+    if mode == "without_singleton_gate":
+        if state.hypothesis_cursor == level["answer"]:
+            return state._replace(last_event=6, terminal=WIN)
+        return _strike(state, 6)
+
+    if (singleton_ready(level, state)
+            and state.survivors & (1 << state.hypothesis_cursor)):
+        return state._replace(last_eliminated=0, last_event=6, terminal=WIN)
+    return _strike(state, 6)
+
+
+def transition(level, state, action):
+    return _transition(level, state, action, "normal")
+
+
+def without_probe_effect(level, state, action):
+    return _transition(level, state, action, "without_probe_effect")
+
+
+def without_large_consequence(level, state, action):
+    return _transition(level, state, action, "without_large_consequence")
+
+
+def without_singleton_gate(level, state, action):
+    return _transition(level, state, action, "without_singleton_gate")
+
+
+def without_dependencies(level, state, action):
+    """Counterfactual: every probe ignores its visible prerequisite marks."""
+    return _transition(level, state, action, "without_dependencies")
+
+
+def without_exclusions(level, state, action):
+    """Counterfactual: fired probes no longer close their marked alternatives."""
+    return _transition(level, state, action, "without_exclusions")
+
+
+def action_cost(before, after):
+    if after == before:
+        return 0
+    # A first timing/claim error is a visible free warning. The second is
+    # terminal, so there is no zero-cost cycle.
+    if after.strikes > before.strikes:
+        return 0
+    return 1
+
+
+def execute(level, actions, transition_fn=transition):
+    state = start_state(level)
+    budget = level["budget"]
+    for action in actions:
+        after = transition_fn(level, state, action)
+        budget -= action_cost(state, after)
+        state = after
+    return state, budget
+
+
+for _level in LEVELS:
+    _state, _left = execute(_level, _level["witness"])
+    assert (solved(_level, _state)
+            and _left == _level["budget_slack"]), (
+                _level["name"], _state, _left)
+    _state = start_state(_level)
+    _large = False
+    for _action in _level["witness"]:
+        _after = transition(_level, _state, _action)
+        if (_state.survivors ^ _after.survivors).bit_count() >= _level["large_elimination"]:
+            _large = True
+        _state = _after
+    assert _large, _level["name"]
+assert {action for level in LEVELS for action in level["witness"]} == set(range(1, 7))
+
+
+def _points(level):
+    result = []
+    for index in range(level["n"]):
+        angle = -math.pi / 2 + 2 * math.pi * index / level["n"]
+        result.append((32 + round(19 * math.cos(angle)),
+                       31 + round(14 * math.sin(angle))))
+    return tuple(result)
+
+
+class PlanetariumDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def pixel(frame, x, y, color):
+        if 0 <= x < 64 and 0 <= y < 64:
+            frame[y, x] = color
+
+    @classmethod
+    def line(cls, frame, start, end, color, dotted=False, width=1):
+        x0, y0 = start; x1, y1 = end
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 4 in (1, 2):
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            for offset in range(width):
+                cls.pixel(frame, x, y + offset, color)
+
+    @classmethod
+    def disc(cls, frame, center, radius, color, hollow=False):
+        cx, cy = center
+        inner = max(0, radius - 1) ** 2
+        for y in range(cy - radius, cy + radius + 1):
+            for x in range(cx - radius, cx + radius + 1):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius ** 2 and (not hollow or distance >= inner):
+                    cls.pixel(frame, x, y, color)
+
+    @classmethod
+    def diamond(cls, frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for dy in range(-radius, radius + 1):
+            reach = radius - abs(dy)
+            if hollow:
+                cls.pixel(frame, cx - reach, cy + dy, color)
+                cls.pixel(frame, cx + reach, cy + dy, color)
+            else:
+                for x in range(cx - reach, cx + reach + 1):
+                    cls.pixel(frame, x, cy + dy, color)
+
+    @classmethod
+    def triangle(cls, frame, center, radius, color, invert=False,
+                 hollow=False):
+        cx, cy = center
+        for step in range(radius + 1):
+            reach = step
+            y = cy + (radius - step if invert else step - radius)
+            if hollow:
+                cls.pixel(frame, cx - reach, y, color)
+                cls.pixel(frame, cx + reach, y, color)
+            else:
+                for x in range(cx - reach, cx + reach + 1):
+                    cls.pixel(frame, x, y, color)
+
+    @classmethod
+    def hypothesis(cls, frame, center, index, color, folded=False):
+        """Eight large silhouettes with distinct internal hatch patterns."""
+        x, y = center
+        if folded:
+            cls.line(frame, (x - 4, y), (x + 4, y), RED, width=2)
+            cls.line(frame, (x - 2, y - 2), (x + 2, y + 2), SLATE)
+            return
+        shape = index % 8
+        if shape == 0:
+            cls.triangle(frame, center, 4, color, hollow=True)
+        elif shape == 1:
+            cls.diamond(frame, center, 4, color, hollow=True)
+        elif shape == 2:
+            cls.disc(frame, center, 4, color, hollow=True)
+        elif shape == 3:
+            cls.line(frame, (x - 4, y), (x + 4, y), color, width=2)
+            cls.line(frame, (x, y - 4), (x, y + 4), color, width=2)
+        elif shape == 4:
+            cls.triangle(frame, center, 4, color, invert=True, hollow=True)
+        elif shape == 5:
+            cls.line(frame, (x - 4, y + 3), (x, y - 3), color, width=2)
+            cls.line(frame, (x, y - 3), (x + 4, y + 3), color, width=2)
+        elif shape == 6:
+            cls.disc(frame, center, 4, color)
+            cls.disc(frame, (x + 2, y - 1), 3, INK)
+        else:
+            cls.diamond(frame, center, 4, color)
+            cls.disc(frame, center, 2, INK)
+        # Index-specific notches keep same-family shapes distinguishable.
+        for mark in range(index % 3 + 1):
+            cls.pixel(frame, x - 2 + mark * 2, y, PAPER)
+
+    def background(self, frame):
+        frame[:, :] = INK
+        for y in range(2, 57, 7):
+            for x in range((y * 5) % 11, 64, 13):
+                frame[y, x] = VELVET if (x + y) % 3 else CHARCOAL
+        self.disc(frame, (32, 29), 24, VELVET, hollow=True)
+        self.disc(frame, (32, 29), 21, SLATE, hollow=True)
+        for spoke in range(12):
+            angle = 2 * math.pi * spoke / 12
+            a = (32 + round(7 * math.cos(angle)),
+                 29 + round(7 * math.sin(angle)))
+            b = (32 + round(23 * math.cos(angle)),
+                 29 + round(23 * math.sin(angle)))
+            self.line(frame, a, b, CHARCOAL, dotted=True)
+
+    def partition_halo(self, frame, point, in_a, color=None):
+        if in_a:
+            self.disc(frame, point, 6, SKY if color is None else color,
+                      hollow=True)
+            self.pixel(frame, point[0], point[1] - 6, PAPER)
+        else:
+            self.diamond(frame, point, 6, VIOLET if color is None else color,
+                         hollow=True)
+            self.pixel(frame, point[0] - 6, point[1], PAPER)
+
+    def field(self, frame, state):
+        level = self.game.level
+        points = _points(level)
+        side_a, _side_b = probe_partition(level, state.probe_cursor)
+        for index, point in enumerate(points):
+            bit = 1 << index
+            alive = bool(state.survivors & bit)
+            if alive:
+                self.partition_halo(frame, point, bool(side_a & bit))
+            self.hypothesis(frame, point, index,
+                            GOLD if alive else SLATE, folded=not alive)
+            if state.hypothesis_cursor == index:
+                self.disc(frame, point, 7, PAPER, hollow=True)
+                self.line(frame, (32, 29), point, GOLD, dotted=True)
+
+    def probe_lenses(self, frame, state):
+        level = self.game.level
+        count = len(level["probes"])
+        spacing = 9 if count >= 6 else 11
+        start = 32 - spacing * (count - 1) // 2
+        for index, item in enumerate(level["probes"]):
+            x = start + index * spacing
+            bit = 1 << index
+            used = bool(state.used_probes & bit)
+            available = probe_available(level, state, index)
+            color = SLATE if used else MOSS if available else VELVET
+            self.disc(frame, (x, 5), 3, color, hollow=not used)
+            self.diamond(frame, (x, 5), 2, PAPER if index == state.probe_cursor
+                         else ASH, hollow=True)
+            for cost_mark in range(item["cost"]):
+                self.pixel(frame, x - item["cost"] + 1 + cost_mark * 2,
+                           9, AMBER if cost_mark < state.charge and
+                           index == state.probe_cursor else ASH)
+            if item["requires"]:
+                self.line(frame, (x - 2, 11), (x + 2, 11), VIOLET,
+                          dotted=True)
+            if item["excludes"]:
+                self.pixel(frame, x, 12, RED)
+        selected_x = start + state.probe_cursor * spacing
+        self.disc(frame, (selected_x, 5), 5, GOLD, hollow=True)
+
+    def center_instrument(self, frame, state):
+        level = self.game.level
+        item = chosen_probe(level, state)
+        side_a, side_b = probe_partition(level, state.probe_cursor)
+        self.disc(frame, (32, 29), 7, VELVET)
+        self.disc(frame, (32, 29), 7, GOLD, hollow=True)
+        self.diamond(frame, (32, 29), 4, SKY, hollow=True)
+        # Partition size is shown by paired countable round/diamond notches.
+        for index in range(side_a.bit_count()):
+            self.disc(frame, (27 + index * 2, 27), 1, SKY,
+                      hollow=bool(index % 2))
+        for index in range(side_b.bit_count()):
+            self.diamond(frame, (27 + index * 2, 32), 1, VIOLET,
+                         hollow=bool(index % 2))
+        for index in range(item["cost"]):
+            angle = -math.pi / 2 + index * math.pi / max(1, item["cost"] - 1)
+            point = (32 + round(6 * math.cos(angle)),
+                     29 + round(6 * math.sin(angle)))
+            self.disc(frame, point, 1,
+                      AMBER if index < state.charge else PAPER)
+
+    def hud(self, frame, state):
+        # One lower gold diamond per exact remaining action.
+        for index in range(self.game.budget_max):
+            row, column = divmod(index, 15)
+            center = (4 + column * 4, 59 + row * 3)
+            live = index < self.game.budget_left
+            self.diamond(frame, center, 1, GOLD if live else CHARCOAL,
+                         hollow=not live)
+        # Evidence purse is independent from navigation/action budget.
+        for index in range(self.game.level["evidence_budget"]):
+            self.triangle(frame, (3, 13 + index * 4), 1,
+                          MAGENTA if index < state.evidence_left else CHARCOAL,
+                          hollow=index >= state.evidence_left)
+        # Paired warning seals: first remains cracked, second closes terminally.
+        for index, y in enumerate((18, 27)):
+            cracked = index < state.strikes
+            self.disc(frame, (61, y), 3, RED if cracked else MOSS,
+                      hollow=not cracked)
+            if cracked:
+                self.line(frame, (59, y - 2), (63, y + 2), PAPER)
+
+    def animation(self, frame, state):
+        g = self.game
+        if not g.anim_kind:
+            if state.terminal == LOSS:
+                self.line(frame, (5, 8), (59, 51), RED, width=2)
+                self.line(frame, (59, 8), (5, 51), VIOLET, width=2)
+            return
+        before, after = g.state, g.pending_state
+        p = g.anim_progress
+        span = max(1, g.anim_total - 1)
+        wave = min(p, span - p)
+        if g.anim_kind in ("probe_select", "claim_select"):
+            center = (32, 29)
+            self.disc(frame, center, 8 + wave, GOLD, hollow=True)
+            angle = 2 * math.pi * p / max(1, span)
+            point = (32 + round((9 + wave) * math.cos(angle)),
+                     29 + round((9 + wave) * math.sin(angle)))
+            self.line(frame, center, point, PAPER, dotted=True)
+        elif g.anim_kind == "charge":
+            radius = 3 + p
+            self.disc(frame, (32, 29), radius, AMBER, hollow=True)
+            self.diamond(frame, (32, 29), 2 + wave, GOLD)
+        elif g.anim_kind == "probe":
+            self.diamond(frame, (32, 29 - p * 2), 3 + wave, GOLD)
+            points = _points(g.level)
+            for index, point in enumerate(points):
+                if not after.last_eliminated & (1 << index):
+                    continue
+                folded = (point[0] + (32 - point[0]) * p // span,
+                          point[1] + (29 - point[1]) * p // span)
+                self.line(frame, point, folded, SKY, dotted=True)
+                self.diamond(frame, folded, max(1, 4 - p // 2), RED,
+                             hollow=True)
+        elif g.anim_kind == "warning":
+            offset = (-2, 2, -1, 1, 0, 1, 0)[min(p, 6)]
+            self.disc(frame, (32 + offset, 29), 8 + wave, RED, hollow=True)
+            self.line(frame, (25, 26 + offset), (39, 32 - offset), PAPER)
+        elif g.anim_kind == "success":
+            self.disc(frame, (32, 29), 7 + p * 3, GOLD, hollow=True)
+            self.disc(frame, (32, 29), max(1, 6 - p // 2), PAPER,
+                      hollow=True)
+            for index in range(8):
+                angle = 2 * math.pi * index / 8
+                point = (32 + round((8 + p) * math.cos(angle)),
+                         29 + round((8 + p) * math.sin(angle)))
+                self.diamond(frame, point, 1, AMBER)
+        elif g.anim_kind == "loss":
+            inset = min(22, p * 3)
+            self.line(frame, (4 + inset, 6), (60 - inset, 52), RED, width=2)
+            self.line(frame, (60 - inset, 6), (4 + inset, 52), VIOLET,
+                      width=2)
+        else:
+            self.disc(frame, (32, 29), 8 + wave, ASH, hollow=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        state = self.game.state
+        self.background(frame)
+        self.probe_lenses(frame, state)
+        self.field(frame, state)
+        self.center_instrument(frame, state)
+        self.hud(frame, state)
+        self.animation(frame, state)
+        return frame
+
+
+class Q161(ARCBaseGame):
+    def __init__(self):
+        self.display = PlanetariumDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        levels = [
+            Level(sprites=[], grid_size=(64, 64), data=deepcopy(item),
+                  name=item["name"])
+            for item in LEVELS
+        ]
+        super().__init__(
+            "q161", levels,
+            Camera(0, 0, 64, 64, INK, INK, [self.display]),
+            False, len(levels), [1, 2, 3, 4, 5, 6],
+        )
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+
+    def begin(self, kind, frames, after, budget, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.pending_state = after
+        self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state
+        self.budget_left = self.pending_budget
+        self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        aid = self.action.id.value
+        if aid == 0:
+            self.complete_action()
+            return
+        before = self.state
+        after = transition(self.level, before, aid)
+        if after == before:
+            self.begin("blocked", 5, before, self.budget_left)
+            return
+        cost = action_cost(before, after)
+        budget = self.budget_left - cost
+        won = after.terminal == WIN
+        lost = after.terminal == LOSS or (budget <= 0 and not won)
+        if lost and after.terminal != LOSS:
+            after = after._replace(terminal=LOSS)
+        if won:
+            kind, frames, terminal = "success", 6, "win"
+        elif lost:
+            kind, frames, terminal = "loss", 6, "loss"
+        elif after.strikes > before.strikes:
+            kind, frames, terminal = "warning", 7, None
+        elif aid in (1, 2):
+            kind, frames, terminal = "probe_select", 6, None
+        elif aid in (3, 4):
+            kind, frames, terminal = "claim_select", 6, None
+        elif aid == 5 and after.survivors != before.survivors:
+            kind, frames, terminal = "probe", 8, None
+        else:
+            kind, frames, terminal = "charge", 6, None
+        self.begin(kind, frames, after, budget, terminal)

--- a/data/community-games/sonpham/q165_v3_q165.py
+++ b/data/community-games/sonpham/q165_v3_q165.py
@@ -1,0 +1,601 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q165-v3 The Patient Folio -- an archival cabinet for patient inference.
+
+Candidates advertise their predictions before the player chooses a specimen press.
+Evidence is retained as a separate card and never edits the candidate stack: the
+player must park incompatible leaves manually, may restore them, and audits only
+after a discriminative evidence set has been assembled.  Later folios introduce
+negative impressions, delayed development, pinned evidence, explicit revision,
+and compound two-mark observations.  This version keeps the inference model
+unchanged while giving every input a quiet five-to-seven-frame press/develop/
+settle response and arranging the predictions as a dense glass-and-paper atlas.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, LINEN, MIST, CLAY, BARK, INK = 0, 1, 2, 3, 4, 5
+BERRY, ROSE, RED, BLUE, SKY, HONEY, APRICOT, PLUM, SAGE, LAVENDER = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+
+
+def folio(name, predictions, target, quota, budget, **rules):
+    probes = len(predictions[0])
+    base = {
+        "name": name,
+        "predictions": tuple(tuple(row) for row in predictions),
+        "target": target,
+        "quota": quota,
+        "budget": budget,
+        "negative_mask": 0,
+        "delayed_mask": 0,
+        "locked_mask": 0,
+        "required_mask": 0,
+        "revisions": 0,
+        "must_revise": False,
+        "revision_probe": -1,
+        "compound": (-1,) * probes,
+    }
+    base.update(rules)
+    return base
+
+
+LEVELS = [
+    folio("First Impression", ((0, 0), (1, 0), (1, 1)), 0, 1, 10,
+          required_mask=0b01),
+    folio("Forked Claims", ((0, 0, 0), (0, 1, 0), (1, 0, 0), (1, 1, 0)), 2, 2, 15,
+          required_mask=0b011),
+    folio("Counterleaf", ((0, 0, 1), (1, 0, 1), (1, 1, 1), (2, 0, 1)), 1, 2, 15,
+          negative_mask=0b010, required_mask=0b011),
+    folio("Sleeping Ink", ((0, 0, 0, 0), (0, 1, 0, 1), (1, 0, 1, 0),
+                            (1, 1, 0, 0), (1, 0, 0, 1)), 3, 2, 21,
+          delayed_mask=0b0001, required_mask=0b0011),
+    folio("Pinned Specimen", ((0, 0, 0, 0), (0, 1, 1, 0), (1, 0, 0, 1),
+                               (1, 1, 0, 0), (1, 0, 1, 0)), 4, 2, 21,
+          locked_mask=0b0001, required_mask=0b0101),
+    folio("Erratum Thread", ((0, 0, 0, 0), (1, 0, 1, 1), (2, 1, 0, 1),
+                              (0, 1, 1, 0), (1, 0, 0, 1)), 2, 2, 24,
+          locked_mask=0b0001, required_mask=0b0110, revisions=1,
+          must_revise=True, revision_probe=0),
+    folio("Twin Imprint", ((0, 0, 0, 0, 0), (0, 0, 1, 0, 1), (0, 1, 0, 1, 0),
+                            (0, 1, 1, 1, 1), (1, 1, 0, 1, 1),
+                            (1, 1, 1, 0, 1)), 4, 2, 28,
+          delayed_mask=0b00010, required_mask=0b00011,
+          compound=(-1, 3, -1, -1, -1)),
+    folio("The Patient Folio", ((0, 0, 0, 0, 0), (1, 1, 0, 1, 2),
+                                 (2, 1, 2, 0, 2), (0, 0, 2, 1, 2),
+                                 (1, 1, 2, 1, 0), (2, 1, 2, 1, 2)), 5, 3, 34,
+          delayed_mask=0b00100, locked_mask=0b00001,
+          required_mask=0b01110, revisions=1, must_revise=True,
+          revision_probe=0, compound=(-1, -1, -1, 4, -1)),
+]
+
+
+def probe_count(level):
+    return len(level["predictions"][0])
+
+
+def reported(level, candidate, probe):
+    value = level["predictions"][candidate][probe]
+    return 2 - value if level["negative_mask"] & (1 << probe) else value
+
+
+def probe_signature(level, candidate, probe):
+    result = (reported(level, candidate, probe),)
+    partner = level["compound"][probe]
+    if partner >= 0:
+        result += (reported(level, candidate, partner),)
+    return result
+
+
+def consistent_mask(level, used_mask):
+    target = level["target"]
+    mask = 0
+    for candidate in range(len(level["predictions"])):
+        if all(probe_signature(level, candidate, probe) == probe_signature(level, target, probe)
+               for probe in range(probe_count(level)) if used_mask & (1 << probe)):
+            mask |= 1 << candidate
+    return mask
+
+
+def evidence_ready(level, state):
+    used = state[3]
+    revised = state[7] < level["revisions"]
+    return (state[4] < 0
+            and used.bit_count() == level["quota"]
+            and used & level["required_mask"] == level["required_mask"]
+            and (not level["must_revise"] or revised)
+            and consistent_mask(level, used) == 1 << level["target"])
+
+
+def start_state(level):
+    count = len(level["predictions"])
+    # phase, candidate cursor, probe cursor, used probes, pending probe,
+    # active candidates, retained evidence order, revisions, retries, terminal
+    return 0, 0, 0, 0, -1, (1 << count) - 1, (), level["revisions"], 2, 0
+
+
+def transition(level, state, action):
+    phase, cursor, probe, used, pending, active, history, revisions, chances, terminal = state
+    if terminal or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    candidates = len(level["predictions"])
+    probes = probe_count(level)
+
+    if action == 1:
+        return phase, (cursor - 1) % candidates, probe, used, pending, active, history, revisions, chances, terminal
+    if action == 2:
+        return phase, (cursor + 1) % candidates, probe, used, pending, active, history, revisions, chances, terminal
+
+    if phase == 0:
+        if action == 3:
+            return phase, cursor, (probe - 1) % probes, used, pending, active, history, revisions, chances, terminal
+        if action == 4:
+            return phase, cursor, (probe + 1) % probes, used, pending, active, history, revisions, chances, terminal
+        if action == 5:
+            if pending >= 0:
+                bit = 1 << pending
+                if used & bit or used.bit_count() >= level["quota"]:
+                    return state
+                return phase, cursor, probe, used | bit, -1, active, history + (pending,), revisions, chances, terminal
+            bit = 1 << probe
+            if used & bit:
+                if level["locked_mask"] & bit:
+                    if revisions <= 0 or probe != level["revision_probe"]:
+                        return state
+                    revisions -= 1
+                new_history = tuple(item for item in history if item != probe)
+                return phase, cursor, probe, used & ~bit, -1, active, new_history, revisions, chances, terminal
+            if used.bit_count() >= level["quota"]:
+                return state
+            if level["delayed_mask"] & bit:
+                return phase, cursor, probe, used, probe, active, history, revisions, chances, terminal
+            return phase, cursor, probe, used | bit, -1, active, history + (probe,), revisions, chances, terminal
+        if action == 6:
+            if evidence_ready(level, state):
+                return 1, cursor, probe, used, pending, active, history, revisions, chances, terminal
+            chances -= 1
+            return phase, cursor, probe, used, pending, active, history, revisions, chances, 3 if chances <= 0 else 0
+        return state
+
+    if action == 3:
+        return phase, cursor, probe, used, pending, active ^ (1 << cursor), history, revisions, chances, terminal
+    if action == 4:
+        if not history:
+            return state
+        next_probe = history[0] if probe not in history else history[(history.index(probe) + 1) % len(history)]
+        return phase, cursor, next_probe, used, pending, active, history, revisions, chances, terminal
+    if action == 6:
+        if (evidence_ready(level, state)
+                and active == 1 << level["target"]
+                and cursor == level["target"]):
+            return phase, cursor, probe, used, pending, active, history, revisions, chances, 2
+        chances -= 1
+        return phase, cursor, probe, used, pending, active, history, revisions, chances, 3 if chances <= 0 else 0
+    return state
+
+
+def action_cost(state, after):
+    # A rejected folio close consumes a wax retry, not a page-turn action.
+    return 0 if after[8] < state[8] else 1
+
+
+def solved(_level, state):
+    return state[-1] == 2
+
+
+class FolioDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius ** 2 and (not hollow or distance >= max(0, radius - 1) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def line(frame, a, b, color, dotted=False):
+        x0, y0 = a; x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    @classmethod
+    def rect(cls, frame, left, top, right, bottom, color, dotted=False):
+        """A thin archival plate; critical cards are never raw filled boxes."""
+        cls.line(frame, (left, top), (right, top), color, dotted)
+        cls.line(frame, (right, top), (right, bottom), color, dotted)
+        cls.line(frame, (right, bottom), (left, bottom), color, dotted)
+        cls.line(frame, (left, bottom), (left, top), color, dotted)
+
+    @staticmethod
+    def candidate_centers(count):
+        layouts = {
+            3: ((14, 44), (32, 31), (51, 44)),
+            4: ((11, 45), (25, 33), (40, 33), (54, 45)),
+            5: ((9, 46), (20, 36), (32, 31), (45, 36), (56, 46)),
+            6: ((8, 47), (17, 38), (28, 32), (39, 32), (50, 38), (57, 47)),
+        }
+        return layouts[count]
+
+    @staticmethod
+    def probe_center(index, total):
+        xs = (8, 19, 31, 43, 55)
+        ys = (10, 6, 9, 6, 11)
+        return xs[index], ys[index]
+
+    @staticmethod
+    def evidence_center(index):
+        # Three retained glass slides sit in one calm, countable row.
+        return 8 + index * 10, 23
+
+    def background(self, frame):
+        frame[:, :] = PAPER
+        # Quiet specimen-cabinet architecture: rag paper, glass, and metal.
+        self.rect(frame, 1, 1, 62, 62, CLAY)
+        self.rect(frame, 3, 13, 60, 29, MIST)
+        self.rect(frame, 3, 30, 60, 56, LINEN)
+        for y in range(4, 61, 7):
+            frame[y, 4 + (y * 3) % 8:60:13] = LINEN
+        for x in range(6, 60, 11):
+            frame[15 + x % 3:28:6, x] = MIST
+        # Four brass hinge rosettes and a stitched lower binding.
+        for center in ((3, 3), (60, 3), (3, 60), (60, 60)):
+            self.disc(frame, center, 2, BARK, hollow=True)
+            frame[center[1], center[0]] = INK
+        self.line(frame, (4, 57), (59, 57), CLAY, dotted=True)
+        for x in range(6, 59, 8):
+            self.line(frame, (x, 55), (x + 3, 59), MIST)
+
+    def sigil(self, frame, center, identity, color=INK, small=False):
+        x, y = center; radius = 1 if small else 2; kind = identity % 6
+        if kind == 0:
+            self.disc(frame, center, radius + 1, color, hollow=True); frame[y, x] = color
+        elif kind == 1:
+            self.line(frame, (x, y - radius - 1), (x + radius + 1, y + radius), color)
+            self.line(frame, (x + radius + 1, y + radius), (x - radius - 1, y + radius), color)
+            self.line(frame, (x - radius - 1, y + radius), (x, y - radius - 1), color)
+        elif kind == 2:
+            self.line(frame, (x, y - radius - 1), (x + radius + 1, y), color)
+            self.line(frame, (x + radius + 1, y), (x, y + radius + 1), color)
+            self.line(frame, (x, y + radius + 1), (x - radius - 1, y), color)
+            self.line(frame, (x - radius - 1, y), (x, y - radius - 1), color)
+        elif kind == 3:
+            self.line(frame, (x - radius - 1, y), (x + radius + 1, y), color)
+            self.line(frame, (x, y - radius - 1), (x, y + radius + 1), color)
+        elif kind == 4:
+            self.line(frame, (x - radius, y - radius), (x + radius, y + radius), color)
+            self.line(frame, (x + radius, y - radius), (x - radius, y + radius), color)
+        else:
+            for dx, dy in ((0, -2), (2, 0), (0, 2), (-2, 0)):
+                self.disc(frame, (x + dx, y + dy), 1, color)
+
+    def outcome(self, frame, center, value, small=False):
+        x, y = center; radius = 1 if small else 2
+        if value == 0:
+            self.disc(frame, center, radius + 1, PLUM, hollow=True)
+        elif value == 1:
+            self.disc(frame, center, radius + 1, SAGE)
+            self.line(frame, (x, y - radius - 2), (x + 2, y - radius - 4), SAGE)
+        else:
+            self.line(frame, (x - radius - 1, y + radius), (x, y - radius - 1), APRICOT)
+            self.line(frame, (x, y - radius - 1), (x + radius + 1, y + radius), APRICOT)
+            self.line(frame, (x - radius, y), (x + radius, y), INK, dotted=True)
+
+    def probe_glyph(self, frame, center, probe, color=CLAY):
+        self.sigil(frame, center, probe, color, small=True)
+
+    def leaf(self, frame, center, identity, active, selected, signature):
+        x, y = center
+        # A glass plate makes prediction comparison dense and rectilinear,
+        # while the specimen itself keeps a distinct leaf/rosette silhouette.
+        self.rect(frame, x - 7, y - 10, x + 7, y + 8,
+                  CLAY if active else MIST, dotted=not active)
+        self.line(frame, (32, 56), (x, y + 6), BARK, dotted=not active)
+        if active:
+            # Low-saturation paper/glass field; identity is shape-coded, never
+            # a rainbow lookup.  Sage and steel are restrained accents.
+            color = (LINEN, MIST, CLAY, LINEN, MIST, CLAY)[identity % 6]
+            self.disc(frame, center, 6, color)
+            self.line(frame, (x, y - 8), (x - 5, y + 2), color)
+            self.line(frame, (x, y - 8), (x + 5, y + 2), color)
+            if identity % 2:
+                self.disc(frame, (x - 4, y - 3), 2, color)
+            if identity % 3 == 2:
+                self.disc(frame, (x + 4, y - 2), 2, color)
+        else:
+            self.disc(frame, center, 6, MIST, hollow=True)
+            self.line(frame, (x - 5, y - 4), (x + 5, y + 4), CLAY)
+            self.line(frame, (x + 2, y + 1), (x + 6, y - 3), CLAY)
+        self.sigil(frame, (x, y - 2), identity, INK)
+        offsets = (-3, 3) if len(signature) == 2 else (0,)
+        for dx, value in zip(offsets, signature):
+            self.outcome(frame, (x + dx, y + 4), value, small=True)
+        if selected:
+            self.disc(frame, center, 9, INK, hollow=True)
+            self.disc(frame, (x, y - 10), 1, BERRY)
+
+    def probes(self, frame):
+        g = self.game; level = g.level; state = g.state; total = probe_count(level)
+        for probe in range(total):
+            center = self.probe_center(probe, total); used = bool(state[3] & (1 << probe))
+            self.disc(frame, center, 5, CLAY if used else LINEN)
+            self.disc(frame, center, 5, CLAY, hollow=True)
+            self.probe_glyph(frame, center, probe, INK)
+            if level["required_mask"] & (1 << probe):
+                self.line(frame, (center[0] - 3, center[1] + 6), (center[0] + 3, center[1] + 6), SAGE)
+                frame[center[1] + 5:center[1] + 8, center[0]] = SAGE
+            if level["locked_mask"] & (1 << probe):
+                self.disc(frame, (center[0] + 4, center[1] - 4), 2, PLUM)
+                frame[center[1] - 4:center[1] + 1, center[0] + 4] = INK
+            if level["delayed_mask"] & (1 << probe):
+                self.disc(frame, center, 7, SKY, hollow=True)
+            if level["compound"][probe] >= 0:
+                self.disc(frame, (center[0] + 6, center[1]), 3, APRICOT, hollow=True)
+            if probe == state[2] and state[0] == 0:
+                self.disc(frame, center, 8, INK, hollow=True)
+                self.disc(frame, (center[0], center[1] - 9), 1, BERRY)
+            elif probe == state[2] and state[0] == 1:
+                # Review focus is a double-notched ring, visibly distinct from
+                # the open investigation cursor and tied to the evidence card.
+                self.disc(frame, center, 8, PLUM, hollow=True)
+                self.line(frame, (center[0] - 3, center[1] - 8),
+                          (center[0] + 3, center[1] - 8), INK)
+                self.line(frame, (center[0] - 3, center[1] + 8),
+                          (center[0] + 3, center[1] + 8), INK)
+
+    def evidence(self, frame):
+        g = self.game; level = g.level; state = g.state
+        for index, probe in enumerate(state[6]):
+            center = self.evidence_center(index)
+            self.rect(frame, center[0] - 4, center[1] - 5,
+                      center[0] + 4, center[1] + 5, BARK)
+            self.disc(frame, center, 5, LINEN)
+            self.disc(frame, center, 5, BARK, hollow=True)
+            self.probe_glyph(frame, (center[0], center[1] - 2), probe, INK)
+            signature = probe_signature(level, level["target"], probe)
+            offsets = (-2, 2) if len(signature) == 2 else (0,)
+            for dx, value in zip(offsets, signature):
+                self.outcome(frame, (center[0] + dx, center[1] + 2), value, small=True)
+            if state[0] == 1 and probe == state[2]:
+                self.disc(frame, center, 7, PLUM, hollow=True)
+                self.line(frame, (center[0] - 5, center[1] + 6),
+                          (center[0] + 5, center[1] + 6), INK)
+        if state[4] >= 0:
+            self.rect(frame, 47, 15, 59, 27, SKY)
+            self.disc(frame, (53, 21), 6, SKY, hollow=True)
+            self.probe_glyph(frame, (53, 21), state[4], INK)
+            self.line(frame, (49, 25), (57, 17), SKY, dotted=True)
+
+    def candidates(self, frame):
+        g = self.game; state = g.state; level = g.level
+        centers = self.candidate_centers(len(level["predictions"]))
+        for candidate, center in enumerate(centers):
+            signature = probe_signature(level, candidate, state[2])
+            self.leaf(frame, center, candidate, bool(state[5] & (1 << candidate)),
+                      candidate == state[1], signature)
+
+    def hud(self, frame):
+        g = self.game; state = g.state
+        # Investigation is an open magnifying flower; review is a tied folio.
+        if state[0] == 0:
+            self.disc(frame, (37, 21), 4, SKY, hollow=True)
+            self.line(frame, (40, 24), (43, 27), SKY)
+        else:
+            self.line(frame, (33, 17), (41, 24), CLAY)
+            self.line(frame, (41, 17), (33, 24), CLAY)
+            self.disc(frame, (37, 21), 3, LINEN)
+        for index in range(g.level["revisions"]):
+            center = (43 + index * 6, 27)
+            self.disc(frame, center, 2, LAVENDER if index < state[7] else MIST, hollow=index >= state[7])
+            self.line(frame, (center[0] - 2, center[1] + 3), (center[0] + 2, center[1] - 3), PLUM, dotted=True)
+        for index in range(state[8]):
+            self.disc(frame, (54 + index * 5, 27), 2, BERRY)
+            self.disc(frame, (54 + index * 5, 27), 1, PAPER)
+        # Four actions form one seed bloom.  A remaining action is a full
+        # five-pixel petal; a spent action is only a one-pixel socket.  The
+        # grouped silhouette therefore exposes every exact count without a
+        # merged color strip, even at the 34-action maximum.
+        petal_offsets = ((0, -2), (2, 0), (0, 2), (-2, 0))
+        for group in range((g.budget_max + 3) // 4):
+            center = (4 + group * 7, 60)
+            self.disc(frame, center, 1, BARK)
+            for petal, (dx, dy) in enumerate(petal_offsets):
+                index = group * 4 + petal
+                if index >= g.budget_max:
+                    continue
+                if index < g.budget_left:
+                    self.disc(frame, (center[0] + dx, center[1] + dy), 1, BARK)
+                else:
+                    frame[center[1] + dy, center[0] + dx] = CLAY
+
+    def animation(self, frame):
+        g = self.game
+        if not g.anim_kind:
+            if g.intro_mark:
+                self.line(frame, (4, 56), (58, 53), HONEY, dotted=True)
+            if g.terminal_hold == "loss":
+                self.line(frame, (4, 13), (59, 55), PLUM, dotted=True)
+                self.line(frame, (59, 13), (4, 55), PLUM, dotted=True)
+            return
+        p = g.anim_progress; state = g.state; after = g.pending_state
+        if g.anim_kind in ("candidate_cursor", "probe_cursor"):
+            if g.anim_kind == "candidate_cursor":
+                center = self.candidate_centers(len(g.level["predictions"]))[after[1]]
+            else:
+                center = self.probe_center(after[2], probe_count(g.level))
+            self.disc(frame, center, 7 + p, BERRY, hollow=True)
+        elif g.anim_kind in ("press", "develop"):
+            probe = state[4] if g.anim_kind == "develop" else state[2]
+            card_index = len(state[6])
+            card = self.evidence_center(card_index)
+            if g.anim_kind == "develop":
+                source, destination = (53, 21), card
+            elif after[4] >= 0 and state[4] < 0:
+                source, destination = self.probe_center(probe, probe_count(g.level)), (53, 21)
+            else:
+                source, destination = self.probe_center(probe, probe_count(g.level)), card
+            x = source[0] + (destination[0] - source[0]) * p // g.anim_total
+            y = source[1] + (destination[1] - source[1]) * p // g.anim_total - p * (g.anim_total - p) // 2
+            self.disc(frame, (x, y), 3, SKY if g.anim_kind == "develop" else CLAY)
+            self.probe_glyph(frame, (x, y), probe, INK)
+        elif g.anim_kind in ("retract", "revision"):
+            probe = state[2]
+            card_index = state[6].index(probe) if probe in state[6] else max(0, len(state[6]) - 1)
+            source = self.evidence_center(card_index)
+            destination = self.probe_center(probe, probe_count(g.level))
+            x = source[0] + (destination[0] - source[0]) * p // g.anim_total
+            y = source[1] + (destination[1] - source[1]) * p // g.anim_total
+            self.disc(frame, (x, y), 3 + p // 2, LAVENDER if g.anim_kind == "revision" else LINEN, hollow=True)
+        elif g.anim_kind in ("park", "restore"):
+            center = self.candidate_centers(len(g.level["predictions"]))[state[1]]
+            self.disc(frame, center, 7 + p, MIST if g.anim_kind == "park" else SAGE, hollow=True)
+            self.line(frame, (center[0] - 6 + p, center[1] - 5), (center[0] + 6 - p, center[1] + 5), CLAY)
+        elif g.anim_kind == "phase":
+            edge = 3 + p * 8
+            frame[24:58, 2:min(62, edge):3] = LINEN
+            self.line(frame, (edge, 23), (edge - 5, 57), CLAY)
+        elif g.anim_kind == "reject":
+            for offset in range(0, 55, 8):
+                self.line(frame, (5 + offset + p, 14), (2 + offset, 55), PLUM, dotted=True)
+        elif g.anim_kind == "success":
+            for index, center in enumerate(self.candidate_centers(len(g.level["predictions"]))):
+                self.disc(frame, center, 2 + p, (BARK, CLAY, SKY)[index % 3], hollow=True)
+        elif g.anim_kind == "loss":
+            self.line(frame, (4 + p * 3, 13), (59 - p * 3, 55), PLUM)
+            self.line(frame, (59 - p * 3, 13), (4 + p * 3, 55), PLUM)
+        else:
+            # A blocked action presses two nonflashing metal brackets inward;
+            # the fifth frame settles on the same deterministic state.
+            center = (self.probe_center(state[2], probe_count(g.level))
+                      if state[0] == 0 else
+                      self.candidate_centers(len(g.level["predictions"]))[state[1]])
+            inset = min(4, p)
+            self.line(frame, (center[0] - 10 + inset, center[1] - 7),
+                      (center[0] - 10 + inset, center[1] + 7), PLUM)
+            self.line(frame, (center[0] + 10 - inset, center[1] - 7),
+                      (center[0] + 10 - inset, center[1] + 7), PLUM)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self.background(frame)
+        self.probes(frame)
+        self.evidence(frame)
+        self.candidates(frame)
+        self.hud(frame)
+        self.animation(frame)
+        return frame
+
+
+class Q165(ARCBaseGame):
+    def __init__(self):
+        self.display = FolioDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = None
+        self.pending_budget = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q165", levels, Camera(0, 0, 64, 64, PAPER, PAPER, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+
+    def begin(self, kind, frames, state, budget, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.pending_state = state
+        self.pending_budget = budget
+        self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state
+        self.budget_left = self.pending_budget
+        self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.terminal_hold = "win"
+            self.next_level()
+        elif terminal == "loss":
+            self.terminal_hold = "loss"
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        self.intro_mark = False
+        before = self.state
+        after = transition(self.level, before, action)
+        if after == before:
+            self.begin("blocked", 5, before, self.budget_left)
+            return
+        budget = self.budget_left - action_cost(before, after)
+        won = solved(self.level, after)
+        lost = after[-1] == 3 or (budget <= 0 and not won)
+        if won:
+            kind = "success"
+        elif lost:
+            kind = "loss"
+        elif after[8] < before[8]:
+            kind = "reject"
+        elif before[0] != after[0]:
+            kind = "phase"
+        elif before[1] != after[1]:
+            kind = "candidate_cursor"
+        elif before[2] != after[2]:
+            kind = "probe_cursor"
+        elif before[4] < 0 <= after[4]:
+            kind = "press"
+        elif before[4] >= 0 > after[4]:
+            kind = "develop"
+        elif before[3].bit_count() > after[3].bit_count():
+            kind = "revision" if after[7] < before[7] else "retract"
+        elif before[3] != after[3]:
+            kind = "press"
+        elif before[5] != after[5]:
+            kind = "park" if after[5].bit_count() < before[5].bit_count() else "restore"
+        else:
+            kind = "blocked"
+        frames = 7 if kind in ("success", "loss", "phase") else 5
+        self.begin(kind, frames, after, budget, "win" if won else "loss" if lost else None)

--- a/data/community-games/sonpham/q176_v3_q176.py
+++ b/data/community-games/sonpham/q176_v3_q176.py
@@ -1,0 +1,621 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q176-v3 Thermal Quilt -- sculpt an exact field through visible material laws.
+
+Rounded woven basins share heat by an exact local rule. Later quilts introduce
+direct heat/cool tools, retentive ceramic, insulated seams, directional wicks,
+irreversible phase buds, fixed reservoirs, and an explicitly stitched wrap edge.
+Two large audit knots are independent of the physical-energy loom clusters.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+IVORY, PEARL, ASH, INK = 0, 1, 2, 5
+MAGENTA, ROSE, RED, BLUE, AQUA, SUN, CORAL, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 14, 15
+
+
+LEVELS = [
+    {"name": "First Tide", "start": (0, 4, 0), "plan": (5,), "max_temp": 6,
+     "budget": 4},
+    {"name": "Warm and Cool", "start": (1, 4, 0, 2),
+     "plan": (1, 1, 1, 4, 4, 5, 2, 3), "allow_heat": True, "allow_cool": True,
+     "max_temp": 6, "budget": 10},
+    {"name": "Ceramic Memory", "start": (0, 5, 1, 0, 3),
+     "plan": (1, 1, 4, 4, 2, 3, 5, 5, 1, 5), "allow_heat": True, "allow_cool": True,
+     "heavy": (2,), "max_temp": 6, "budget": 12},
+    {"name": "Stitched Chambers", "start": (2, 0, 5, 0, 1),
+     "plan": (1, 1, 4, 4, 4, 5, 1, 1, 1, 3, 2), "allow_heat": True,
+     "allow_cool": True, "barriers": ((1, 2),), "max_temp": 6, "budget": 13},
+    {"name": "Directional Wick", "start": (0, 4, 0, 5, 1, 0),
+     "plan": (5, 2, 4, 4, 1, 4, 4, 1, 1, 1, 3, 5), "allow_heat": True,
+     "allow_cool": True, "heavy": (4,), "wicks": ((2, 1),), "max_temp": 6,
+     "budget": 14},
+    {"name": "Phase Blossom", "start": (1, 5, 0, 2, 0, 3),
+     "plan": (1, 1, 4, 4, 5, 2, 5, 1, 1, 3, 1, 5, 5), "allow_heat": True,
+     "allow_cool": True, "heavy": (3,), "phase": ((2, 3),), "max_temp": 6,
+     "budget": 15},
+    {"name": "Looped Reservoir", "start": (0, 2, 5, 0, 3, 1),
+     "plan": (4, 2, 2, 3, 3, 3, 1, 5, 5, 2, 3, 1, 1), "allow_heat": True,
+     "allow_cool": True, "heavy": (1,), "barriers": ((2, 3),),
+     "wicks": ((4, -1),), "phase": ((3, 3),), "reservoirs": ((0, 0), (5, 5)),
+     "wrap": True, "max_temp": 6, "budget": 15},
+    {"name": "Thermal Quilt", "start": (1, 5, 0, 3, 0, 4, 2),
+     "plan": (3, 1, 1, 3, 1, 5, 1, 1, 5, 1, 5, 1, 3, 1, 3, 3, 2, 4),
+     "allow_heat": True, "allow_cool": True, "heavy": (1, 5),
+     "barriers": ((2, 3),), "wicks": ((4, 1),), "phase": ((3, 3), (6, 4)),
+     "reservoirs": ((0, 1),), "wrap": True, "max_temp": 6, "budget": 20},
+]
+
+
+def _dict_entries(level, key):
+    return dict(level.get(key, ()))
+
+
+def _neighbors(level, values, index):
+    size = len(values)
+    wrap = level.get("wrap", False)
+    left_index = index - 1
+    right_index = index + 1
+    if left_index < 0:
+        left_index = size - 1 if wrap else index
+    if right_index >= size:
+        right_index = 0 if wrap else index
+    barriers = {frozenset(pair) for pair in level.get("barriers", ())}
+    left = values[index] if frozenset((index, left_index)) in barriers else values[left_index]
+    right = values[index] if frozenset((index, right_index)) in barriers else values[right_index]
+    return left, right
+
+
+def _phase_settle(level, values, locks):
+    values = list(values)
+    for index, threshold in _dict_entries(level, "phase").items():
+        if values[index] >= threshold:
+            locks |= 1 << index
+            values[index] = threshold
+    for index, fixed in _dict_entries(level, "reservoirs").items():
+        values[index] = fixed
+    return tuple(values), locks
+
+
+def diffuse(level, values, locks):
+    changed = []
+    heavy = set(level.get("heavy", ()))
+    wicks = _dict_entries(level, "wicks")
+    reservoirs = _dict_entries(level, "reservoirs")
+    for index, value in enumerate(values):
+        if locks & (1 << index) or index in reservoirs:
+            changed.append(value)
+            continue
+        left, right = _neighbors(level, values, index)
+        if index in wicks:
+            next_value = ((3 * left + value + right) // 5 if wicks[index] < 0
+                          else (left + value + 3 * right) // 5)
+        elif index in heavy:
+            next_value = (left + 4 * value + right) // 6
+        else:
+            next_value = (left + 2 * value + right) // 4
+        changed.append(max(0, min(level["max_temp"], next_value)))
+    return _phase_settle(level, tuple(changed), locks)
+
+
+def start_state(level):
+    values, locks = _phase_settle(level, tuple(level["start"]), 0)
+    # values, locked blossoms, selected pool, audit knots, terminal
+    return values, locks, 0, 2, 0
+
+
+_TARGET_CACHE = {}
+
+
+def target_state(level):
+    """Return the visible target configuration without audit/terminal fields."""
+    key = level["name"]
+    if key not in _TARGET_CACHE:
+        state = start_state(level)
+        for action in level["plan"]:
+            state = transition(level, state, action)
+        _TARGET_CACHE[key] = state[:3]
+    return _TARGET_CACHE[key]
+
+
+def configuration_solved(level, state):
+    return state[:3] == target_state(level)
+
+
+def solved(level, state):
+    return state[4] == 2
+
+
+def transition(level, state, action):
+    values, locks, cursor, audits, terminal = state
+    if terminal:
+        return state
+    size = len(values)
+    if action == 3:
+        next_cursor = (cursor - 1) % size if level.get("wrap") else max(0, cursor - 1)
+        return values, locks, next_cursor, audits, terminal
+    if action == 4:
+        next_cursor = (cursor + 1) % size if level.get("wrap") else min(size - 1, cursor + 1)
+        return values, locks, next_cursor, audits, terminal
+    if action in (1, 2):
+        if ((action == 1 and not level.get("allow_heat"))
+                or (action == 2 and not level.get("allow_cool"))
+                or locks & (1 << cursor) or cursor in _dict_entries(level, "reservoirs")):
+            return state
+        changed = list(values)
+        delta = 1 if action == 1 else -1
+        changed[cursor] = max(0, min(level["max_temp"], changed[cursor] + delta))
+        changed, locks = _phase_settle(level, tuple(changed), locks)
+        return changed, locks, cursor, audits, terminal
+    if action == 5:
+        changed, locks = diffuse(level, values, locks)
+        return changed, locks, cursor, audits, terminal
+    if action == 6:
+        if configuration_solved(level, state):
+            return values, locks, cursor, audits, 2
+        next_audits = max(0, audits - 1)
+        return values, locks, cursor, next_audits, 3 if next_audits == 0 else 0
+    return state
+
+
+def action_cost(level, before, after):
+    """Physical energy only; audit knots and terminal changes are independent."""
+    del level
+    if after == before:
+        return 0
+    return 1 if after[:3] != before[:3] else 0
+
+
+def _with_terminal(state, terminal):
+    return state[:4] + (terminal,)
+
+
+class QuiltDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def _disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        inner = max(0, radius - 1)
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius ** 2 and (not hollow or distance >= inner ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def _line(frame, a, b, color, dotted=False):
+        x0, y0 = a
+        x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for step in range(steps + 1):
+            if dotted and step % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * step // steps
+            y = y0 + (y1 - y0) * step // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    @staticmethod
+    def _interp(old, new, progress, total):
+        delta = new - old
+        distance = (abs(delta) * progress + total // 2) // max(1, total)
+        return old + (distance if delta >= 0 else -distance)
+
+    def _base_kind(self):
+        kind = self.game.anim_kind or ""
+        return kind if kind == "audit_loss" else kind.removesuffix("_loss")
+
+    def _positions(self):
+        size = len(self.game.state[0])
+        return tuple(7 + index * 50 // max(1, size - 1) for index in range(size))
+
+    def _visual_state(self):
+        g = self.game
+        before = g.state
+        after = g.pending_state
+        if after is None or not g.anim_kind:
+            return before
+        p, total = g.anim_progress, max(1, g.anim_total)
+        base = self._base_kind()
+        if base in ("heat", "cool", "diffuse"):
+            values = tuple(self._interp(old, new, p, total)
+                           for old, new in zip(before[0], after[0]))
+            locks = after[1] if p >= total else before[1]
+            audits = after[3] if p >= total else before[3]
+            terminal = after[4] if p >= total else before[4]
+            return values, locks, before[2], audits, terminal
+        return after if p >= total else before
+
+    def _background(self, frame):
+        frame[:, :] = IVORY
+        for y in range(3, 61, 6):
+            frame[y, 1:63:4] = PEARL
+        for x in range(2, 63, 7):
+            frame[1:63:5, x] = ASH
+        frame[13:55, 2:62] = PEARL
+        for y in range(14, 54, 5):
+            frame[y, 3:61:3] = IVORY
+
+    def _pool(self, frame, index, x, value, target_value, locked, target_locked, selected):
+        g = self.game
+        center = (x, 34)
+        size = len(g.state[0])
+        radius = 4 if size >= 7 else 5 if size == 6 else 6
+        material = "normal"
+        if index in g.level.get("heavy", ()):
+            material = "heavy"
+        if index in _dict_entries(g.level, "wicks"):
+            material = "wick"
+        if index in _dict_entries(g.level, "reservoirs"):
+            material = "reservoir"
+        color = BLUE if value <= 1 else AQUA if value <= 3 else CORAL if value <= 5 else SUN
+        self._disc(frame, center, radius + 1, INK)
+        self._disc(frame, center, radius, PEARL)
+        for band in range(value):
+            y = 39 - band * 2
+            width = min(radius, 2 + band // 2)
+            frame[y:y + 2, x - width:x + width + 1] = color
+        for band in range(target_value):
+            y = 39 - band * 2
+            frame[y, max(0, x - radius - 2):max(0, x - radius)] = MAGENTA
+            frame[y, min(64, x + radius + 1):min(64, x + radius + 3)] = MAGENTA
+        if material == "heavy":
+            frame[29:31, x - radius:x + radius + 1:2] = VIOLET
+            frame[38:40, x - radius:x + radius + 1:2] = VIOLET
+        elif material == "wick":
+            direction = _dict_entries(g.level, "wicks")[index]
+            if direction < 0:
+                frame[31:38, x - radius:x + 1] = GREEN
+                frame[34, max(0, x - radius - 2):x - radius + 1] = GREEN
+            else:
+                frame[31:38, x:x + radius + 1] = GREEN
+                frame[34, x + radius:min(64, x + radius + 3)] = GREEN
+        elif material == "reservoir":
+            frame[26:31, x - 2:x + 3] = BLUE
+            frame[24:27, x - 1:x + 2] = BLUE
+        if locked:
+            reach = radius + 2
+            for dx, dy in ((0, -reach), (reach, -reach + 2), (reach, 0),
+                           (reach, reach - 2), (0, reach), (-reach, reach - 2),
+                           (-reach, 0), (-reach, -reach + 2)):
+                px, py = x + dx, 34 + dy
+                if 0 <= px < 64 and 0 <= py < 64:
+                    frame[py, px] = SUN
+        if target_locked:
+            frame[23, x - 3:x + 4:2] = MAGENTA
+        if index in _dict_entries(g.level, "phase") and not locked:
+            threshold = _dict_entries(g.level, "phase")[index]
+            notch_y = 39 - (threshold - 1) * 2
+            frame[notch_y, x - radius:x + radius + 1:2] = SUN
+        if selected:
+            # A stitched crown and hem stay wholly inside endpoint footprints;
+            # the large top gauge supplies magnification without clipped halos.
+            frame[34 - radius - 3, x - radius:x + radius + 1:2] = INK
+            frame[34 + radius + 3, x - radius:x + radius + 1:2] = INK
+            frame[33:36, x - radius] = INK
+            frame[33:36, x + radius] = INK
+
+    def _seams(self, frame):
+        g = self.game
+        xs = self._positions()
+        for left, right in g.level.get("barriers", ()):
+            if abs(left - right) == 1:
+                x = (xs[left] + xs[right]) // 2
+                frame[25:44:2, x - 1:x + 2] = VIOLET
+                frame[27:42:4, x - 3:x + 4] = VIOLET
+        if g.level.get("wrap"):
+            self._line(frame, (xs[0], 25), (xs[0], 15), AQUA)
+            self._line(frame, (xs[0], 15), (xs[-1], 15), AQUA, dotted=True)
+            self._line(frame, (xs[-1], 15), (xs[-1], 25), AQUA)
+
+    def _cursor_stone(self, frame, center):
+        self._disc(frame, center, 3, INK)
+        self._disc(frame, center, 1, SUN)
+
+    def _selected_gauge(self, frame, visual_state, target):
+        selected = visual_state[2]
+        value = visual_state[0][selected]
+        # The gauge compares the selected pool with that same pool's target.
+        # The separate magenta dock continues to communicate final cursor position.
+        target_value = target[0][selected]
+        # Two enlarged, shared-scale wells: round current at left, diamond target at right.
+        self._disc(frame, (27, 7), 5, INK, hollow=True)
+        self._line(frame, (36, 2), (41, 7), MAGENTA)
+        self._line(frame, (41, 7), (36, 12), MAGENTA)
+        self._line(frame, (36, 12), (31, 7), MAGENTA)
+        self._line(frame, (31, 7), (36, 2), MAGENTA)
+        for band in range(value):
+            y = 10 - band
+            frame[y, 25:30] = AQUA if value <= 3 else CORAL
+        for band in range(target_value):
+            y = 10 - band
+            frame[y, 34:39:2] = MAGENTA
+        self._line(frame, (31, 3), (31, 11), ASH, dotted=True)
+        if visual_state[1] & (1 << visual_state[2]):
+            self._disc(frame, (27, 1), 1, SUN)
+        if target[1] & (1 << selected):
+            frame[1, 34:39:2] = MAGENTA
+
+    def _audit_knot(self, frame, index, active):
+        x, y = ((8, 8), (56, 8))[index]
+        if index == 0:
+            # Round four-petal rosette.
+            self._disc(frame, (x, y), 2, GREEN if active else ASH, hollow=not active)
+            for dx, dy in ((0, -4), (4, 0), (0, 4), (-4, 0)):
+                self._disc(frame, (x + dx, y + dy), 1, AQUA if active else ASH,
+                           hollow=not active)
+        else:
+            # Angular loom diamond, deliberately unlike the rosette.
+            color = CORAL if active else ASH
+            self._line(frame, (x, y - 4), (x + 4, y), color)
+            self._line(frame, (x + 4, y), (x, y + 4), color)
+            self._line(frame, (x, y + 4), (x - 4, y), color)
+            self._line(frame, (x - 4, y), (x, y - 4), color)
+            if active:
+                frame[y - 1:y + 2, x - 1:x + 2] = CORAL
+            else:
+                frame[y, x] = INK
+
+    def _audits(self, frame, audits):
+        for index in range(2):
+            self._audit_knot(frame, index, index < audits)
+
+    def _energy(self, frame):
+        g = self.game
+        # Four physical actions make one legible loom-flower cluster.
+        for group in range((g.budget_max + 3) // 4):
+            x, y = 8 + group * 12, 60
+            frame[y, x] = INK
+            for petal, (dx, dy) in enumerate(((0, -2), (2, 0), (0, 2), (-2, 0))):
+                action = group * 4 + petal
+                if action >= g.budget_max:
+                    continue
+                px, py = x + dx, y + dy
+                if action < g.budget_left:
+                    self._disc(frame, (px, py), 1, AQUA if group % 2 == 0 else CORAL)
+                else:
+                    frame[py, px] = ASH
+
+    def _edge_weight(self, destination, source):
+        g = self.game
+        if g.state[1] & (1 << destination) or destination in _dict_entries(g.level, "reservoirs"):
+            return 0
+        if frozenset((destination, source)) in {frozenset(pair) for pair in g.level.get("barriers", ())}:
+            return 0
+        wicks = _dict_entries(g.level, "wicks")
+        if destination in wicks:
+            size = len(g.state[0])
+            favored = ((destination - 1) % size if wicks[destination] < 0
+                       else (destination + 1) % size)
+            return 3 if source == favored else 1
+        return 1
+
+    def _phase_bloom(self, frame, progress):
+        g = self.game
+        if g.pending_state is None:
+            return
+        new_locks = g.pending_state[1] & ~g.state[1]
+        xs = self._positions()
+        size = len(g.state[0])
+        reach = (4 if size >= 7 else 5 if size == 6 else 6) + 2
+        petals = ((0, -reach), (reach, -reach + 2), (reach, 0),
+                  (reach, reach - 2), (0, reach), (-reach, reach - 2),
+                  (-reach, 0), (-reach, -reach + 2))
+        for index, x in enumerate(xs):
+            if not new_locks & (1 << index):
+                continue
+            for dx, dy in petals[:min(len(petals), progress + 1)]:
+                px, py = x + dx, 34 + dy
+                if 0 <= px < 64 and 0 <= py < 64:
+                    frame[py, px] = SUN
+
+    def _loss_hold(self, frame):
+        frame[18:50:2, 4:60] = RED
+        frame[18:50, 4:60:4] = VIOLET
+
+    def _win_hold(self, frame):
+        for radius, color in ((17, AQUA), (12, GREEN), (7, SUN)):
+            self._disc(frame, (32, 34), radius, color)
+        self._disc(frame, (32, 34), 3, IVORY)
+
+    def _event_animation(self, frame, base, progress, total):
+        g = self.game
+        xs = self._positions()
+        if progress >= total:
+            return
+        if base == "move":
+            a, b = xs[g.anim_from], xs[g.anim_to]
+            x = a + (b - a) * progress // max(1, total)
+            lift = progress * (total - progress) // max(1, total * 2)
+            self._cursor_stone(frame, (x, 49 - lift))
+        elif base in ("heat", "cool"):
+            x = xs[g.state[2]]
+            radius = 2 + progress * 2
+            for dx in range(-radius, radius + 1):
+                y = 34 + abs(dx) // 3
+                if 0 <= x + dx < 64 and 0 <= y < 64:
+                    frame[y, x + dx] = CORAL if base == "heat" else BLUE
+        elif base == "diffuse":
+            for index, (left, right) in enumerate(zip(xs, xs[1:])):
+                distance = right - left
+                span = max(1, distance * progress // max(1, total))
+                rightward = self._edge_weight(index + 1, index)
+                leftward = self._edge_weight(index, index + 1)
+                if rightward:
+                    lane = 31 if rightward == 1 else 30
+                    frame[lane:lane + (2 if rightward == 3 else 1),
+                          left:min(right, left + span)] = CORAL
+                if leftward:
+                    lane = 37 if leftward == 1 else 38
+                    frame[lane - (1 if leftward == 3 else 0):lane + 1,
+                          max(left, right - span):right] = AQUA
+            if g.level.get("wrap"):
+                if self._edge_weight(0, len(xs) - 1):
+                    frame[15 - min(4, progress):16, xs[0]:xs[-1]:2] = CORAL
+                if self._edge_weight(len(xs) - 1, 0):
+                    frame[16:17 + min(3, progress), xs[0]:xs[-1]:2] = AQUA
+        if base in ("heat", "cool", "diffuse"):
+            self._phase_bloom(frame, progress)
+
+    def _animation(self, frame):
+        g = self.game
+        if g.intro_mark:
+            self._line(frame, (1, 18), (1, 50), AQUA, dotted=True)
+            self._line(frame, (62, 18), (62, 50), CORAL, dotted=True)
+        if g.terminal_hold == "win":
+            self._win_hold(frame)
+        elif g.terminal_hold == "loss":
+            self._loss_hold(frame)
+        if not g.anim_kind:
+            return
+        p, total = g.anim_progress, max(1, g.anim_total)
+        base = self._base_kind()
+        if base in ("move", "heat", "cool", "diffuse"):
+            if base == "move" and p >= total:
+                xs = self._positions()
+                self._cursor_stone(frame, (xs[g.anim_to], 49))
+            else:
+                self._event_animation(frame, base, p, total)
+        elif base == "blocked" and p < total:
+            x = self._positions()[g.state[2]]
+            frame[25 + p:44 - p, x - 7:x + 8:2] = RED
+        elif base in ("audit_reject", "audit_loss") and p < total:
+            spent = max(0, g.state[3] - 1)
+            x, y = ((8, 8), (56, 8))[spent]
+            end_x = x + (32 - x) * p // total
+            end_y = y + (17 - y) * p // total
+            # A continuously lengthening loose thread makes every reject frame
+            # spatially distinct without blinking the knot itself.
+            self._line(frame, (x, y), (end_x, end_y), RED)
+        elif base == "success":
+            for radius, color in ((2 + p * 2, GREEN), (1 + p, AQUA)):
+                self._disc(frame, (32, 34), radius, color, hollow=True)
+            self._line(frame, (4, 54 - p * 5), (60, 54 - p * 5), SUN, dotted=True)
+        if g.anim_kind.endswith("_loss") or base == "audit_loss":
+            lead = max(0, p - (total - 3))
+            if p >= total:
+                self._loss_hold(frame)
+            elif lead:
+                frame[18 + lead:50 - lead:2, 4 + lead:60 - lead] = RED
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        g = self.game
+        visual = self._visual_state()
+        target = target_state(g.level)
+        self._background(frame)
+        self._seams(frame)
+        xs = self._positions()
+        moving = self._base_kind() == "move" and g.anim_kind is not None
+        for index, (x, value, target_value) in enumerate(zip(xs, visual[0], target[0])):
+            self._pool(frame, index, x, value, target_value,
+                       bool(visual[1] & (1 << index)), bool(target[1] & (1 << index)),
+                       index == visual[2] and not moving)
+        if not moving:
+            self._cursor_stone(frame, (xs[visual[2]], 49))
+        dock_x = xs[target[2]]
+        frame[52:55, dock_x - 4:dock_x + 5:2] = MAGENTA
+        frame[53, dock_x - 1:dock_x + 2] = IVORY
+        self._selected_gauge(frame, visual, target)
+        self._audits(frame, visual[3])
+        self._energy(frame)
+        self._animation(frame)
+        return frame
+
+
+class Q176(ARCBaseGame):
+    def __init__(self):
+        self.display = QuiltDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_from = self.anim_to = 0
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q176", levels, Camera(0, 0, 64, 64, IVORY, IVORY, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+
+    def _begin(self, kind, frames, *, next_state=None, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.pending_state = next_state
+        self.pending_terminal = terminal
+
+    def _finish(self):
+        terminal = self.pending_terminal
+        if self.pending_state is not None:
+            self.state = self.pending_state
+        self.anim_kind = None
+        self.pending_state = None
+        self.pending_terminal = None
+        if terminal == "win":
+            self.terminal_hold = "win"
+            self.next_level()
+        elif terminal == "loss":
+            self.terminal_hold = "loss"
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self._finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        self.intro_mark = False
+        before = self.state
+        after = transition(self.level, before, action)
+        if after == before:
+            self._begin("blocked", 3, next_state=before)
+            return
+        if action == 6:
+            if after[4] == 2:
+                self._begin("success", 6, next_state=after, terminal="win")
+            elif after[4] == 3:
+                self._begin("audit_loss", 7, next_state=after, terminal="loss")
+            else:
+                self._begin("audit_reject", 5, next_state=after)
+            return
+        self.budget_left -= action_cost(self.level, before, after)
+        self.anim_from, self.anim_to = before[2], after[2]
+        base = ("move" if action in (3, 4) else "heat" if action == 1
+                else "cool" if action == 2 else "diffuse")
+        exhausted = self.budget_left <= 0 and not configuration_solved(self.level, after)
+        if exhausted:
+            after = _with_terminal(after, 3)
+            self._begin(base + "_loss", 8, next_state=after, terminal="loss")
+        else:
+            self._begin(base, 7 if base == "diffuse" else 4, next_state=after)

--- a/data/community-games/sonpham/q181_v2_q181.py
+++ b/data/community-games/sonpham/q181_v2_q181.py
@@ -1,0 +1,336 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q181-v2 Palimpsest Garden -- present shortcuts write future terrain debt."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, PEARL, ASH, SLATE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, AQUA, GOLD, CORAL, EARTH, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+DIRS = {1: (0, -1), 2: (0, 1), 3: (-1, 0), 4: (1, 0)}
+ARROWS = {"^": 1, "v": 2, "<": 3, ">": 4}
+W, H = 9, 5
+
+
+LEVELS = [
+    {"name": "One Tomorrow", "first": ("#########", "#S..a..G#", "#.......#", "#########", "#########"),
+     "future": ("#########", "#S.....G#", "#.#####.#", "#.......#", "#########"),
+     "debts": {"a": ((4, 1),)}, "budget": 15},
+    {"name": "Bramble Shape", "first": ("#########", "#S..a..G#", "#.......#", "#########", "#########"),
+     "future": ("#########", "#S.....G#", "#.#####.#", "#.......#", "#########"),
+     "debts": {"a": ((3, 1), (4, 1), (5, 1))}, "budget": 15},
+    {"name": "Two Ledgers", "first": ("#########", "#S.a...G#", "#.#####.#", "#..b....#", "#########"),
+     "future": ("#########", "#S.....G#", "#.#####.#", "#.......#", "#########"),
+     "debts": {"a": ((4, 1),), "b": ((4, 3),)}, "budget": 17},
+    {"name": "Countermark", "first": ("#########", "#S.a...G#", "#..b....#", "#########", "#########"),
+     "future": ("#########", "#S.....G#", "#########", "#########", "#########"),
+     "debts": {"a": ((4, 1),), "b": ((4, 1),)}, "toggle": True, "budget": 15},
+    {"name": "Rewind Shrine", "first": ("#########", "#S.a...G#", "###.#####", "###r#####", "#########"),
+     "future": ("#########", "#S.....G#", "#########", "#########", "#########"),
+     "debts": {"a": ((4, 1),)}, "budget": 17},
+    {"name": "Wind Reeds", "first": ("#########", "#S..a..G#", "#########", "#########", "#########"),
+     "future": ("#########", "#S.....G#", "#.#####^#", "#..>....#", "#########"),
+     "debts": {"a": ((4, 1),)}, "budget": 17},
+    {"name": "Double Entry", "first": ("#########", "#S.a...G#", "#..b....#", "#########", "#########"),
+     "future": ("#########", "#S.....G#", "#.#####^#", "#..>....#", "#########"),
+     "debts": {"a": ((4, 1), (5, 1)), "b": ((4, 1), (5, 1))}, "toggle": True, "budget": 15},
+    {"name": "Palimpsest Garden", "first": ("#########", "#S.a...G#", "#..b.r..#", "#########", "#########"),
+     "future": ("#########", "#S.....G#", "#.#####^#", "#..>....#", "#########"),
+     "debts": {"a": ((4, 1), (5, 1)), "b": ((4, 1),)}, "toggle": True, "budget": 15},
+]
+
+
+def locate(grid, char):
+    for y, row in enumerate(grid):
+        for x, value in enumerate(row):
+            if value == char:
+                return x, y
+    raise ValueError(char)
+
+
+def debt_keys(level):
+    return tuple(sorted(level["debts"]))
+
+
+def debt_cells(level, state):
+    _phase, _x, _y, active, repaired, _last = state
+    cells = set()
+    for index, key in enumerate(debt_keys(level)):
+        bit = 1 << index
+        if not active & bit or repaired & bit:
+            continue
+        shape = set(level["debts"][key])
+        if level.get("toggle"):
+            cells ^= shape
+        else:
+            cells |= shape
+    return frozenset(cells)
+
+
+def start_state(level):
+    x, y = locate(level["first"], "S")
+    return 0, x, y, 0, 0, -1
+
+
+def transition(level, state, action):
+    phase, x, y, active, repaired, last = state
+    if phase >= 2 or action not in DIRS:
+        return state
+    grid = level["first"] if phase == 0 else level["future"]
+    dx, dy = DIRS[action]; nx, ny = x + dx, y + dy
+    if not (0 <= nx < W and 0 <= ny < H) or grid[ny][nx] == "#":
+        return state
+    if phase == 1 and (nx, ny) in debt_cells(level, state):
+        return state
+    if phase == 1 and grid[ny][nx] in ARROWS and ARROWS[grid[ny][nx]] != action:
+        return state
+    char = grid[ny][nx]
+    if phase == 0 and char in level["debts"]:
+        index = debt_keys(level).index(char); bit = 1 << index
+        if not active & bit:
+            active |= bit; last = index
+    if phase == 0 and char == "r" and last >= 0 and not repaired:
+        repaired |= 1 << last
+    if char == "G":
+        if phase == 0:
+            sx, sy = locate(level["future"], "S")
+            return 1, sx, sy, active, repaired, last
+        return 2, nx, ny, active, repaired, last
+    return phase, nx, ny, active, repaired, last
+
+
+def solved(_level, state):
+    return state[0] == 2
+
+
+class GardenDisplay(RenderableUserDisplay):
+    CELL, OX, TOP, BOTTOM = 5, 9, 3, 36
+
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def _disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                d = (x - cx) ** 2 + (y - cy) ** 2
+                if d <= radius ** 2 and (not hollow or d >= max(0, radius - 2) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def _line(frame, a, b, color, dotted=False):
+        x0, y0 = a; x1, y1 = b; steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for i in range(steps + 1):
+            if dotted and i % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * i // steps; y = y0 + (y1 - y0) * i // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    @classmethod
+    def _center(cls, phase, pos):
+        ox = cls.OX; oy = cls.TOP if phase == 0 else cls.BOTTOM
+        return ox + pos[0] * cls.CELL + 2, oy + pos[1] * cls.CELL + 2
+
+    def _glyph(self, frame, key, center, color, hollow=False):
+        x, y = center; index = max(0, ord(key) - ord("a"))
+        if index % 3 == 0:
+            self._disc(frame, center, 2, color, hollow=hollow)
+        elif index % 3 == 1:
+            self._line(frame, (x, y - 2), (x + 2, y), color)
+            self._line(frame, (x + 2, y), (x, y + 2), color)
+            self._line(frame, (x, y + 2), (x - 2, y), color)
+            self._line(frame, (x - 2, y), (x, y - 2), color)
+        else:
+            self._line(frame, (x, y - 2), (x + 2, y + 2), color)
+            self._line(frame, (x + 2, y + 2), (x - 2, y + 2), color)
+            self._line(frame, (x - 2, y + 2), (x, y - 2), color)
+
+    def _background(self, frame):
+        frame[:, :] = INK
+        for y in range(1, 63, 5): frame[y, 2 + y % 4:62:8] = CHARCOAL
+        for x in range(3, 62, 7): frame[2 + x % 5:62:9, x] = EARTH
+        frame[30:35, 5:59] = SLATE
+        for x in range(8, 58, 8):
+            self._disc(frame, (x, 32), 2, GOLD, hollow=True)
+
+    def _wall(self, frame, center, future):
+        x, y = center; color = BLUE if future else EARTH
+        self._disc(frame, center, 3, color)
+        self._disc(frame, (x - 2, y - 1), 2, CHARCOAL)
+        self._disc(frame, (x + 2, y + 1), 2, color)
+        frame[y - 2:y + 3:2, x - 2:x + 3:2] = ASH if future else GOLD
+
+    def _path(self, frame, center, future):
+        x, y = center; base = SLATE if future else EARTH; accent = AQUA if future else CORAL
+        self._disc(frame, center, 3, base)
+        frame[y, x - 2:x + 3:2] = accent
+
+    def _debt(self, frame, center):
+        x, y = center
+        self._disc(frame, center, 3, CHARCOAL)
+        self._line(frame, (x - 3, y + 3), (x, y - 3), RED)
+        self._line(frame, (x, y - 3), (x + 3, y + 3), RED)
+        self._line(frame, (x - 3, y), (x + 3, y), VIOLET)
+
+    def _beetle(self, frame, center, color=GREEN):
+        x, y = center
+        self._disc(frame, center, 3, color)
+        self._line(frame, (x, y - 3), (x, y + 3), INK)
+        self._line(frame, (x - 2, y - 1), (x - 4, y - 3), color)
+        self._line(frame, (x + 2, y - 1), (x + 4, y - 3), color)
+
+    def _goal(self, frame, center, future):
+        x, y = center; color = AQUA if future else GOLD
+        self._disc(frame, center, 4, color, hollow=True)
+        frame[y:y + 4, x - 4:x + 5] = color
+        frame[y + 1:y + 4, x - 2:x + 3] = INK
+
+    def _room(self, frame, phase, grid, state):
+        g = self.game; future = phase == 1; active_debts = debt_cells(g.level, state)
+        preview = {}
+        for key, cells in g.level["debts"].items():
+            for cell in cells: preview.setdefault(tuple(cell), []).append(key)
+        for y, row in enumerate(grid):
+            for x, char in enumerate(row):
+                center = self._center(phase, (x, y))
+                if char == "#": self._wall(frame, center, future); continue
+                self._path(frame, center, future)
+                if future and (x, y) in active_debts:
+                    self._debt(frame, center)
+                elif future and (x, y) in preview:
+                    for offset, key in enumerate(preview[(x, y)][:2]):
+                        self._glyph(frame, key, (center[0] - 1 + offset * 2, center[1]), ASH, hollow=True)
+                if char in g.level["debts"]:
+                    index = debt_keys(g.level).index(char); used = bool(state[3] & (1 << index)); repaired = bool(state[4] & (1 << index))
+                    self._glyph(frame, char, center, ASH if repaired else PEARL if used else GOLD, hollow=used)
+                elif char == "r":
+                    self._disc(frame, center, 3, AQUA, hollow=True)
+                    self._line(frame, (center[0] - 2, center[1]), (center[0] + 2, center[1] - 2), AQUA)
+                elif char in ARROWS:
+                    action = ARROWS[char]; dx, dy = DIRS[action]
+                    self._line(frame, (center[0] - dx * 2, center[1] - dy * 2), (center[0] + dx * 2, center[1] + dy * 2), PEARL)
+                    self._line(frame, (center[0] + dx * 2, center[1] + dy * 2), (center[0] + dx - dy * 2, center[1] + dy + dx * 2), PEARL)
+                if char == "G": self._goal(frame, center, future)
+        # Inactive room keeps a pinned insect at its entry/exit; active room carries the player.
+        if state[0] == phase:
+            self._beetle(frame, self._center(phase, (state[1], state[2])))
+        elif phase == 0:
+            self._beetle(frame, self._center(phase, locate(grid, "G")), ASH)
+        else:
+            self._beetle(frame, self._center(phase, locate(grid, "S")), ASH)
+
+    def _hud(self, frame):
+        g = self.game; groups, remainder = divmod(g.budget_left, 5)
+        for i in range(groups):
+            x = 4 + i * 7
+            self._disc(frame, (x, 62), 2, GREEN, hollow=True)
+            frame[60:63, x] = GREEN
+        for i in range(remainder): frame[60:63, 43 + i * 3] = GOLD
+        # The causal ledger preserves which shortcut shape was used or repaired.
+        for index, key in enumerate(debt_keys(g.level)):
+            x = 47 + index * 7; y = 32
+            used = bool(g.state[3] & (1 << index)); repaired = bool(g.state[4] & (1 << index))
+            self._glyph(frame, key, (x, y), AQUA if repaired else RED if used else ASH, hollow=not used)
+            if used:
+                self._line(frame, (x, 28), (x, 36), AQUA if repaired else RED, dotted=repaired)
+
+    def _animation(self, frame):
+        g = self.game
+        if not g.anim_kind:
+            if g.intro_mark:
+                self._disc(frame, self._center(0, locate(g.level["first"], "S")), 7, GOLD, hollow=True)
+            if g.terminal_hold == "loss":
+                self._line(frame, (8, 8), (56, 57), RED)
+                self._line(frame, (56, 8), (8, 57), RED)
+            return
+        p = g.anim_progress
+        if g.anim_kind == "move":
+            before = self._center(g.state[0], (g.state[1], g.state[2])); after = self._center(g.pending_state[0], (g.pending_state[1], g.pending_state[2]))
+            x = before[0] + (after[0] - before[0]) * p // g.anim_total
+            y = before[1] + (after[1] - before[1]) * p // g.anim_total
+            self._beetle(frame, (x, y), CORAL)
+        elif g.anim_kind in ("stamp", "repair"):
+            key = debt_keys(g.level)[g.pending_state[5] if g.pending_state[5] >= 0 else 0]
+            source = self._center(0, (g.pending_state[1], g.pending_state[2]))
+            target = self._center(1, g.level["debts"][key][0])
+            mid = (source[0] + (target[0] - source[0]) * p // g.anim_total,
+                   source[1] + (target[1] - source[1]) * p // g.anim_total)
+            self._glyph(frame, key, mid, AQUA if g.anim_kind == "repair" else RED)
+            self._line(frame, source, mid, AQUA if g.anim_kind == "repair" else VIOLET, dotted=True)
+        elif g.anim_kind == "phase":
+            y = 4 + p * 7
+            frame[max(0, y - 2):min(64, y + 3), 5:59] = AQUA
+            self._disc(frame, (32, 32), min(12, 2 + p * 2), GOLD, hollow=True)
+        elif g.anim_kind == "blocked":
+            center = self._center(g.state[0], (g.state[1], g.state[2]))
+            self._disc(frame, center, 4 + p % 2, RED, hollow=True)
+        elif g.anim_kind == "success":
+            for radius in range(4, min(30, 4 + p * 4), 5): self._disc(frame, (32, 32), radius, GREEN, hollow=True)
+        elif g.anim_kind == "loss":
+            self._line(frame, (8 + p, 8), (56 - p, 57), RED)
+            self._line(frame, (56 - p, 8), (8 + p, 57), RED)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self._background(frame); self._room(frame, 0, self.game.level["first"], self.game.state)
+        self._room(frame, 1, self.game.level["future"], self.game.state)
+        self._hud(frame); self._animation(frame); return frame
+
+
+class Q181(ARCBaseGame):
+    def __init__(self):
+        self.display = GardenDisplay(self); self.level = LEVELS[0]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0; self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = None; self.pending_budget = None; self.pending_terminal = None
+        self.intro_mark = True; self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"]) for item in LEVELS]
+        super().__init__("q181", levels, Camera(0, 0, 64, 64, INK, INK, [self.display]), False, len(levels), [1, 2, 3, 4])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = None; self.pending_budget = None; self.pending_terminal = None
+        self.intro_mark = True; self.terminal_hold = None
+
+    def _begin(self, kind, frames, state, budget, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames; self.anim_progress = 0
+        self.pending_state = state; self.pending_budget = budget; self.pending_terminal = terminal
+
+    def _finish(self):
+        terminal = self.pending_terminal; self.state = self.pending_state; self.budget_left = self.pending_budget
+        self.anim_kind = None; self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.terminal_hold = "win"; self.next_level()
+        elif terminal == "loss":
+            self.terminal_hold = "loss"; self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1; self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0: self._finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action(); return
+        self.intro_mark = False
+        after = transition(self.level, self.state, action)
+        if after == self.state:
+            self._begin("blocked", 4, after, self.budget_left); return
+        budget = self.budget_left - 1; won = solved(self.level, after); lost = budget <= 0 and not won
+        new_active = after[3] != self.state[3]; new_repair = after[4] != self.state[4]
+        phase_change = after[0] != self.state[0] and not won
+        kind = "success" if won else "phase" if phase_change else "repair" if new_repair else "stamp" if new_active else "move"
+        self._begin(kind, 7 if kind in ("success", "phase", "stamp", "repair") else 5,
+                    after, budget, "win" if won else "loss" if lost else None)

--- a/data/community-games/sonpham/q191_v2_q191.py
+++ b/data/community-games/sonpham/q191_v2_q191.py
@@ -1,0 +1,324 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q191-v2 Shutter Orbit -- compress a kinetic reel at causal boundaries.
+
+The reel is turn based: WAIT advances its aperture and CUT commits only at the
+next shape-coded event.  Later reels add tempo splices, direction reversal,
+round-trip echoes, and event drift.  Timing is never real-time or motor based.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PAPER, SILVER, ASH, SLATE, COAL, INK = 0, 1, 2, 3, 4, 5
+MAGENTA, ROSE, RED, BLUE, AQUA, GOLD, CORAL, EARTH, GREEN, VIOLET = 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
+
+
+LEVELS = [
+    {"name": "First Cut", "period": 8, "events": (2,), "budget": 5,
+     "warp": (), "reverse": (), "echo": (), "drift": False},
+    {"name": "Shape Reel", "period": 13, "events": (3, 10, 5), "budget": 23,
+     "warp": (), "reverse": (), "echo": (), "drift": False},
+    {"name": "Elastic Film", "period": 15, "events": (5, 12, 7), "budget": 25,
+     "warp": (1, 2, 8), "reverse": (), "echo": (), "drift": False},
+    {"name": "Backsplice", "period": 14, "events": (3, 10, 5), "budget": 26,
+     "warp": (), "reverse": (0, 1), "echo": (), "drift": False},
+    {"name": "Echo Gate", "period": 12, "events": (2, 7), "budget": 27,
+     "warp": (), "reverse": (), "echo": (1,), "drift": False},
+    {"name": "Walking Marks", "period": 15, "events": (4, 11, 6), "budget": 26,
+     "warp": (), "reverse": (), "echo": (), "drift": True},
+    {"name": "Moonlit Assembly", "period": 16, "events": (3, 12, 7), "budget": 38,
+     "warp": (1, 8, 9), "reverse": (0, 2), "echo": (1,), "drift": False},
+    {"name": "Shutter Orbit", "period": 17, "events": (4, 13, 8, 1), "budget": 48,
+     "warp": (2, 3, 10), "reverse": (0, 2), "echo": (1,), "drift": True},
+]
+
+
+def start_state(level):
+    # phase, next event, direction, event drift, echo charge, remaining slips
+    return 0, 0, 1, 0, 0, 2
+
+
+def event_phase(level, state, index=None):
+    if index is None:
+        index = state[1]
+    return (level["events"][index] + state[3]) % level["period"]
+
+
+def transition(level, state, action):
+    phase, index, direction, shift, echo, slips = state
+    if index >= len(level["events"]) or slips <= 0:
+        return state
+    if action == 5:
+        jump = 2 if phase in level.get("warp", ()) else 1
+        phase = (phase + direction * jump) % level["period"]
+        if echo == 1:
+            opposite = (event_phase(level, state) + level["period"] // 2) % level["period"]
+            if phase == opposite:
+                echo = 2
+        return phase, index, direction, shift, echo, slips
+    if action != 6 or phase != event_phase(level, state):
+        return phase, index, direction, shift, echo, slips - (1 if action == 6 else 0)
+    if index in level.get("echo", ()):
+        if echo == 0:
+            return phase, index, direction, shift, 1, slips
+        if echo != 2:
+            return phase, index, direction, shift, echo, slips - 1
+    old_index = index
+    index += 1
+    echo = 0
+    if level.get("drift"):
+        shift = (shift + direction) % level["period"]
+    if old_index in level.get("reverse", ()):
+        direction *= -1
+    return phase, index, direction, shift, echo, slips
+
+
+def solved(level, state):
+    return state[1] == len(level["events"]) and state[5] > 0
+
+
+class OrbitDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def _disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                d = (x - cx) ** 2 + (y - cy) ** 2
+                if d <= radius ** 2 and (not hollow or d >= max(0, radius - 2) ** 2):
+                    frame[y, x] = color
+
+    @staticmethod
+    def _line(frame, a, b, color, dotted=False):
+        x0, y0 = a; x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for i in range(steps + 1):
+            if dotted and i % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * i // steps
+            y = y0 + (y1 - y0) * i // steps
+            if 0 <= x < 64 and 0 <= y < 64:
+                frame[y, x] = color
+
+    @staticmethod
+    def _pos(phase, period, radius=20):
+        angle = -math.pi / 2 + 2 * math.pi * phase / period
+        return 32 + round(radius * math.cos(angle)), 31 + round(radius * math.sin(angle))
+
+    def _background(self, frame):
+        frame[:, :] = INK
+        frame[3:59, 3:61] = COAL
+        # Film grain and perforations are sparse, stable, and non-flashing.
+        for y in range(6, 58, 5):
+            frame[y, 5 + (y % 7):59:9] = SLATE
+        for x in range(6, 59, 7):
+            frame[5:8, x:x + 2] = ASH
+            frame[54:57, x:x + 2] = ASH
+        frame[9:53, 6:58] = INK
+        self._disc(frame, (32, 31), 23, SLATE, hollow=True)
+        self._disc(frame, (32, 31), 18, COAL, hollow=True)
+        self._disc(frame, (32, 31), 4, ASH, hollow=True)
+
+    def _event_glyph(self, frame, index, center, color, tiny=False):
+        x, y = center; r = 1 if tiny else 3
+        kind = index % 4
+        if kind == 0:
+            self._disc(frame, center, r + 1, color, hollow=True)
+            frame[y, x] = color
+        elif kind == 1:
+            for d in range(-r, r + 1):
+                span = r - abs(d)
+                frame[y + d, x - span:x + span + 1] = color
+        elif kind == 2:
+            frame[y - r:y + r + 1, x] = color
+            frame[y, x - r:x + r + 1] = color
+        else:
+            self._line(frame, (x - r, y - r), (x + r, y + r), color)
+            self._line(frame, (x + r, y - r), (x - r, y + r), color)
+
+    def _track(self, frame):
+        g = self.game; state = g.state
+        for p in range(g.level["period"]):
+            x, y = self._pos(p, g.level["period"])
+            color = ASH if p not in g.level.get("warp", ()) else VIOLET
+            if p in g.level.get("warp", ()):
+                frame[y - 1:y + 2, x - 1:x + 2] = color
+                frame[y, x] = INK
+            else:
+                self._disc(frame, (x, y), 1, color)
+        for i in range(state[1], len(g.level["events"])):
+            phase = (g.level["events"][i] + state[3]) % g.level["period"]
+            self._event_glyph(frame, i, self._pos(phase, g.level["period"]), GOLD if i == state[1] else AQUA)
+        # Echo checkpoint is a doubled, dotted moon opposite the active event.
+        if state[1] < len(g.level["events"]) and state[1] in g.level.get("echo", ()):
+            opposite = (event_phase(g.level, state) + g.level["period"] // 2) % g.level["period"]
+            x, y = self._pos(opposite, g.level["period"])
+            self._disc(frame, (x, y), 4, ROSE, hollow=True)
+            if state[4] == 2:
+                self._disc(frame, (x, y), 2, ROSE)
+        # The aperture has a triangular nose, so its direction is not color-only.
+        x, y = self._pos(state[0], g.level["period"], 16)
+        self._disc(frame, (x, y), 4, SILVER)
+        self._disc(frame, (x, y), 2, BLUE)
+        frame[y, x + state[2] * 4] = GOLD
+        frame[y - 1:y + 2, x + state[2] * 3] = GOLD
+
+    def _reel_hud(self, frame):
+        g = self.game; state = g.state
+        # Captured events become punched, shape-coded cells in a physical reel.
+        start = 30 - 6 * len(g.level["events"]) // 2
+        for i in range(len(g.level["events"])):
+            x = start + i * 7
+            frame[1:7, x - 2:x + 3] = SLATE
+            if i < state[1]:
+                self._event_glyph(frame, i, (x, 4), GOLD, tiny=True)
+            else:
+                frame[3:5, x - 1:x + 2] = INK
+        # Direction is a wide chevron, not an unexplained colored slab.
+        d = state[2]
+        cx = 32
+        for k in range(5):
+            frame[59 + abs(2 - k):61 + abs(2 - k), cx + d * (k - 2)] = AQUA
+        # Budget and two recoverable film slips use distinct physical notches.
+        groups, remainder = divmod(g.budget_left, 4)
+        for i in range(groups):
+            x = 5 + i * 3
+            self._disc(frame, (x, 58), 2, SILVER, hollow=True)
+            frame[58, x] = SILVER
+        for i in range(remainder):
+            frame[57:59, 43 + i * 2] = GOLD
+        for i in range(2):
+            x = 53 + i * 4
+            if i < state[5]:
+                self._disc(frame, (x, 58), 2, ROSE, hollow=True)
+            else:
+                frame[57:60, x - 1:x + 2] = RED
+
+    def _animation(self, frame):
+        g = self.game
+        if not g.anim_kind:
+            if g.intro_mark:
+                self._disc(frame, (32, 31), 6, GOLD, hollow=True)
+            if g.terminal_hold == "loss":
+                frame[28:35, 7:57] = RED
+                frame[30:33, 11:53:4] = INK
+            elif g.terminal_hold == "win":
+                self._disc(frame, (32, 31), 12, GREEN, hollow=True)
+            return
+        p = g.anim_progress; total = max(1, g.anim_total)
+        if g.anim_kind == "wait":
+            before = self._pos(g.anim_before[0], g.level["period"], 16)
+            after = self._pos(g.pending_state[0], g.level["period"], 16)
+            x = before[0] + (after[0] - before[0]) * p // total
+            y = before[1] + (after[1] - before[1]) * p // total
+            self._disc(frame, (x, y), 2 + p % 2, AQUA)
+            self._line(frame, before, (x, y), VIOLET, dotted=True)
+        elif g.anim_kind in ("capture", "echo"):
+            x, y = self._pos(g.state[0], g.level["period"])
+            self._disc(frame, (x, y), min(8, 2 + p), GOLD, hollow=True)
+            self._line(frame, (x, y), (32, 4), GOLD, dotted=(g.anim_kind == "echo"))
+            if g.anim_kind == "echo":
+                self._disc(frame, (32, 31), min(10, 2 + p), ROSE, hollow=True)
+        elif g.anim_kind == "miss":
+            offset = (2, -2, 1, -1, 0)[min(p, 4)]
+            frame[12:51, 30 + offset:34 + offset] = RED
+            frame[16:47:4, 7:57] = RED
+        elif g.anim_kind == "transition":
+            self._disc(frame, (32, 31), min(20, 3 + p * 3), GREEN, hollow=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self._background(frame)
+        self._track(frame)
+        self._reel_hud(frame)
+        self._animation(frame)
+        return frame
+
+
+class Q191(ARCBaseGame):
+    def __init__(self):
+        self.display = OrbitDisplay(self)
+        self.level = LEVELS[0]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_before = self.state
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q191", levels, Camera(0, 0, 64, 64, INK, INK, [self.display]),
+                         False, len(levels), [5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]
+        self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+
+    def _begin(self, kind, frames, next_state, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = self.anim_left = frames
+        self.anim_progress = 0
+        self.anim_before = self.state
+        self.pending_state = next_state
+        self.pending_terminal = terminal
+
+    def _finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state
+        self.anim_kind = None
+        self.pending_state = None
+        self.pending_terminal = None
+        if terminal == "win":
+            self.terminal_hold = "win"
+            self.next_level()
+        elif terminal == "loss" or self.budget_left <= 0:
+            self.terminal_hold = "loss"
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self._finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action(); return
+        self.intro_mark = False
+        if action not in (5, 6):
+            self._begin("miss", 4, self.state); return
+        after = transition(self.level, self.state, action)
+        self.budget_left -= 1
+        if action == 5:
+            kind = "wait"
+        elif after[5] < self.state[5]:
+            kind = "miss"
+        elif after[1] == self.state[1]:
+            kind = "echo"
+        else:
+            kind = "capture"
+        terminal = "win" if solved(self.level, after) else "loss" if after[5] <= 0 or self.budget_left <= 0 else None
+        self._begin(kind, 4 if kind == "wait" else 6, after, terminal)

--- a/data/community-games/sonpham/q193_v2_q193.py
+++ b/data/community-games/sonpham/q193_v2_q193.py
@@ -1,0 +1,629 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q193-v2 Brassbound Routines -- bind and replay branch-safe action ribbons.
+
+The player punches a short reusable ribbon, closes an arched clamp, turns a
+shape-coded transformation cam, previews the complete consequence, and then
+replays the whole ribbon into exactly one folio branch.  Individual punches
+never write the target, so manual target typing cannot replace abstraction.
+One rejected clamp or replay leaves the work intact for editing; the second
+breaks the two-seal audit and ends the run.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import math
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+PARCHMENT, PAPER, ASH, STONE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+ROSE, CORAL, RED, SKY, AQUA, GOLD = 6, 7, 8, 9, 10, 11
+BRASS, OXBLOOD, MOSS, VIOLET = 12, 13, 14, 15
+
+GLYPHS = 4
+MAX_RIBBON = 4
+TERMINAL_INDEX = 9
+
+
+def bindery(name, motif, cams, budget, *, prefill=(), branch_after=()):
+    branches = frozenset(branch_after)
+    return {
+        "name": name,
+        "motif": tuple(motif),
+        "cams": tuple(cams),
+        "budget": budget,
+        "prefill": tuple(prefill),
+        "branch_after": branches,
+        # The audit contract is deliberately separate from the mechanism.  A
+        # qualifier can remove branch_after while preserving required_branches
+        # and prove that the corresponding campaign becomes unsolvable.
+        "required_branches": branches,
+    }
+
+
+LEVELS = [
+    bindery("Three Punches", (0, 2, 1), (0,), 11),
+    bindery("Branch Binding", (1, 3, 0), (0, 1), 16,
+             branch_after=(0,)),
+    bindery("Ratchet Refrain", (2, 0, 3), (0, 0, 0), 19,
+             branch_after=(0, 1)),
+    bindery("Counterfeit Tooth", (0, 1, 3, 2), (3, 0), 17,
+             branch_after=(0,)),
+    bindery("Shifted Signatures", (3, 1, 0), (2, 1, 2), 23,
+             branch_after=(0, 1)),
+    bindery("Open the Misbinding", (1, 2, 3, 0), (0, 3), 14,
+             prefill=(1, 2, 1), branch_after=(0,)),
+    bindery("Four-Folio Register", (0, 3, 1, 2), (1, 0, 2, 1), 25,
+             branch_after=(0, 2)),
+    bindery("Brassbound Routines", (2, 1, 3, 0), (3, 0, 2, 3, 1), 26,
+             prefill=(2, 1, 2), branch_after=(0, 2, 3)),
+]
+
+
+def transform_ribbon(ribbon, cam):
+    """Return the complete, previewable effect of one transformation cam."""
+    ribbon = tuple(ribbon)
+    if cam == 0:                         # plain circular cam
+        return ribbon
+    if cam == 1:                         # reversing crescent cam
+        return tuple(reversed(ribbon))
+    if cam == 2:                         # one-tooth symbol shift
+        return tuple((glyph + 1) % GLYPHS for glyph in ribbon)
+    if not ribbon:                       # counterfeit tooth: a near-repeat
+        return ribbon
+    return ribbon[:-1] + ((ribbon[-1] + 1) % GLYPHS,)
+
+
+def target_segments(level):
+    return tuple(transform_ribbon(level["motif"], cam)
+                 for cam in level["cams"])
+
+
+def branch_bit(index):
+    return 1 << (GLYPHS + index)
+
+
+def required_branch_mask(level):
+    return sum(branch_bit(index) for index in level["required_branches"])
+
+
+def branch_contract_ready(level, state):
+    required = required_branch_mask(level)
+    return state[8] & required == required
+
+
+def branch_pending(level, state):
+    previous = state[5] - 1
+    return (state[5] > 0 and previous in level["branch_after"]
+            and not state[8] & branch_bit(previous))
+
+
+def start_state(level):
+    # punched ribbon, glyph selector, bound, cam, preview, completed folios,
+    # intact wax seals, ever edited, used-cam mask, terminal (0/2/3)
+    return level["prefill"], 0, 0, 0, 0, 0, 2, 0, 0, 0
+
+
+def rejected(state):
+    seals = state[6] - 1
+    return state[:6] + (seals,) + state[7:TERMINAL_INDEX] + (
+        3 if seals <= 0 else 0,
+    )
+
+
+def transition(level, state, action):
+    if state[TERMINAL_INDEX] or action not in (1, 2, 3, 4, 5, 6):
+        return state
+    ribbon, selector, bound, cam, preview, folio, seals, edited, used, _ = state
+
+    if not bound:
+        if action == 1:
+            return (ribbon, (selector - 1) % GLYPHS, bound, cam, preview,
+                    folio, seals, edited, used, 0)
+        if action == 2:
+            return (ribbon, (selector + 1) % GLYPHS, bound, cam, preview,
+                    folio, seals, edited, used, 0)
+        if action == 3:
+            if len(ribbon) >= MAX_RIBBON:
+                return state
+            return (ribbon + (selector,), selector, bound, cam, preview,
+                    folio, seals, edited, used, 0)
+        if action == 4:
+            if not ribbon:
+                return state
+            return (ribbon[:-1], selector, bound, cam, preview, folio,
+                    seals, 1, used, 0)
+        if action == 5:
+            if ribbon != level["motif"]:
+                return rejected(state)
+            return (ribbon, selector, 1, 0, 0, folio, seals, edited, used, 0)
+        return state
+
+    # A replay may never flow silently across a folio branch.  The player must
+    # close a visible page-turn seal before selecting the next cam.  All other
+    # inputs are blocked while the boundary is open.
+    if branch_pending(level, state):
+        if action == 5:
+            return (ribbon, selector, bound, 0, 0, folio, seals, edited,
+                    used | branch_bit(folio - 1), 0)
+        return state
+    if folio >= len(level["cams"]):
+        # Reached only by a deliberate branch-mechanism deletion: the target
+        # output exists, but its still-required folio seals cannot be forged.
+        return state
+
+    if action == 1:
+        return (ribbon, selector, bound, (cam - 1) % GLYPHS, 0,
+                folio, seals, edited, used, 0)
+    if action == 2:
+        return (ribbon, selector, bound, (cam + 1) % GLYPHS, 0,
+                folio, seals, edited, used, 0)
+    if action == 3:
+        if preview:
+            return state
+        return (ribbon, selector, bound, cam, 1, folio, seals, edited, used, 0)
+    if action == 4:
+        # The closed book may be reopened before its first branch is written.
+        if folio:
+            return state
+        return (ribbon, selector, 0, cam, 0, folio, seals, 1, used, 0)
+    if action == 5:
+        if not preview:
+            return state
+        return (ribbon, selector, bound, cam, 0, folio,
+                seals, edited, used, 0)
+
+    # One press writes a complete ribbon into one branch, but only after its
+    # effect has been exposed and compared.  No punch action can advance folio.
+    if not preview or cam != level["cams"][folio]:
+        return rejected(state)
+    next_folio = folio + 1
+    final = next_folio == len(level["cams"])
+    terminal = 2 if final and branch_contract_ready(level, state) else 0
+    return (ribbon, selector, bound, 0, 0, next_folio, seals, edited,
+            used | (1 << cam), terminal)
+
+
+def action_cost(state, after):
+    if after == state:
+        return 0
+    # A rejected audit consumes a physical seal instead of the action budget.
+    if after[6] < state[6]:
+        return 0
+    return 1
+
+
+def solved(_level, state):
+    return (state[TERMINAL_INDEX] == 2
+            and branch_contract_ready(_level, state))
+
+
+def shortest_turns(current, target):
+    clockwise = (target - current) % GLYPHS
+    counter = (current - target) % GLYPHS
+    if clockwise <= counter:
+        return (2,) * clockwise
+    return (1,) * counter
+
+
+def known_solution(level):
+    """Construct a deterministic campaign witness without mutating the game."""
+    ribbon = level["prefill"]
+    prefix = 0
+    while (prefix < len(ribbon) and prefix < len(level["motif"])
+           and ribbon[prefix] == level["motif"][prefix]):
+        prefix += 1
+    plan = [4] * (len(ribbon) - prefix)
+    selector = 0
+    for glyph in level["motif"][prefix:]:
+        moves = shortest_turns(selector, glyph)
+        plan.extend(moves); selector = glyph; plan.append(3)
+    plan.append(5)
+    for index, cam in enumerate(level["cams"]):
+        plan.extend(shortest_turns(0, cam))
+        plan.extend((3, 6))
+        if index in level["branch_after"]:
+            plan.append(5)
+    return tuple(plan)
+
+
+class BinderyDisplay(RenderableUserDisplay):
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def line(frame, a, b, color, dotted=False, width=1):
+        x0, y0 = a; x1, y1 = b
+        steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+        for index in range(steps + 1):
+            if dotted and index % 3 == 1:
+                continue
+            x = x0 + (x1 - x0) * index // steps
+            y = y0 + (y1 - y0) * index // steps
+            for dy in range(-(width // 2), width - width // 2):
+                for dx in range(-(width // 2), width - width // 2):
+                    if 0 <= x + dx < 64 and 0 <= y + dy < 64:
+                        frame[y + dy, x + dx] = color
+
+    @staticmethod
+    def disc(frame, center, radius, color, hollow=False):
+        cx, cy = center
+        inner = max(0, radius - 1) ** 2
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                distance = (x - cx) ** 2 + (y - cy) ** 2
+                if distance <= radius ** 2 and (not hollow or distance >= inner):
+                    frame[y, x] = color
+
+    @classmethod
+    def diamond(cls, frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for dy in range(-radius, radius + 1):
+            reach = radius - abs(dy)
+            if hollow:
+                frame[cy + dy, cx - reach] = color
+                frame[cy + dy, cx + reach] = color
+            else:
+                frame[cy + dy, cx - reach:cx + reach + 1] = color
+
+    @classmethod
+    def triangle(cls, frame, center, radius, color, hollow=False):
+        cx, cy = center
+        for row in range(radius + 1):
+            y = cy - radius // 2 + row
+            reach = row * radius // max(1, radius)
+            if hollow:
+                frame[y, cx - reach] = color; frame[y, cx + reach] = color
+            else:
+                frame[y, cx - reach:cx + reach + 1] = color
+        cls.line(frame, (cx - radius, cy + radius // 2),
+                 (cx + radius, cy + radius // 2), color)
+
+    @classmethod
+    def glyph(cls, frame, center, identity, color=INK, small=False):
+        """Four silhouettes each repeat a distinct interior punch pattern."""
+        x, y = center; radius = 2 if small else 3
+        if identity == 0:
+            cls.disc(frame, center, radius, color, hollow=True)
+            cls.disc(frame, center, 1, color)
+        elif identity == 1:
+            cls.triangle(frame, center, radius, color, hollow=True)
+            cls.line(frame, (x, y - 1), (x, y + 2), color, dotted=True)
+        elif identity == 2:
+            cls.diamond(frame, center, radius, color, hollow=True)
+            cls.line(frame, (x - 1, y), (x + 1, y), color)
+            cls.line(frame, (x, y - 1), (x, y + 1), color)
+        else:
+            # Notched fork: rectangular shoulders, open bottom, twin teeth.
+            cls.line(frame, (x - radius, y - radius),
+                     (x + radius, y - radius), color)
+            cls.line(frame, (x - radius, y - radius),
+                     (x - radius, y + radius), color)
+            cls.line(frame, (x + radius, y - radius),
+                     (x + radius, y + radius), color)
+            cls.line(frame, (x, y - radius), (x, y + 1), color, dotted=True)
+            frame[y + radius, x - radius:x - 1] = color
+            frame[y + radius, x + 2:x + radius + 1] = color
+
+    @classmethod
+    def cam(cls, frame, center, identity, color=BRASS, small=False):
+        x, y = center; radius = 2 if small else 4
+        if identity == 0:
+            cls.disc(frame, center, radius, color, hollow=True)
+            cls.line(frame, (x, y - radius - 1), (x, y - 1), color)
+        elif identity == 1:
+            cls.disc(frame, center, radius, color, hollow=True)
+            cls.line(frame, (x - radius, y), (x + radius, y), color)
+            cls.line(frame, (x - radius, y), (x - radius + 2, y - 2), color)
+            cls.line(frame, (x + radius, y), (x + radius - 2, y + 2), color)
+        elif identity == 2:
+            cls.diamond(frame, center, radius, color, hollow=True)
+            cls.line(frame, (x - 2, y), (x + 2, y), color)
+            cls.line(frame, (x, y - 2), (x, y + 2), color)
+        else:
+            cls.line(frame, (x - radius, y - radius),
+                     (x + radius, y - radius), color)
+            cls.line(frame, (x - radius, y - radius),
+                     (x - radius, y + radius), color)
+            cls.line(frame, (x + radius, y - radius),
+                     (x + radius, y + radius), color)
+            cls.line(frame, (x - radius, y + radius),
+                     (x + 1, y + radius), color)
+            cls.line(frame, (x + 3, y + radius),
+                     (x + radius, y + radius), color)
+            cls.disc(frame, center, 1, color)
+
+    @staticmethod
+    def ribbon_centers(length):
+        spacing = 11
+        start = 32 - (length - 1) * spacing // 2
+        return tuple((start + index * spacing) for index in range(length))
+
+    def background(self, frame):
+        frame[:, :] = PARCHMENT
+        frame[1:63, 1] = CHARCOAL; frame[1:63, 62] = CHARCOAL
+        frame[1, 1:63] = CHARCOAL; frame[62, 1:63] = CHARCOAL
+        frame[35:62, 2:62] = OXBLOOD
+        frame[37:60, 3:61] = PAPER
+        # Aged wood grain and stitched paper fibers remain restrained.
+        for x in range(4, 61, 7):
+            self.line(frame, (x, 61), (x + 4, 58), CHARCOAL, dotted=True)
+        for x in range(4, 61, 9):
+            self.line(frame, (x, 3), (x + 5, 3), ASH, dotted=True)
+        self.line(frame, (3, 34), (60, 34), BRASS, dotted=True)
+        for x in range(5, 61, 8):
+            self.disc(frame, (x, 36), 1, GOLD, hollow=True)
+
+    def folio_register(self, frame, state):
+        level = self.game.level; total = len(level["cams"])
+        centers = tuple(8 + i * 48 // max(1, total - 1) for i in range(total))
+        for index, (x, cam_id) in enumerate(zip(centers, level["cams"])):
+            complete = index < state[5]
+            color = CHARCOAL if complete else BRASS
+            frame[6:20, max(3, x - 5):min(61, x + 6)] = PAPER
+            self.line(frame, (x - 5, 6), (x - 5, 20), color,
+                      dotted=not complete)
+            self.line(frame, (x + 5, 6), (x + 5, 20), color,
+                      dotted=not complete)
+            self.line(frame, (x - 5, 6), (x + 5, 6), color)
+            self.cam(frame, (x, 13), cam_id, color, small=True)
+            if complete:
+                self.disc(frame, (x, 18), 1, OXBLOOD)
+                self.line(frame, (x - 2, 18), (x + 2, 18), INK)
+            if index == state[5] and not state[TERMINAL_INDEX]:
+                self.line(frame, (x - 6, 4), (x, 2), OXBLOOD)
+                self.line(frame, (x, 2), (x + 6, 4), OXBLOOD)
+            if index in level["branch_after"] and index + 1 < total:
+                bx = (x + centers[index + 1]) // 2
+                self.line(frame, (bx, 5), (bx, 21), OXBLOOD, dotted=True)
+                self.diamond(frame, (bx, 22), 2, CHARCOAL, hollow=True)
+
+    def target_and_preview(self, frame, state):
+        level = self.game.level
+        if state[5] >= len(level["cams"]):
+            target = transform_ribbon(level["motif"], level["cams"][-1])
+        else:
+            target = target_segments(level)[state[5]]
+        centers = self.ribbon_centers(len(target))
+        for x, glyph in zip(centers, target):
+            self.glyph(frame, (x, 27), glyph, CHARCOAL)
+            frame[31, x - 3:x + 4:2] = ASH
+        self.line(frame, (centers[0] - 5, 22), (centers[-1] + 5, 22), BRASS)
+        self.line(frame, (centers[0] - 5, 22), (centers[0] - 5, 31), BRASS)
+        self.line(frame, (centers[-1] + 5, 22), (centers[-1] + 5, 31), BRASS)
+
+        if state[2] and state[4]:
+            ghost = transform_ribbon(state[0], state[3])
+            for x, glyph in zip(self.ribbon_centers(len(ghost)), ghost):
+                self.glyph(frame, (x, 35), glyph, BRASS, small=True)
+            self.line(frame, (15, 35), (49, 35), GOLD, dotted=True)
+        else:
+            for x in centers:
+                self.disc(frame, (x, 35), 1, ASH, hollow=True)
+
+    def working_ribbon(self, frame, state):
+        frame[40:50, 5:59] = PAPER
+        self.line(frame, (5, 40), (59, 40), CHARCOAL, dotted=True)
+        self.line(frame, (5, 49), (59, 49), CHARCOAL, dotted=True)
+        centers = self.ribbon_centers(MAX_RIBBON)
+        for index, x in enumerate(centers):
+            self.disc(frame, (x, 45), 4, ASH, hollow=True)
+            if index < len(state[0]):
+                self.glyph(frame, (x, 45), state[0][index], INK)
+        if state[2]:
+            self.line(frame, (3, 39), (3, 51), BRASS, width=2)
+            self.line(frame, (61, 39), (61, 51), BRASS, width=2)
+            self.line(frame, (3, 39), (10, 35), BRASS, width=2)
+            self.line(frame, (61, 39), (54, 35), BRASS, width=2)
+            self.line(frame, (10, 35), (54, 35), BRASS, dotted=True)
+            self.disc(frame, (32, 38), 2, OXBLOOD)
+        else:
+            self.line(frame, (4, 52), (60, 52), OXBLOOD, dotted=True)
+
+    def gauges(self, frame, state):
+        # Selector and transform cam occupy opposite corners with unlike shapes.
+        self.glyph(frame, (8, 56), state[1], INK)
+        self.line(frame, (3, 56), (5, 56), BRASS)
+        self.line(frame, (11, 56), (14, 56), BRASS)
+        if state[2]:
+            self.cam(frame, (56, 56), state[3], BRASS)
+        else:
+            self.cam(frame, (56, 56), 3, ASH, small=True)
+
+        for index, x in enumerate((46, 53)):
+            live = index < state[6]
+            self.disc(frame, (x, 32), 3, OXBLOOD if live else ASH,
+                      hollow=not live)
+            self.glyph(frame, (x, 32), 0 if live else 3, INK, small=True)
+
+        # Every available action is one countable brass rivet; spent rivets are
+        # crossed holes, not a hue-only meter and never a rendered digit.
+        shown = self.game.budget_left
+        for index in range(self.game.budget_max):
+            x = 3 if index < 13 else 60
+            y = 24 + (index % 13) * 2
+            if index < shown:
+                self.disc(frame, (x, y), 1, GOLD)
+            else:
+                frame[y, x] = ASH
+                if x + 1 < 64:
+                    frame[y, x + 1] = CHARCOAL
+
+    def animation(self, frame):
+        g = self.game
+        if not g.anim_kind:
+            if g.state[TERMINAL_INDEX] == 3:
+                for x in range(7, 58, 9):
+                    self.line(frame, (x, 24), (x + 5, 31), RED, width=2)
+            return
+        before, after = g.state, g.pending_state
+        p = g.anim_progress; span = max(1, g.anim_total - 1)
+        wave = min(p, span - p)
+
+        if g.anim_kind == "ratchet":
+            center = (56, 56) if before[2] else (8, 56)
+            radius = 5 + wave
+            self.disc(frame, center, radius, BRASS, hollow=True)
+            angle = 2 * math.pi * p / max(1, span)
+            tooth = (center[0] + round(radius * math.cos(angle)),
+                     center[1] + round(radius * math.sin(angle)))
+            self.line(frame, center, tooth, GOLD)
+        elif g.anim_kind == "punch":
+            index = len(before[0]); x = self.ribbon_centers(MAX_RIBBON)[index]
+            y = 33 + 10 * p // span
+            self.line(frame, (x - 4, y - 5), (x + 4, y - 5), CHARCOAL, width=2)
+            self.glyph(frame, (x, y), before[1], OXBLOOD)
+        elif g.anim_kind == "edit":
+            index = max(0, len(before[0]) - 1)
+            x = self.ribbon_centers(MAX_RIBBON)[index]
+            y = 45 - 9 * p // span
+            self.glyph(frame, (x + wave, y), before[0][-1] if before[0] else 3,
+                       ASH)
+            self.line(frame, (x - 4, y + 4), (x + 5, y - 3), OXBLOOD,
+                      dotted=True)
+        elif g.anim_kind == "clamp":
+            inset = 20 * p // span
+            self.line(frame, (3 + inset, 38), (3 + inset, 51), BRASS, width=2)
+            self.line(frame, (61 - inset, 38), (61 - inset, 51), BRASS, width=2)
+            self.line(frame, (3 + inset, 38), (10 + inset // 2, 34), GOLD)
+            self.line(frame, (61 - inset, 38), (54 - inset // 2, 34), GOLD)
+        elif g.anim_kind == "preview":
+            edge = 13 + 38 * p // span
+            self.line(frame, (13, 35), (edge, 35), GOLD, width=2)
+            ghost = transform_ribbon(before[0], before[3])
+            for index, (x, glyph) in enumerate(zip(self.ribbon_centers(len(ghost)), ghost)):
+                if index * span <= p * len(ghost):
+                    self.glyph(frame, (x, 35), glyph, BRASS, small=True)
+        elif g.anim_kind == "release":
+            self.line(frame, (8, 35 - wave), (56, 35 + wave), ASH,
+                      dotted=True)
+            self.line(frame, (8, 35 + wave), (56, 35 - wave), BRASS,
+                      dotted=True)
+        elif g.anim_kind == "replay":
+            ghost = transform_ribbon(before[0], before[3])
+            y = 44 - 17 * p // span
+            for x, glyph in zip(self.ribbon_centers(len(ghost)), ghost):
+                self.glyph(frame, (x, y), glyph, BRASS)
+                self.line(frame, (x, 44), (x, y), ASH, dotted=True)
+            self.disc(frame, (56, 56), 5 + wave, GOLD, hollow=True)
+        elif g.anim_kind == "reject":
+            offset = (-2, 1, 2, -1, 2, 0, -1, 0)[min(p, 7)]
+            self.line(frame, (14 + offset, 38), (50 + offset, 51), OXBLOOD,
+                      width=2)
+            self.line(frame, (50 + offset, 38), (14 + offset, 51), OXBLOOD,
+                      width=2)
+            self.disc(frame, (49, 32), 3 + wave, RED, hollow=True)
+        elif g.anim_kind == "success":
+            for index, x in enumerate(range(7, 59, 10)):
+                y = 28 - (p + index) % 5
+                self.glyph(frame, (x, y), index % GLYPHS, GOLD)
+            self.line(frame, (5, 21), (5 + 54 * p // span, 21), MOSS,
+                      width=2)
+        elif g.anim_kind == "loss":
+            inset = 27 * p // span
+            self.line(frame, (3 + inset, 22), (3 + inset, 52), RED, width=2)
+            self.line(frame, (61 - inset, 22), (61 - inset, 52), RED, width=2)
+        else:  # blocked: a notched stamp shakes without hiding stable state
+            offset = (-2, 2, -1, 1, 0)[min(p, 4)]
+            self.glyph(frame, (32 + offset, 36), 3, OXBLOOD)
+            self.line(frame, (25 + offset, 33), (39 + offset, 39), ASH,
+                      dotted=True)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        self.background(frame)
+        state = self.game.state
+        self.folio_register(frame, state)
+        self.target_and_preview(frame, state)
+        self.working_ribbon(frame, state)
+        self.gauges(frame, state)
+        self.animation(frame)
+        return frame
+
+
+class Q193(ARCBaseGame):
+    def __init__(self):
+        self.display = BinderyDisplay(self)
+        self.level = LEVELS[0]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(level),
+                        name=level["name"]) for level in LEVELS]
+        super().__init__("q193", levels,
+                         Camera(0, 0, 64, 64, PARCHMENT, PARCHMENT, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, _level):
+        self.level = LEVELS[self.level_index]; self.state = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None; self.anim_left = self.anim_total = self.anim_progress = 0
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+
+    def begin(self, kind, frames, after, budget, terminal=None):
+        self.anim_kind = kind; self.anim_total = self.anim_left = frames
+        self.anim_progress = 0; self.pending_state = after
+        self.pending_budget = budget; self.pending_terminal = terminal
+
+    def finish(self):
+        terminal = self.pending_terminal
+        self.state = self.pending_state; self.budget_left = self.pending_budget
+        self.anim_kind = None
+        self.pending_state = self.pending_budget = self.pending_terminal = None
+        if terminal == "win":
+            self.next_level()
+        elif terminal == "loss":
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self.finish()
+            return
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        before = self.state; after = transition(self.level, before, action)
+        if after == before:
+            self.begin("blocked", 5, before, self.budget_left)
+            return
+        cost = action_cost(before, after)
+        if cost > self.budget_left:
+            lost = before[:TERMINAL_INDEX] + (3,)
+            self.begin("loss", 7, lost, self.budget_left, "loss")
+            return
+        budget = self.budget_left - cost
+        won = after[TERMINAL_INDEX] == 2
+        lost = after[TERMINAL_INDEX] == 3
+        if won:
+            kind, frames, terminal = "success", 7, "win"
+        elif lost:
+            kind, frames, terminal = "loss", 7, "loss"
+        elif after[6] < before[6]:
+            kind, frames, terminal = "reject", 7, None
+        elif action in (1, 2):
+            kind, frames, terminal = "ratchet", 5, None
+        elif not before[2] and action == 3:
+            kind, frames, terminal = "punch", 6, None
+        elif action == 4:
+            kind, frames, terminal = "edit", 6, None
+        elif not before[2] and action == 5:
+            kind, frames, terminal = "clamp", 7, None
+        elif before[2] and action == 3:
+            kind, frames, terminal = "preview", 6, None
+        elif before[2] and action == 5:
+            kind, frames, terminal = "release", 5, None
+        elif before[2] and action == 6:
+            kind, frames, terminal = "replay", 7, None
+        else:
+            kind, frames, terminal = "blocked", 5, None
+        self.begin(kind, frames, after, budget, terminal)

--- a/data/community-games/sonpham/q200_v2_q200.py
+++ b/data/community-games/sonpham/q200_v2_q200.py
@@ -1,0 +1,412 @@
+# Author: OpenAI Codex (GPT-5), for Son Pham
+# Date: 2026-09-05
+# PURPOSE: Standalone verified ARC3 community game exported from Son Pham's pairwise glow-up program; behavior and qualified source body are preserved exactly.
+# SRP/DRY check: Pass - one self-contained ARCBaseGame implementation with no ARC Explainer runtime-service changes.
+
+"""q200-v2 Clock of Clocks -- mesh visible local completions into macro time.
+
+Three tactile dials have visible periods. Wrapping a dial raises a shape-coded latch;
+the escapement accepts only the displayed latch recipe and advances the macro ring.
+Later levels add ordered recipes, linked gears, a clutch, and period changes. Success
+depends only on rendered state, never on a hidden action trace.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import numpy as np
+from arcengine import ARCBaseGame, Camera, Level, RenderableUserDisplay
+
+
+# Restrained mechanical art bible: paper, charcoal, brass, and one vermilion accent.
+PAPER, PALE, SILVER, GRAPHITE, CHARCOAL, INK = 0, 1, 2, 3, 4, 5
+VERMILION, ROSE, BLUE, SKY, BRASS, COPPER, GREEN, PURPLE = 8, 7, 9, 10, 11, 12, 14, 15
+
+
+LEVELS = [
+    {"name": "Single Escapement", "periods": ((2, 0, 0),), "recipe": (1,), "active": 1,
+     "budget": 9},
+    {"name": "Second Escapement", "periods": ((2, 3, 0),), "recipe": (1, 2, 1), "active": 2,
+     "budget": 11},
+    {"name": "Conjunction", "periods": ((2, 3, 0),), "recipe": (3, 1, 2), "active": 2,
+     "budget": 14},
+    {"name": "Phase Gate", "periods": ((2, 3, 0),), "recipe": (1, 2, 1), "active": 2,
+     "phase_gate": ((1, 1), (0, 1), (1, 2)), "budget": 13},
+    {"name": "Shifting Cadence", "periods": ((2, 3, 4), (3, 2, 4), (3, 4, 2)),
+     "recipe": (3, 4, 5), "active": 3, "budget": 18},
+    {"name": "Gear Cascade", "periods": ((2, 3, 4),), "recipe": (3, 4), "active": 3,
+     "coupling": {0: 1}, "budget": 11},
+    {"name": "Clutched Pair", "periods": ((3, 4, 0),), "recipe": (3, 1), "active": 2,
+     "clutch_pair": (0, 1), "clutch_required": (1,), "budget": 10},
+    {"name": "Clock of Clocks", "periods": ((2, 3, 4), (3, 2, 4), (3, 4, 2)),
+     "recipe": (3, 4, 6), "active": 3, "coupling": {0: 1},
+     "clutch_pair": (1, 2), "clutch_required": (2,), "budget": 16},
+]
+
+
+def periods_for(level, macro):
+    banks = level["periods"]
+    return tuple(banks[min(macro, len(banks) - 1)])
+
+
+def start_state(level):
+    return (0, 0, 0), 0, 0, False
+
+
+def _tick(phases, pending, index, periods):
+    if periods[index] <= 0:
+        return phases, pending, False
+    phases = list(phases)
+    phases[index] = (phases[index] + 1) % periods[index]
+    wrapped = phases[index] == 0
+    if wrapped:
+        pending |= 1 << index
+    return tuple(phases), pending, wrapped
+
+
+def transition(level, state, action):
+    """Pure visible-state transition; ``None`` is a jammed escapement."""
+    phases, pending, macro, clutch = state
+    periods = periods_for(level, macro)
+    if action == 5:
+        if "clutch_pair" not in level:
+            return state
+        return phases, pending, macro, not clutch
+    if action == 4:
+        gate = None
+        if macro < len(level.get("phase_gate", ())):
+            gate = level["phase_gate"][macro]
+        gate_open = gate is None or phases[gate[0]] == gate[1]
+        if macro >= len(level["recipe"]) or pending != level["recipe"][macro] or not gate_open:
+            # A rejected mesh visibly releases the latches instead of killing the run.
+            return phases, 0, macro, clutch
+        macro += 1
+        new_periods = periods_for(level, macro)
+        phases = tuple(phase % period if period else 0
+                       for phase, period in zip(phases, new_periods))
+        return phases, 0, macro, clutch
+    if action not in (1, 2, 3):
+        return state
+    index = action - 1
+    if index >= level["active"]:
+        return state
+    if index in level.get("clutch_required", ()):
+        return state
+    phases, pending, wrapped = _tick(phases, pending, index, periods)
+    if wrapped and index in level.get("coupling", {}):
+        phases, pending, _ = _tick(phases, pending, level["coupling"][index], periods)
+    if clutch and "clutch_pair" in level and index in level["clutch_pair"]:
+        a, b = level["clutch_pair"]
+        partner = b if index == a else a
+        phases, pending, _ = _tick(phases, pending, partner, periods)
+    return phases, pending, macro, clutch
+
+
+def solved(level, state):
+    _phases, pending, macro, _clutch = state
+    return macro == len(level["recipe"]) and pending == 0
+
+
+def _line(frame, a, b, color):
+    x0, y0 = a
+    x1, y1 = b
+    steps = max(abs(x1 - x0), abs(y1 - y0), 1)
+    for index in range(steps + 1):
+        x = x0 + (x1 - x0) * index // steps
+        y = y0 + (y1 - y0) * index // steps
+        if 0 <= x < 64 and 0 <= y < 64:
+            frame[y, x] = color
+
+
+class ClockDisplay(RenderableUserDisplay):
+    CLOCKS = ((13, 21), (32, 17), (51, 21))
+    NOTCHES = ((0, -7), (5, -5), (7, 0), (5, 5), (0, 7), (-5, 5), (-7, 0), (-5, -5))
+    HANDS = ((0, -4), (3, -3), (4, 0), (3, 3), (0, 4), (-3, 3), (-4, 0), (-3, -3))
+
+    def __init__(self, game):
+        self.game = game
+
+    @staticmethod
+    def _disc(frame, center, radius, color):
+        cx, cy = center
+        for y in range(max(0, cy - radius), min(64, cy + radius + 1)):
+            for x in range(max(0, cx - radius), min(64, cx + radius + 1)):
+                if (x - cx) ** 2 + (y - cy) ** 2 <= radius ** 2:
+                    frame[y, x] = color
+
+    def _paper(self, frame):
+        frame[:, :] = PAPER
+        for y in range(3, 62, 6):
+            frame[y, 2:62:4] = PALE
+        for x in range(5, 60, 10):
+            frame[2:61:8, x] = SILVER
+        frame[6:57, 4] = GRAPHITE
+        frame[6:57, 59] = GRAPHITE
+
+    def _clock(self, frame, index, center, period, phase):
+        if index >= self.game.level["active"]:
+            return
+        cx, cy = center
+        # Squared teeth around a circular engraved face.
+        for dx, dy in self.NOTCHES:
+            frame[max(0, cy + dy - 1):min(64, cy + dy + 2),
+                  max(0, cx + dx - 1):min(64, cx + dx + 2)] = GRAPHITE
+        self._disc(frame, center, 7, CHARCOAL)
+        self._disc(frame, center, 6, PALE)
+        self._disc(frame, center, 4, PAPER)
+        # Period has explicit unique notches; current phase is a triangular hand.
+        for slot in range(period):
+            dx, dy = self.NOTCHES[slot * 8 // period]
+            frame[cy + dy, cx + dx] = BRASS
+        dx, dy = self.HANDS[phase * 8 // max(1, period)]
+        _line(frame, center, (cx + dx, cy + dy), INK)
+        frame[cy + dy, cx + dx] = VERMILION
+        self._disc(frame, center, 1, COPPER)
+        # Pending latch: each dial uses a different shape, not color alone.
+        if self.game.pending & (1 << index):
+            ly = 31
+            if index == 0:
+                self._disc(frame, (cx, ly), 2, GREEN)
+            elif index == 1:
+                frame[ly - 2:ly + 3, cx - 2:cx + 3] = BLUE
+                frame[ly - 1:ly + 2, cx - 1:cx + 2] = PAPER
+            else:
+                frame[ly, cx - 3:cx + 4] = PURPLE
+                frame[ly - 1:ly + 2, cx] = PURPLE
+
+    @staticmethod
+    def _mask_glyph(frame, mask, x, y, active):
+        outline = VERMILION if active else GRAPHITE
+        frame[y:y + 9, x] = outline
+        frame[y:y + 9, x + 10] = outline
+        frame[y, x:x + 11] = outline
+        frame[y + 8, x:x + 11] = outline
+        if active:
+            frame[y - 2:y, x + 3:x + 8] = VERMILION
+            frame[y - 3, x + 5] = INK
+        for bit in range(3):
+            gx = x + 2 + bit * 3
+            if mask & (1 << bit):
+                if bit == 0:
+                    frame[y + 3:y + 6, gx:gx + 2] = GREEN
+                elif bit == 1:
+                    frame[y + 2:y + 7, gx] = BLUE
+                else:
+                    frame[y + 2:y + 7:2, gx:gx + 2] = PURPLE
+
+    def _animation(self, frame):
+        g = self.game
+        if g.intro_mark:
+            frame[7:11, 8:56:3] = BRASS
+            frame[53:57, 8:56:3] = GRAPHITE
+            frame[8:56:3, 7:11] = GRAPHITE
+            frame[8:56:3, 53:57] = BRASS
+        if g.terminal_hold == "win":
+            self._disc(frame, (32, 32), 15, BRASS)
+            self._disc(frame, (32, 32), 11, PAPER)
+            self._disc(frame, (32, 32), 6, GREEN)
+        elif g.terminal_hold == "loss":
+            frame[8:56:3, 8:56:3] = VERMILION
+            _line(frame, (12, 12), (52, 52), INK)
+            _line(frame, (52, 12), (12, 52), INK)
+        if not g.anim_kind:
+            return
+        p = g.anim_progress
+        if g.anim_kind == "tick" and g.anim_clock is not None:
+            clock_index = g.anim_clock
+            local_p = p
+            if g.anim_partner is not None and p > g.anim_total // 2:
+                clock_index = g.anim_partner
+                local_p = p - g.anim_total // 2
+            cx, cy = self.CLOCKS[clock_index]
+            radius = 8 + local_p
+            for dx, dy in self.NOTCHES:
+                x = cx + dx * radius // 8
+                y = cy + dy * radius // 8
+                if 0 <= x < 64 and 0 <= y < 64:
+                    frame[y, x] = BRASS
+        elif g.anim_kind == "mesh":
+            frame[37 + p:39 + p, 12:53:2] = BRASS
+        elif g.anim_kind == "clutch":
+            y = 35 + p % 2
+            _line(frame, (13, y), (51, y), VERMILION)
+        elif g.anim_kind == "jam":
+            frame[39:42, 9 + p:55 - p] = VERMILION
+        elif g.anim_kind == "blocked":
+            # Crossed teeth are a nonterminal, non-budget-consuming refusal cue.
+            frame[12 + p:14 + p, 27:38] = VERMILION
+            _line(frame, (28, 12), (37, 21), INK)
+            _line(frame, (37, 12), (28, 21), INK)
+        elif g.anim_kind == "success":
+            self._disc(frame, (32, 44), 8 + p, BRASS)
+            self._disc(frame, (32, 44), 5, PAPER)
+
+    def render_interface(self, frame: np.ndarray) -> np.ndarray:
+        g = self.game
+        self._paper(frame)
+        periods = periods_for(g.level, g.macro)
+        # Coupled gears have a permanent toothed shaft and directional stop.
+        for source, partner in g.level.get("coupling", {}).items():
+            ax, ay = self.CLOCKS[source]
+            bx, by = self.CLOCKS[partner]
+            _line(frame, (ax + 5, ay + 5), (bx - 5, by + 5), GRAPHITE)
+            for x in range(min(ax, bx) + 8, max(ax, bx) - 6, 4):
+                frame[min(63, max(0, ay + 7)), x:x + 2] = BRASS
+            frame[max(0, by + 4):min(64, by + 8), max(0, bx - 7):min(64, bx - 4)] = INK
+        for index, center in enumerate(self.CLOCKS):
+            self._clock(frame, index, center, periods[index], g.phases[index])
+        if g.macro < len(g.level.get("phase_gate", ())):
+            gate = g.level["phase_gate"][g.macro]
+            if gate is not None:
+                clock_index, required_phase = gate
+                cx, cy = self.CLOCKS[clock_index]
+                dx, dy = self.NOTCHES[required_phase * 8 // periods[clock_index]]
+                gx, gy = cx + dx, cy + dy
+                frame[max(0, gy - 2):min(64, gy + 3), max(0, gx - 2):min(64, gx + 3):2] = ROSE
+                frame[gy, gx] = INK
+        # Engraved escapement and macro ring.
+        frame[37:40, 9:55] = CHARCOAL
+        frame[38, 12:53:4] = BRASS
+        self._disc(frame, (32, 45), 8, CHARCOAL)
+        self._disc(frame, (32, 45), 6, PAPER)
+        for step in range(len(g.level["recipe"])):
+            dx, dy = self.NOTCHES[step * 8 // max(1, len(g.level["recipe"]))]
+            frame[45 + dy, 32 + dx] = BRASS if step < g.macro else SILVER
+        hand_slot = min(7, g.macro * 8 // max(1, len(g.level["recipe"])))
+        dx, dy = self.HANDS[hand_slot]
+        _line(frame, (32, 45), (32 + dx, 45 + dy), VERMILION)
+        # Visible recipe cards; current card is vermilion outlined.
+        width = len(g.level["recipe"]) * 13
+        start = max(1, 32 - width // 2)
+        for index, mask in enumerate(g.level["recipe"]):
+            self._mask_glyph(frame, mask, start + index * 13, 53, index == g.macro)
+        # Clutch is a physical bridge with two square jaw ends.
+        if "clutch_pair" in g.level:
+            a, b = g.level["clutch_pair"]
+            ax, _ = self.CLOCKS[a]
+            bx, _ = self.CLOCKS[b]
+            frame[34:37, ax:bx + 1] = VERMILION if g.clutch else SILVER
+            frame[33:38, ax - 1:ax + 2] = CHARCOAL
+            frame[33:38, bx - 1:bx + 2] = CHARCOAL
+            if g.clutch:
+                frame[33:38:2, ax + 3:bx - 2:4] = INK
+            else:
+                gap = (ax + bx) // 2
+                frame[33:38, gap - 1:gap + 2] = PAPER
+        # Budget as screw heads rather than a generic bar.
+        lit = max(0, min(10, (g.budget_left * 10 + g.budget_max - 1) // max(1, g.budget_max)))
+        for index in range(10):
+            self._disc(frame, (6 + index * 6, 4), 1, BRASS if index < lit else SILVER)
+        self._animation(frame)
+        return frame
+
+
+class Q200(ARCBaseGame):
+    def __init__(self):
+        self.display = ClockDisplay(self)
+        self.level = LEVELS[0]
+        self.phases = (0, 0, 0)
+        self.pending = self.macro = 0
+        self.clutch = False
+        self.budget_left = self.budget_max = 0
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_clock = None
+        self.anim_partner = None
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+        levels = [Level(sprites=[], grid_size=(64, 64), data=deepcopy(item), name=item["name"])
+                  for item in LEVELS]
+        super().__init__("q200", levels, Camera(0, 0, 64, 64, PAPER, PAPER, [self.display]),
+                         False, len(levels), [1, 2, 3, 4, 5, 6])
+
+    def on_set_level(self, level):
+        self.level = LEVELS[self.level_index]
+        self.phases, self.pending, self.macro, self.clutch = start_state(self.level)
+        self.budget_left = self.budget_max = self.level["budget"]
+        self.anim_kind = None
+        self.anim_left = self.anim_total = self.anim_progress = 0
+        self.anim_clock = None
+        self.anim_partner = None
+        self.pending_state = None
+        self.pending_terminal = None
+        self.intro_mark = True
+        self.terminal_hold = None
+
+    def _begin_animation(self, kind, frames, *, clock=None, partner=None,
+                         next_state=None, terminal=None):
+        self.anim_kind = kind
+        self.anim_total = frames
+        self.anim_left = frames
+        self.anim_progress = 0
+        self.anim_clock = clock
+        self.anim_partner = partner
+        self.pending_state = next_state
+        self.pending_terminal = terminal
+
+    def _finish_animation(self):
+        terminal = self.pending_terminal
+        next_state = self.pending_state
+        if next_state is not None:
+            self.phases, self.pending, self.macro, self.clutch = next_state
+        self.anim_kind = None
+        self.anim_clock = None
+        self.anim_partner = None
+        self.pending_state = None
+        self.pending_terminal = None
+        if terminal == "win":
+            self.terminal_hold = "win"
+            self.next_level()
+        elif terminal == "loss" or self.budget_left <= 0:
+            self.terminal_hold = "loss"
+            self.lose()
+        self.complete_action()
+
+    def step(self):
+        if self.anim_left:
+            self.anim_left -= 1
+            self.anim_progress = self.anim_total - self.anim_left
+            if self.anim_left == 0:
+                self._finish_animation()
+            return
+
+        action = self.action.id.value
+        if action == 0:
+            self.complete_action()
+            return
+        self.intro_mark = False
+        state = (self.phases, self.pending, self.macro, self.clutch)
+        if action == 6:
+            won = solved(self.level, state)
+            if not won:
+                self.budget_left -= 1
+            self._begin_animation("success" if won else "jam", 4,
+                                  terminal="win" if won else None)
+            return
+
+        gate = None
+        if self.macro < len(self.level.get("phase_gate", ())):
+            gate = self.level["phase_gate"][self.macro]
+        wrong_mesh = action == 4 and (
+            self.macro >= len(self.level["recipe"])
+            or self.pending != self.level["recipe"][self.macro]
+            or (gate is not None and self.phases[gate[0]] != gate[1])
+        )
+        after = transition(self.level, state, action)
+        if after == state:
+            self._begin_animation("blocked", 3)
+            return
+        self.budget_left -= 1
+        if action in (1, 2, 3):
+            partner = next((index for index, (before_phase, after_phase) in
+                            enumerate(zip(state[0], after[0]))
+                            if index != action - 1 and before_phase != after_phase), None)
+            self._begin_animation("tick", 6 if partner is not None else 3,
+                                  clock=action - 1, partner=partner, next_state=after)
+        elif action == 4:
+            self._begin_animation("jam" if wrong_mesh else "mesh", 4, next_state=after)
+        else:
+            self._begin_animation("clutch", 3, next_state=after)

--- a/docs/plans/2026-09-05-glowed-community-games-import-plan.md
+++ b/docs/plans/2026-09-05-glowed-community-games-import-plan.md
@@ -1,0 +1,27 @@
+# Glowed ARC3 Community Games Import Plan
+
+Author: OpenAI Codex (GPT-5)
+Date: 2026-09-05
+PURPOSE: Import the completed Son Pham glow-up game set as standalone ARCEngine community-game Python files, preserving each active immutable version and making review provenance explicit.
+SRP/DRY check: Pass — reuse the existing `data/community-games/sonpham/` catalog layout and the repository's existing static validation contract without changing runtime services.
+
+## Approved scope
+
+- Source only games whose canonical glow-up count is at least one after Cycle 27 closes.
+- Exclude every remaining v1 seed and all internal research metadata, recordings, and evaluation ledgers.
+- Keep one standalone Python file per active game under `data/community-games/sonpham/`.
+- Add the repository-required file header to each imported Python file without changing game behavior.
+
+## Verification
+
+- Verify the source repository's canonical pool, checksums, schemas, deterministic replays, structural audit, and regression suite before export.
+- Re-run the ARC Explainer static contribution rules: ARCBaseGame subclass, arcengine import, allowed imports, no forbidden execution or file APIs, no more than 2,000 lines, and no more than 500 KB.
+- Compile and instantiate every exported game against the same ARCEngine runtime used by the source verifier.
+- Confirm that the exported source body is byte-identical to the qualified source after removing only the required contribution header.
+- Commit the import and open a reviewable pull request against the `arc3` staging branch; do not push directly to `main`.
+
+## Files intentionally unchanged
+
+- Runtime services, routes, database schema, and frontend components.
+- Existing community games and production configuration.
+- Internal source-repository research artifacts that are not runnable game files.


### PR DESCRIPTION
Imports all 44 active games with at least one completed glow-up after Cycle 27. The six remaining unglowed v1 seeds are intentionally excluded under the approved quality rule. Each standalone ARCBaseGame file preserves its qualified canonical source body exactly, with only the repository-required contribution header added. Verification: 44/44 compile, import, instantiate, and return a palette-valid 64x64 RESET frame; source-body hashes match; no forbidden imports or calls were found. Animation audit: replayed every eight-level winning campaign across all 44 games—4,466 recorded actions total. Every action visibly changes across its animation sequence, with 4–9 frames per action and zero failures. q121-v2 has one validator-safe hashlib import used only by its direct-run self-check. No client, server, route, storage, or runtime behavior changes.